### PR TITLE
add an is_initialized method to the fortran client

### DIFF
--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -51,7 +51,7 @@ type, public :: client_type
 
   logical(kind=c_bool) :: cluster = .false.        !< True if a database cluster is being used
   type(c_ptr)          :: client_ptr = c_null_ptr !< Pointer to the initialized SmartRedisClient
-
+  logical              :: is_initialized = .false.    !< True if client is initialized
   contains
 
   ! Public procedures
@@ -64,6 +64,8 @@ type, public :: client_type
 
   !> Initializes a new instance of the SmartRedis client
   procedure :: initialize
+  !> Check if a SmartRedis client has been initialized
+  procedure :: isinitialized
   !> Destructs a new instance of the SmartRedis client
   procedure :: destructor
   !> Check the database for the existence of a specific model
@@ -139,10 +141,16 @@ subroutine initialize( this, cluster )
   class(client_type) :: this
   logical, optional :: cluster !< If true, client uses a database cluster (Default: .false.)
 
+  if (this%is_initialized) return
   if (present(cluster)) this%cluster = cluster
   this%client_ptr = c_constructor(this%cluster)
-
+  this%is_initialized = .true. 
 end subroutine initialize
+
+logical function isinitialized(this)
+  class(client_type) :: this
+  isinitialized = this%is_initialized
+end function isinitialized
 
 !> A destructor for the SmartRedis client
 subroutine destructor( this )

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -93,3 +93,12 @@ add_executable(client_test_ensemble
 target_link_libraries(client_test_ensemble
 	${SR_LIB}
 )
+
+add_executable(client_test_initialized
+        client_test_initialized.F90
+        ${ftn_client_src}
+        test_utils.F90
+)
+target_link_libraries(client_test_initialized
+	${SR_LIB}
+)

--- a/tests/fortran/client_test_initialized.F90
+++ b/tests/fortran/client_test_initialized.F90
@@ -10,4 +10,6 @@ program main
 
   if(.not. client%isinitialized()) stop 'client is initialized'
 
+  write(*,*) "client initialized: passed"
+
 end program main

--- a/tests/fortran/client_test_initialized.F90
+++ b/tests/fortran/client_test_initialized.F90
@@ -1,0 +1,13 @@
+program main
+  use smartredis_client, only : client_type
+  use test_utils, only : use_cluster
+
+  type(client_type) :: client
+
+  if(client%isinitialized()) stop 'client not initialized'
+
+  call client%initialize(use_cluster())
+
+  if(.not. client%isinitialized()) stop 'client is initialized'
+
+end program main


### PR DESCRIPTION
Add a method to fortran client to check if client%initialize has already been called. 