### PR TITLE
Add method to retrieve cluster node information and update exception handling

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -552,9 +552,19 @@ class Client
         /*!
         *   \brief Returns information about the given database node
         *   \param address The address of the database node (host:port)
-        *   \returns parsed_reply_map containing the database node information
+        *   \returns parsed_reply_nested_map containing the database node information
         */
-        parsed_reply_map get_db_node_info(std::string address);
+        parsed_reply_nested_map get_db_node_info(std::string address);
+
+        /*!
+        *   \brief Returns the CLUSTER INFO command reply addressed to a single
+        *          cluster node.
+        *   \param address The address of the database node (host:port)
+        *   \returns parsed_reply_map containing the database cluster information.
+        *            If this command is executed on a non-cluster database, an
+        *            empty parsed_reply_map is returned.
+        */
+        parsed_reply_map get_db_cluster_info(std::string address);
 
     protected:
 

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -434,6 +434,15 @@ class PyClient
         */
         std::vector<py::dict> get_db_node_info(std::vector<std::string> addresses);
 
+        /*!
+        *   \brief \brief Returns the CLUSTER INFO command reply addressed to one
+        *                 or multiple cluster nodes.
+        *   \param addresses The addresses of the database nodes
+        *   \returns A list of parsed_map objects containing all the cluster
+        *            information about the given database nodes
+        */
+        std::vector<py::dict> get_db_cluster_info(std::vector<std::string> addresses);
+
     private:
 
         /*!

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -670,7 +670,7 @@ void Client::use_tensor_ensemble_prefix(bool use_prefix)
     this->_use_tensor_prefix = use_prefix;
 }
 
-parsed_reply_map Client::get_db_node_info(std::string address)
+parsed_reply_nested_map Client::get_db_node_info(std::string address)
 {
     std::string host = address.substr(0, address.find(":"));
     uint64_t port = std::stoul (address.substr(address.find(":") + 1),
@@ -687,6 +687,25 @@ parsed_reply_map Client::get_db_node_info(std::string address)
                                                         reply.str_len()));
 }
 
+parsed_reply_map Client::get_db_cluster_info(std::string address)
+{
+    if(this->_redis_cluster == NULL)
+        return parsed_reply_map();
+
+    std::string host = address.substr(0, address.find(":"));
+    uint64_t port = std::stoul (address.substr(address.find(":") + 1),
+                                nullptr, 0);
+    if (host.empty() or port == 0)
+        throw std::runtime_error(std::string(address) +
+                                 "is not a valid database node address.");
+    Command cmd;
+    cmd.set_exec_address_port(host, port);
+    cmd.add_field("CLUSTER");
+    cmd.add_field("INFO");
+    CommandReply reply = this->_run(cmd);
+    return CommandReplyParser::parse_db_cluster_info(std::string(reply.str(),
+                                                     reply.str_len()));
+}
 
 CommandReply Client::_run(Command& cmd)
 {

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -56,9 +56,8 @@ CommandReply Redis::run(Command& cmd)
     CommandReply reply;
 
     int n_trials = 100;
-    bool success = true;
 
-    while (n_trials > 0 && success) {
+    while (n_trials > 0) {
 
         try {
             reply = this->_redis->command(cmd_fields_start, cmd_fields_end);
@@ -68,7 +67,11 @@ CommandReply Redis::run(Command& cmd)
             else
                 n_trials = 0;
         }
-        catch (sw::redis::Error &e) {
+        catch (sw::redis::IoError &e) {
+            n_trials--;
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+        }
+        catch (sw::redis::ClosedError &e) {
             n_trials--;
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
@@ -78,10 +81,7 @@ CommandReply Redis::run(Command& cmd)
         }
     }
 
-    if (n_trials == 0)
-        success = false;
-
-    if (!success) {
+    if (n_trials == 0) {
         if(reply.has_error()>0)
             reply.print_reply_error();
         throw std::runtime_error("Redis failed to execute command: " +
@@ -358,18 +358,13 @@ inline void Redis::_connect(std::string address_port)
                 break;
             }
         }
-        catch (sw::redis::Error& e) {
+        catch (std::exception& e) {
             if(i == n_trials) {
                 delete this->_redis;
                 this->_redis = 0;
                 throw std::runtime_error(e.what());
             }
             run_sleep = true;
-        }
-        catch (std::exception& e) {
-            delete this->_redis;
-            this->_redis = 0;
-            throw std::runtime_error(e.what());
         }
         if(run_sleep)
             std::this_thread::sleep_for(std::chrono::seconds(2));

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -76,7 +76,6 @@ CommandReply Redis::run(Command& cmd)
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
         catch (std::exception& e) {
-            n_trials--;
             throw std::runtime_error(e.what());
         }
     }

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -68,17 +68,13 @@ CommandReply Redis::run(Command& cmd)
             else
                 n_trials = 0;
         }
-        catch (sw::redis::TimeoutError &e) {
+        catch (sw::redis::Error &e) {
             n_trials--;
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
-        catch (sw::redis::IoError &e) {
+        catch (std::exception& e) {
             n_trials--;
-            std::this_thread::sleep_for(std::chrono::seconds(2));
-        }
-        catch (...) {
-            n_trials--;
-            throw;
+            throw std::runtime_error(e.what());
         }
     }
 

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -70,9 +70,8 @@ CommandReply RedisCluster::run(Command& cmd)
     CommandReply reply;
 
     int n_trials = 100;
-    bool success = true;
 
-    while (n_trials > 0 && success) {
+    while (n_trials > 0) {
 
         try {
             sw::redis::Redis db = this->_redis_cluster->redis(sv_prefix, false);
@@ -83,7 +82,11 @@ CommandReply RedisCluster::run(Command& cmd)
             else
                 n_trials = 0;
         }
-        catch (sw::redis::Error &e) {
+        catch (sw::redis::IoError &e) {
+            n_trials--;
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+        }
+        catch (sw::redis::ClosedError &e) {
             n_trials--;
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
@@ -93,10 +96,7 @@ CommandReply RedisCluster::run(Command& cmd)
         }
     }
 
-    if (n_trials == 0)
-        success = false;
-
-    if (!success) {
+    if (n_trials == 0) {
         if(reply.has_error()>0)
             reply.print_reply_error();
         throw std::runtime_error("Redis failed to execute command: " +
@@ -475,18 +475,13 @@ inline void RedisCluster::_connect(std::string address_port)
         catch (std::bad_alloc& e) {
             throw std::runtime_error(e.what());
         }
-        catch (sw::redis::Error& e) {
+        catch (std::exception& e) {
             delete this->_redis_cluster;
             this->_redis_cluster = 0;
             if(i == n_trials) {
                 throw std::runtime_error(e.what());
             }
             run_sleep = true;
-        }
-        catch (std::exception& e) {
-            delete this->_redis_cluster;
-            this->_redis_cluster = 0;
-            throw std::runtime_error(e.what());
         }
         if(run_sleep)
             std::this_thread::sleep_for(std::chrono::seconds(2));

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -91,7 +91,6 @@ CommandReply RedisCluster::run(Command& cmd)
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
         catch (std::exception& e) {
-            n_trials--;
             throw std::runtime_error(e.what());
         }
     }

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -83,17 +83,13 @@ CommandReply RedisCluster::run(Command& cmd)
             else
                 n_trials = 0;
         }
-        catch (sw::redis::TimeoutError &e) {
+        catch (sw::redis::Error &e) {
             n_trials--;
             std::this_thread::sleep_for(std::chrono::seconds(2));
         }
-        catch (sw::redis::IoError &e) {
+        catch (std::exception& e) {
             n_trials--;
-            std::this_thread::sleep_for(std::chrono::seconds(2));
-        }
-        catch (...) {
-            n_trials--;
-            throw;
+            throw std::runtime_error(e.what());
         }
     }
 

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -65,7 +65,8 @@ PYBIND11_MODULE(smartredisPy, m) {
         .def("set_data_source", &PyClient::set_data_source)
         .def("use_tensor_ensemble_prefix", &PyClient::use_tensor_ensemble_prefix)
         .def("use_model_ensemble_prefix", &PyClient::use_model_ensemble_prefix)
-        .def("get_db_node_info", &PyClient::get_db_node_info);
+        .def("get_db_node_info", &PyClient::get_db_node_info)
+        .def("get_db_cluster_info", &PyClient::get_db_cluster_info);
 
     // Python Dataset class
     py::class_<PyDataset>(m, "PyDataset")

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -630,12 +630,32 @@ class Client(PyClient):
 
         :param addresses: The addresses of the database nodes
         :type address: list[str]
+        :returns: A list of dictionaries with each entry in the
+                  list corresponding to an address reply
+        :rtype: list[dict]
 
         """
         try:
             return super().get_db_node_info(addresses)
         except RuntimeError as e:
             raise RedisReplyError(str(e), "get_db_node_info")
+
+    def get_db_cluster_info(self, addresses):
+        """Returns cluster information from a specified db node.
+        If the address does not correspond to a cluster node,
+        an empty dictionary is returned.
+
+        :param addresses: The addresses of the database nodes
+        :type address: list[str]
+        :returns: A list of dictionaries with each entry in the
+                  list corresponding to an address reply
+        :rtype: list[dict]
+
+        """
+        try:
+            return super().get_db_cluster_info(addresses)
+        except RuntimeError as e:
+            raise RedisReplyError(str(e), "get_db_cluster_info")
 
     # ---- helpers --------------------------------------------------------
 

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -445,7 +445,18 @@ std::vector<py::dict> PyClient::get_db_node_info(std::vector<std::string> addres
 {
     std::vector<py::dict> addresses_info;
     for(size_t i=0; i<addresses.size(); i++) {
-        parsed_reply_map info_map = this->_client->get_db_node_info(addresses[i]);
+        parsed_reply_nested_map info_map = this->_client->get_db_node_info(addresses[i]);
+        py::dict info_dict = py::cast(info_map);
+        addresses_info.push_back(info_dict);
+    }
+    return addresses_info;
+}
+
+std::vector<py::dict> PyClient::get_db_cluster_info(std::vector<std::string> addresses)
+{
+    std::vector<py::dict> addresses_info;
+    for(size_t i=0; i<addresses.size(); i++) {
+        parsed_reply_map info_map = this->_client->get_db_cluster_info(addresses[i]);
         py::dict info_dict = py::cast(info_map);
         addresses_info.push_back(info_dict);
     }


### PR DESCRIPTION
This PR adds a method ``get_db_cluster_info`` to retrieve the reply for a ``CLUSTER INFO`` command that is directed at a specific host and port.  Also, exception handling for command execution and client connection are updated to throw a std::runtime_error for any exception, not just sw::redis exceptions.