### PR TITLE
Fixes build of GPU dependencies for RedisAI

### DIFF
--- a/build-scripts/build-redisai-gpu.sh
+++ b/build-scripts/build-redisai-gpu.sh
@@ -51,7 +51,7 @@ else
     fi
     cd RedisAI
     echo "Downloading RedisAI CPU dependencies"
-    CC=gcc CXX=g++ WITH_PT=1 WITH_TF=1 WITH_TFLITE=0 WITH_ORT=0 bash get_deps.sh cpu
+    CC=gcc CXX=g++ WITH_PT=1 WITH_TF=1 WITH_TFLITE=0 WITH_ORT=0 bash get_deps.sh gpu
     echo "Building RedisAI"
     CC=gcc CXX=g++ GPU=1 WITH_PT=1 WITH_TF=1 WITH_TFLITE=0 WITH_ORT=0 WITH_UNIT_TESTS=0 make -C opt clean build
 


### PR DESCRIPTION
This is a quick fix for building GPU dependencies for RedisAI. Currently, the script builds CPU dependencies, and the build of RedisAI for GPU fails.