### PR TITLE
Pin PyBind to v2.6.2.

### DIFF
--- a/build-scripts/build_deps.sh
+++ b/build-scripts/build_deps.sh
@@ -59,7 +59,7 @@ fi
 if [[ -d "./pybind" ]]; then
     echo "PyBind11 has already been downloaded and installed"
 else
-    git clone https://github.com/pybind/pybind11.git pybind --depth=1
+    git clone https://github.com/pybind/pybind11.git pybind --branch v2.6.2 --depth=1
     cd pybind
     mkdir build
     cd ..


### PR DESCRIPTION
Currently, we are not pinned to a version of PyBind, and because of this, the github automated tests started failing.  This PR pins SmartRedis to use PyBind v2.6.2.