### PR TITLE
Set C and Fortran tests to build with C standard 99

### DIFF
--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_BUILD_TYPE Debug)
 cmake_minimum_required(VERSION 3.10)
 
 SET(CMAKE_CXX_STANDARD 17)
-SET(C_STANDARD 11)
+SET(CMAKE_C_STANDARD 99)
 
 #TODO put in output warnings
 # Determine where the hiredis library is based on if an environment variable

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_BUILD_TYPE Debug)
 cmake_minimum_required(VERSION 3.10)
 
 SET(CMAKE_CXX_STANDARD 17)
-SET(C_STANDARD 11)
+SET(CMAKE_C_STANDARD 99)
 
 #TODO put in output warnings
 # Determine where the hiredis library is based on if an environment variable


### PR DESCRIPTION
We set CMake to use C99 standard for C and Fortran tests so we are testing that we conform to the C99 standard we assert in documentation.