### PR TITLE
Add ensemble prefixing methods for Fortran client

### DIFF
--- a/src/fortran/client/ensemble_interfaces.inc
+++ b/src/fortran/client/ensemble_interfaces.inc
@@ -1,0 +1,24 @@
+interface
+  subroutine set_data_source_c( client, source_id, source_id_length ) bind(c, name="set_data_source")
+    use iso_c_binding, only : c_ptr, c_char, c_bool, c_size_t
+    type(c_ptr),            value :: client
+    character(kind=c_char)        :: source_id(*)
+    integer(kind=c_size_t), value :: source_id_length
+  end subroutine set_data_source_c
+end interface
+
+interface
+  subroutine use_model_ensemble_prefix_c( client, use_prefix) bind(c, name="use_model_ensemble_prefix")
+    use iso_c_binding, only : c_ptr, c_bool
+    type(c_ptr),            value :: client
+    logical(kind=c_bool),   value :: use_prefix
+  end subroutine use_model_ensemble_prefix_c
+end interface
+
+interface
+  subroutine use_tensor_ensemble_prefix_c( client, use_prefix) bind(c, name="use_tensor_ensemble_prefix")
+    use iso_c_binding, only : c_ptr, c_bool
+    type(c_ptr),            value :: client
+    logical(kind=c_bool),   value :: use_prefix
+  end subroutine use_tensor_ensemble_prefix_c
+end interface

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -1,12 +1,12 @@
 project(FortranClientTester)
+enable_language(Fortran)
 
-set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_BUILD_TYPE Debug)
 
 cmake_minimum_required(VERSION 3.10)
 
 SET(CMAKE_CXX_STANDARD 17)
-enable_language(Fortran)
-SET(CMAKE_EXE_LINKER_FLAGS "-lpthread")
+SET(C_STANDARD 11)
 
 #TODO put in output warnings
 # Determine where the hiredis library is based on if an environment variable
@@ -20,17 +20,6 @@ else()
 	   find_path(HIREDIS_INCLUDE_PATH hiredis PATH_SUFFIXES "/include")
 endif()
 
-# Determine where the redis++ library is based on if an environment variable
-# is set, and if not, it can be found in the $PATH directory
-if(DEFINED ENV{REDISPP_INSTALL_PATH})
-	   string(CONCAT REDISPP_LIB_PATH $ENV{REDISPP_INSTALL_PATH} "/lib")
-	   find_library(REDISPP_LIB redis++ PATHS ${REDISPP_LIB_PATH} )
-	   string(CONCAT REDISPP_INCLUDE_PATH $ENV{REDISPP_INSTALL_PATH} "/include/")
-else()
-     	   find_library(REDISPP_LIB redis++ PATH_SUFFIXES "/lib")
-	   find_path(REDISPP_INCLUDE_PATH redis++ PATH_SUFFIXES "/include")
-endif()
-
 # Determine where the protobuf library is based on if an environment variable
 # is set, and if not, it can be found in the $PATH directory
 if(DEFINED ENV{PROTOBUF_INSTALL_PATH})
@@ -42,21 +31,33 @@ else()
 	   find_path(PROTOBUF_INCLUDE_PATH protobuf PATH_SUFFIXES "/include")
 endif()
 
+# Determine where the redis++ library is based on if an environment variable
+# is set, and if not, it can be found in the $PATH directory
+if(DEFINED ENV{REDISPP_INSTALL_PATH})
+	   string(CONCAT REDISPP_LIB_PATH $ENV{REDISPP_INSTALL_PATH} "/lib")
+	   find_library(REDISPP_LIB redis++ PATHS ${REDISPP_LIB_PATH} )
+	   string(CONCAT REDISPP_INCLUDE_PATH $ENV{REDISPP_INSTALL_PATH} "/include/")
+else()
+     	   find_library(REDISPP_LIB redis++ PATH_SUFFIXES "/lib")
+	   find_path(REDISPP_INCLUDE_PATH redis++ PATH_SUFFIXES "/include")
+endif()
+
 include_directories(SYSTEM
     ../../include
     ../../utils/protobuf
-    ../../src/fortran
     /usr/local/include
     ${HIREDIS_INCLUDE_PATH}
     ${REDISPP_INCLUDE_PATH}
     ${PROTOBUF_INCLUDE_PATH}
 )
 
+
+
 set(CLIENT_LIBRARIES ${REDISPP_LIB} ${HIREDIS_LIB} ${PROTOBUF_LIB})
 set(CLIENT_SRC
-	 ../../../src/c/c_client.cpp
-	 ../../../src/c/c_dataset.cpp
-	 ../../../src/cpp/client.cpp
+	../../../src/c/c_client.cpp
+	../../../src/c/c_dataset.cpp
+	../../../src/cpp/client.cpp
 	 ../../../src/cpp/dataset.cpp
 	 ../../../src/cpp/command.cpp
 	 ../../../src/cpp/commandlist.cpp
@@ -65,14 +66,13 @@ set(CLIENT_SRC
 	 ../../../src/cpp/tensorpack.cpp
 	 ../../../src/cpp/dbnode.cpp
 	 ../../../src/cpp/commandreply.cpp
-	 ../../../utils/protobuf/silc.pb.cc
+	 ../../utils/protobuf/silc.pb.cc
+     ../../../src/cpp/redisserver.cpp
+     ../../../src/cpp/redis.cpp
+     ../../../src/cpp/rediscluster.cpp
    ../../../src/fortran/fortran_c_interop.F90
    ../../../src/fortran/dataset.F90
    ../../../src/fortran/client.F90
-   ../../../src/cpp/redisserver.cpp
-   ../../../src/cpp/rediscluster.cpp
-   ../../../src/cpp/redis.cpp
-	 ../../utils/protobuf/silc.pb.cc
 	 test_utils.F90)
 
 # ld executables
@@ -130,5 +130,13 @@ add_executable(client_test_misc_tensor
 	${CLIENT_SRC}
 )
 target_link_libraries(client_test_misc_tensor
+	${CLIENT_LIBRARIES}
+)
+
+add_executable(client_test_ensemble
+	client_test_ensemble.F90
+	${CLIENT_SRC}
+)
+target_link_libraries(client_test_ensemble
 	${CLIENT_LIBRARIES}
 )

--- a/tests/fortran/client_test_ensemble.F90
+++ b/tests/fortran/client_test_ensemble.F90
@@ -1,0 +1,87 @@
+program main
+
+use silc_client, only : client_type
+use test_utils,  only : setenv, use_cluster
+use iso_fortran_env, only : STDERR => error_unit
+
+implicit none
+
+character(len=255) :: ensemble_keyout, ensemble_keyin
+character(len=255) :: tensor_key, model_key, script_key
+character(len=255) :: script_file, model_file
+
+real, dimension(10) :: tensor
+type(client_type) :: client
+
+ensemble_keyout = "producer_0"
+call setenv("SSKEYIN", "producer_0,producer_1")
+call setenv("SSKEYOUT", ensemble_keyout)
+
+call client%initialize(use_cluster())
+call client%use_model_ensemble_prefix(.true.)
+
+! Put tensor, script, and model into the database. Then check to make
+! sure that keys were prefixed correctly
+
+tensor_key = "ensemble_tensor"
+call client%put_tensor(tensor_key, tensor, shape(tensor))
+if (.not.client%tensor_exists(tensor_key)) then
+  write(STDERR,*) 'Tensor does not exist: ', tensor_key
+  error stop
+endif
+if (.not.client%key_exists(trim(ensemble_keyout)//"."//trim(tensor_key))) then
+  write(STDERR,*) 'Key does not exist: ', trim(ensemble_keyout)//"."//tensor_key
+  error stop
+endif
+
+script_key = "ensemble_script"
+script_file = "../../cpp/mnist_data/data_processing_script.txt"
+call client%set_script_from_file(script_key, "CPU", script_file)
+if (.not.client%model_exists(script_key)) then
+  write(STDERR,*) 'Script does not exist: ', script_key
+  error stop
+endif
+
+model_key = "ensemble_model"
+model_file = "../../cpp/mnist_data/mnist_cnn.pt"
+call client%set_model_from_file(model_key, model_file, "TORCH", "CPU")
+if (.not.client%model_exists(model_key)) then
+  write(STDERR,*) 'Model does not exist: ', model_key
+  error stop
+endif
+
+call client%destructor()
+
+! Now set the consumer tests
+ensemble_keyout = "producer_1"
+call setenv("SSKEYIN", "producer_1,producer_0")
+call setenv("SSKEYOUT", ensemble_keyout)
+
+call client%initialize(use_cluster())
+call client%use_model_ensemble_prefix(.true.)
+
+! Check that the keys associated with producer_1 do not exist
+if (client%tensor_exists(tensor_key)) then
+  write(STDERR,*) "Tensor should not exist: ", tensor_key
+  error stop
+endif
+if (client%key_exists(trim(ensemble_keyout)//"."//trim(tensor_key))) then
+  write(STDERR,*) "Key should not exist: "//trim(ensemble_keyout)//"."//tensor_key
+  error stop
+endif
+call client%set_data_source("producer_0")
+if (.not. client%tensor_exists(tensor_key)) then
+  write(STDERR,*) "Tensor does not exist: ", tensor_key
+  error stop
+endif
+if (.not. client%model_exists(model_key)) then
+  write(STDERR,*) "Model does not exist: "//model_key
+  error stop
+endif
+if (.not. client%model_exists(script_key)) then
+  write(STDERR,*) "Script does not exist: "//script_key
+  error stop
+endif
+
+
+end program main

--- a/tests/fortran/test_utils.F90
+++ b/tests/fortran/test_utils.F90
@@ -1,9 +1,24 @@
 module test_utils
+  use iso_c_binding, only : c_char, c_int, c_null_char
+  use iso_fortran_env, only : STDERR => error_unit
 
   implicit none; private
 
+  interface
+    integer(kind=c_int) function setenv_c( env_var, env_val, replace ) bind(c,name='setenv')
+      import c_int, c_char
+      character(kind=c_char), intent(in) :: env_var(*) !< Name of the variable to set
+      character(kind=c_char), intent(in) :: env_val(*) !< Value to set the variable to
+      integer(kind=c_int),    intent(in) :: replace    !< If 1, overwrite the value,
+    end function setenv_c
+
+  end interface
+
+
   public :: irand
   public :: use_cluster
+  public :: c_str
+  public :: setenv
 
   contains
 
@@ -52,5 +67,40 @@ module test_utils
     enddo
 
   end function to_lower
+
+  !> Convert a Fortran string to a C-string (i.e. append a null character)
+  function c_str( f_str )
+    character(len=*) :: f_str !< The original Fortran-style string
+    character(kind=c_char,len=len_trim(f_str)+1) :: c_str !< The resultant C-style string
+
+    c_str = trim(f_str)//C_NULL_CHAR
+
+  end function c_str
+
+  !> Set an environment value to a given value
+  subroutine setenv( env_var, env_val, replace )
+    character(len=*) :: env_var !< Environment variable to set
+    character(len=*) :: env_val !< The value to set the variable
+    logical, optional :: replace !< If true (default) overwrite the current value
+
+    integer(kind=c_int) :: c_replace, err_code
+    character(kind=c_char, len=len_trim(env_var)+1) :: c_env_var
+    character(kind=c_char, len=len_trim(env_val)+1) :: c_env_val
+
+    c_replace = 1
+    if (present(replace)) then
+       if (replace)       c_replace = 1
+       if (.not. replace) c_replace = 0
+    endif
+    c_env_var = c_str(env_var)
+    c_env_val = c_str(env_val)
+
+    err_code = setenv_c(c_env_var, c_env_val, c_replace)
+    if (err_code /= 0) then
+      write(STDERR,*) "Error setting", c_env_var, c_env_val
+      error stop
+    endif
+
+  end subroutine setenv
 
 end module test_utils


### PR DESCRIPTION
Implemnent Fortran interfaces to the ensemble prefixing methods. This
includes those used for tensors, models, and scripts. A new test is also
included which passes on horizon using the GNU compiler.

Closes https://github.com/CrayLabs/SILC/issues/12