### PR TITLE
Fix breathe to version 4.26.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest-cov==2.10.1
 black==20.8b1
 isort==5.6.4
 pylint==2.6.0
-breathe==4.25.1
+breathe==4.26.0
 torch==1.7.1
 sphinx-fortran==1.1.1
 cmake>=3.10


### PR DESCRIPTION
This PR resolves the `AssertionError` that occurs when `make docs` is ran with doxygen >= 1.19.