### PR TITLE
Add SILC_INSTALL_PATH as part of the setup_env.sh execution

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -60,3 +60,7 @@ if [[ ":$PYTHONPATH:" != *"$(pwd)/src/python/module/"* ]]; then
 else
     echo "SILC found in PYTHONPATH"
 fi
+
+# Set SILC_INSTALL_PATH for external application build assistance
+export SILC_INSTALL_PATH="$(pwd)"
+echo "Setting the SILC install path to $SILC_INSTALL_PATH"


### PR DESCRIPTION
This PR adds ``SILC_INSTALL_PATH`` as an environment variable that gets set when executing setup_env.sh.  This is helpful and important for external applications that might want to link to the SILC library through an environment variable that points to the top-level directory.