### PR TITLE
Fix error in Python exists functions

### DIFF
--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -375,7 +375,7 @@ class Client(PyClient):
         :raises RedisReplyError: if `tensor_exists` fails (i.e. causes an error)
         """
         try:
-            super().tensor_exists(name)
+            return super().tensor_exists(name)
         except RuntimeError as e:
             raise RedisReplyError(str(e), "tensor_exists")
 
@@ -393,7 +393,7 @@ class Client(PyClient):
         :raises RedisReplyError: if `model_exists` fails (i.e. causes an error)
         """
         try:
-            super().model_exists(name)
+            return super().model_exists(name)
         except RuntimeError as e:
             raise RedisReplyError(str(e), "model_exists")
 
@@ -408,7 +408,7 @@ class Client(PyClient):
         :raises RedisReplyError: if `key_exists` fails
         """
         try:
-            super().key_exists(key)
+            return super().key_exists(key)
         except RuntimeError as e:
             raise RedisReplyError(str(e), "key_exists")
 

--- a/tests/python/test_model_methods_torch.py
+++ b/tests/python/test_model_methods_torch.py
@@ -18,6 +18,7 @@ def test_set_model_from_file(mock_model, use_cluster):
         mock_model.create_torch_cnn(filepath="./torch_cnn.pt")
         c = Client(None, use_cluster)
         c.set_model_from_file("file_cnn", "./torch_cnn.pt", "TORCH", "CPU")
+        assert c.model_exists("file_cnn")
         returned_model = c.get_model("file_cnn")
         with open("./torch_cnn.pt", "rb") as f:
             model = f.read()

--- a/tests/python/test_put_get_tensor.py
+++ b/tests/python/test_put_get_tensor.py
@@ -43,6 +43,8 @@ def send_get_arrays(client, data):
     for index, array in enumerate(data):
         key = f"array_{str(index)}"
         client.put_tensor(key, array)
+        assert client.tensor_exists(key) == True
+        assert client.key_exists(key) == True
 
     # get from database
     for index, array in enumerate(data):

--- a/tests/python/test_script_methods.py
+++ b/tests/python/test_script_methods.py
@@ -31,6 +31,7 @@ def test_set_script_from_file(use_cluster):
     c.set_script_from_file(
         "test-script-file", osp.join(file_path, "./data_processing_script.txt")
     )
+    assert c.model_exists("test-script-file")
     returned_script = c.get_script("test-script-file")
     assert sent_script == returned_script
 


### PR DESCRIPTION
Currently the ``tensor_exists``, ``model_exists``, and ``key_exists`` return ``None`` instead of a boolean value.  This PR fixes this behavior.