### PR TITLE
Update the slurm utility script to bind database nodes

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -553,6 +553,14 @@ class Client
         *   \brief Returns information about the given database node
         *   \param address The address of the database node (host:port)
         *   \returns parsed_reply_nested_map containing the database node information
+	*   \throws std::runtime_error if the address is not addressable by this
+	*           client.  In the case of using a cluster of database nodes,
+	*           it is best practice to bind each node in the cluster
+	*           to a specific adddress to avoid inconsistencies in
+	*           addresses retreived with the CLUSTER SLOTS command.
+	*           Inconsistencies in node addresses across
+	*           CLUSTER SLOTS comands will lead to std::runtime_error
+	*           being thrown.
         */
         parsed_reply_nested_map get_db_node_info(std::string address);
 
@@ -563,6 +571,14 @@ class Client
         *   \returns parsed_reply_map containing the database cluster information.
         *            If this command is executed on a non-cluster database, an
         *            empty parsed_reply_map is returned.
+	*   \throws std::runtime_error if the address is not addressable by this
+        *           client.  In the case of using a cluster of database nodes,
+        *           it is best practice to bind each node in the cluster
+        *           to a specific adddress to avoid inconsistencies in
+        *           addresses retreived with the CLUSTER SLOTS command.
+        *           Inconsistencies in node addresses across
+        *           CLUSTER SLOTS comands will lead to std::runtime_error
+        *           being thrown.
         */
         parsed_reply_map get_db_cluster_info(std::string address);
 

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -431,6 +431,14 @@ class PyClient
         *   \param addresses The addresses of the database nodes
         *   \returns A list of parsed_map objects containing all the
         *            information about the given database nodes
+	*   \throws std::runtime_error if the address is not addressable by this
+        *           client.  In the case of using a cluster of database nodes,
+        *           it is best practice to bind each node in the cluster
+        *           to a specific adddress to avoid inconsistencies in
+        *           addresses retreived with the CLUSTER SLOTS command.
+        *           Inconsistencies in node addresses across
+        *           CLUSTER SLOTS comands will lead to std::runtime_error
+        *           being thrown.
         */
         std::vector<py::dict> get_db_node_info(std::vector<std::string> addresses);
 
@@ -440,6 +448,14 @@ class PyClient
         *   \param addresses The addresses of the database nodes
         *   \returns A list of parsed_map objects containing all the cluster
         *            information about the given database nodes
+	*   \throws std::runtime_error if the address is not addressable by this
+        *           client.  In the case of using a cluster of database nodes,
+        *           it is best practice to bind each node in the cluster
+        *           to a specific adddress to avoid inconsistencies in
+        *           addresses retreived with the CLUSTER SLOTS command.
+        *           Inconsistencies in node addresses across
+        *           CLUSTER SLOTS comands will lead to std::runtime_error
+        *           being thrown.
         */
         std::vector<py::dict> get_db_cluster_info(std::vector<std::string> addresses);
 

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -633,6 +633,16 @@ class Client(PyClient):
         :returns: A list of dictionaries with each entry in the
                   list corresponding to an address reply
         :rtype: list[dict]
+        :raises RedisReplyError: if there is an error in
+                  in command execution or the address
+                  is not reachable by the client.  
+                  In the case of using a cluster of database nodes,
+                  it is best practice to bind each node in the cluster
+                  to a specific adddress to avoid inconsistencies in
+                  addresses retreived with the CLUSTER SLOTS command.
+                  Inconsistencies in node addresses across
+                  CLUSTER SLOTS comands will lead to RedisReplyError
+                  being thrown.
 
         """
         try:
@@ -650,6 +660,16 @@ class Client(PyClient):
         :returns: A list of dictionaries with each entry in the
                   list corresponding to an address reply
         :rtype: list[dict]
+        :raises RedisReplyError: if there is an error in
+                  in command execution or the address
+                  is not reachable by the client.
+                  In the case of using a cluster of database nodes,
+                  it is best practice to bind each node in the cluster
+                  to a specific adddress to avoid inconsistencies in
+                  addresses retreived with the CLUSTER SLOTS command.
+                  Inconsistencies in node addresses across
+                  CLUSTER SLOTS comands will lead to RedisReplyError
+                  being thrown.
 
         """
         try:

--- a/utils/create_cluster/slurm_cluster.py
+++ b/utils/create_cluster/slurm_cluster.py
@@ -5,15 +5,10 @@ import os
 def get_ip_from_host(host):
     ping_out = ping_host(host)
     found = False
-    print(host)
-    print(ping_out)
-    print('here')
     # break loop when the hostname is found in
     # the ping output
     for item in ping_out.split():
-        print(item)
         if found:
-            print('Found!')
             return item.split("(")[1].split(")")[0]
         if item == host:
             found = True


### PR DESCRIPTION
This PR updates the slurm utility script to bind database 
nodes to a specific address.  This prevents inconsistencies in
addresses retrieved with CLUSTER SLOTS when running the test suite.
Updated documentation was also added to better inform users
why inconsistent addresses can throw an error when trying to run
get_db_node_info() command.