### PR TITLE
Change error output to just emit the first field

### DIFF
--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -89,7 +89,7 @@ CommandReply Redis::run(Command& cmd)
         if(reply.has_error()>0)
             reply.print_reply_error();
         throw std::runtime_error("Redis failed to execute command: " +
-                                 cmd.to_string());
+                                 cmd.first_field());
     }
 
     return reply;

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -104,7 +104,7 @@ CommandReply RedisCluster::run(Command& cmd)
         if(reply.has_error()>0)
             reply.print_reply_error();
         throw std::runtime_error("Redis failed to execute command: " +
-                                 cmd.to_string());
+                                 cmd.first_field());
     }
 
     return reply;


### PR DESCRIPTION
A failed command execution will now emit only the first field in order to prevent large amounts of data being printed.