### PR TITLE
Fix Tensor and TensorBase move assignment operator

### DIFF
--- a/include/tensor.tcc
+++ b/include/tensor.tcc
@@ -50,7 +50,7 @@ Tensor<T>::Tensor(const Tensor<T>& tensor) : TensorBase(tensor)
 }
 
 template <class T>
-Tensor<T>::Tensor(Tensor<T>&& tensor) : TensorBase(tensor)
+Tensor<T>::Tensor(Tensor<T>&& tensor) : TensorBase(std::move(tensor))
 {
     this->_c_mem_views = std::move(tensor._c_mem_views);
     this->_f_mem_views = std::move(tensor._f_mem_views);
@@ -75,7 +75,7 @@ Tensor<T>& Tensor<T>::operator=(Tensor<T>&& tensor)
     if(this!=&tensor) {
         this->TensorBase::operator=(std::move(tensor));
         this->_c_mem_views = std::move(tensor._c_mem_views);
-        this->_f_mem_views = std::move(tensor._c_mem_views);
+        this->_f_mem_views = std::move(tensor._f_mem_views);
     }
     return *this;
 }

--- a/include/tensor.tcc
+++ b/include/tensor.tcc
@@ -73,7 +73,7 @@ template <class T>
 Tensor<T>& Tensor<T>::operator=(Tensor<T>&& tensor)
 {
     if(this!=&tensor) {
-        this->TensorBase::operator=(tensor);
+        this->TensorBase::operator=(std::move(tensor));
         this->_c_mem_views = std::move(tensor._c_mem_views);
         this->_f_mem_views = std::move(tensor._c_mem_views);
     }

--- a/src/cpp/tensorbase.cpp
+++ b/src/cpp/tensorbase.cpp
@@ -100,6 +100,8 @@ TensorBase& TensorBase::operator=(TensorBase&& tb)
         this->_name = std::move(tb._name);
         this->_type = std::move(tb._type);
         this->_dims = std::move(tb._dims);
+        if(this->_data)
+            free(this->_data);
         this->_data = tb._data;
         tb._data = 0;
     }


### PR DESCRIPTION
Fix for bugs relating to the `Tensor` and `TensorBase` move assignment operators and move constructors. `Tensor`'s move assignment operator and move constructor are now working as intended, and `_data` for rvalue reference is being freed.