### PR TITLE
Improve error handling for client initialization

### DIFF
--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -347,7 +347,7 @@ inline void Redis::_connect(std::string address_port)
     }
 
     // Attempt to have the sw::redis::Redis object
-    // make a connection using the PONG command
+    // make a connection using the PING command
     int n_trials = 10;
 
     for(int i=n_trials; i>0; i--) {

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -353,8 +353,10 @@ inline void Redis::_connect(std::string address_port)
     // Attempt to have the sw::redis::Redis object
     // make a connection using the PING command
     int n_trials = 10;
+    bool run_sleep = false;
 
     for(int i=1; i<=n_trials; i++) {
+        run_sleep = false;
         try {
             if(this->_redis->ping().compare("PONG")==0) {
                 break;
@@ -366,13 +368,15 @@ inline void Redis::_connect(std::string address_port)
                 this->_redis = 0;
                 throw std::runtime_error(e.what());
             }
-            std::this_thread::sleep_for(std::chrono::seconds(2));
+            run_sleep = true;
         }
         catch (std::exception& e) {
             delete this->_redis;
             this->_redis = 0;
             throw std::runtime_error(e.what());
         }
+        if(run_sleep)
+            std::this_thread::sleep_for(std::chrono::seconds(2));
     }
     return;
 }

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -468,8 +468,10 @@ CommandReply RedisCluster::get_script(const std::string& key)
 inline void RedisCluster::_connect(std::string address_port)
 {
     int n_trials = 10;
+    bool run_sleep = false;
 
     for(int i=1; i<=n_trials; i++) {
+        run_sleep = false;
         try {
             this->_redis_cluster =
                 new sw::redis::RedisCluster(address_port);
@@ -483,13 +485,15 @@ inline void RedisCluster::_connect(std::string address_port)
             if(i == n_trials) {
                 throw std::runtime_error(e.what());
             }
-            std::this_thread::sleep_for(std::chrono::seconds(2));
+            run_sleep = true;
         }
         catch (std::exception& e) {
             delete this->_redis_cluster;
             this->_redis_cluster = 0;
             throw std::runtime_error(e.what());
         }
+        if(run_sleep)
+            std::this_thread::sleep_for(std::chrono::seconds(2));
     }
     return;
 }

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -467,28 +467,30 @@ CommandReply RedisCluster::get_script(const std::string& key)
 
 inline void RedisCluster::_connect(std::string address_port)
 {
-    int n_connection_trials = 10;
+    int n_trials = 10;
 
-    while(n_connection_trials > 0) {
+    for(int i=1; i<=n_trials; i++) {
         try {
-            this->_redis_cluster = new sw::redis::RedisCluster(address_port);
-            n_connection_trials = -1;
+            this->_redis_cluster =
+                new sw::redis::RedisCluster(address_port);
         }
-        catch (sw::redis::TimeoutError &e) {
-          std::cout << "WARNING: Caught redis TimeoutError: "
-                    << e.what() << std::endl;
-          std::cout << "WARNING: TimeoutError occurred with "\
-                       "initial client connection.";
-          std::cout << "WARNING: "<< n_connection_trials
-                      << " more trials will be made.";
-          n_connection_trials--;
-          std::this_thread::sleep_for(std::chrono::seconds(2));
+        catch (std::bad_alloc& e) {
+            throw std::runtime_error(e.what());
+        }
+        catch (sw::redis::Error& e) {
+            delete this->_redis_cluster;
+            this->_redis_cluster = 0;
+            if(i == n_trials) {
+                throw std::runtime_error(e.what());
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+        }
+        catch (std::exception& e) {
+            delete this->_redis_cluster;
+            this->_redis_cluster = 0;
+            throw std::runtime_error(e.what());
         }
     }
-
-    if(n_connection_trials==0)
-        throw std::runtime_error("A connection could not be "\
-                                 "established to the redis cluster.");
     return;
 }
 


### PR DESCRIPTION
This PR addresses #92 by raising all errors encountered during client creation and initialization as ``std::runtime_error``.  Additionally, a client connection is forced in the non-cluster client creation by running the Redis ``ping`` command so that a client connection is made.  This improves error tracking by having the source of a bad client connection traceable to ``_connect()``.