### PR TITLE
hiredis path fix

### DIFF
--- a/build-scripts/build_deps.sh
+++ b/build-scripts/build_deps.sh
@@ -25,8 +25,8 @@ else
     fi
     cd hiredis
 
-    CC=gcc CXX=g++ make PREFIX="$(pwd)/../../install" static -j $NPROC
-    CC=gcc CXX=g++ make PREFIX="$(pwd)/../../install" install
+    LIBRARY_PATH=lib CC=gcc CXX=g++ make PREFIX="$(pwd)/../../install" static -j $NPROC
+    LIBRARY_PATH=lib CC=gcc CXX=g++ make PREFIX="$(pwd)/../../install" install
     cd ../
     # delete shared libraries
     rm ../install/lib/*.so


### PR DESCRIPTION
On Summit, the env variable `LIBRARY_PATH` is defined at system level (similarly to `LD_LIBRARY_PATH`). This variable clashes with one variable in the hiredis build `Makefile`. The result is that libraries end up in the wrong path and `build_deps.sh` cannot find them.