### PR TITLE
Add copy constructors and copy assignment operators to CommandReply

### DIFF
--- a/include/commandreply.h
+++ b/include/commandreply.h
@@ -93,14 +93,14 @@ class CommandReply {
         *          redisReply as input
         *   \param reply The redisReply to copy
         */
-        CommandReply& operator=(redisReply* reply);
+        CommandReply& operator=(const redisReply* reply);
 
         /*!
         *   \brief CommandReply copy constructor with
         *          redisReply as input
         *   \param reply The redisReply to copy
         */
-        CommandReply(redisReply* reply);
+        CommandReply(const redisReply* reply);
 
         /*!
         *   \brief Move constructor with RedisReplyUPtr
@@ -237,7 +237,7 @@ class CommandReply {
         *          redisReply
         *   \param reply redisReply to copy
         */
-        redisReply* deep_clone_reply(redisReply* reply);
+        redisReply* deep_clone_reply(const redisReply* reply);
 
         /*!
         *   \brief RedisReplyUPtr that can hold redis reply data

--- a/include/commandreply.h
+++ b/include/commandreply.h
@@ -78,15 +78,29 @@ class CommandReply {
 
         /*!
         *   \brief CommandReply copy constructor
-        *          not available
+        *   \param reply The CommandReply to copy
         */
-        CommandReply(const CommandReply& reply) = delete;
+        CommandReply(const CommandReply& reply);
 
         /*!
         *   \brief CommandReply copy assignment operator
-        *          not available
+        *   \param reply The CommandReply to copy
         */
-        CommandReply& operator=(const CommandReply& reply) = delete;
+        CommandReply& operator=(const CommandReply& reply);
+
+        /*!
+        *   \brief CommandReply copy assignment operator with
+        *          redisReply as input
+        *   \param reply The redisReply to copy
+        */
+        CommandReply& operator=(redisReply* reply);
+
+        /*!
+        *   \brief CommandReply copy constructor with
+        *          redisReply as input
+        *   \param reply The redisReply to copy
+        */
+        CommandReply(redisReply* reply);
 
         /*!
         *   \brief Move constructor with RedisReplyUPtr
@@ -212,10 +226,18 @@ class CommandReply {
     private:
 
         /*!
-        *   \brief CommandReply constructor from a redisReply.
+        *   \brief Helper function for getting a CommandReply
+        *          constructed from shallow copying a redisReply
         *   \param reply redisReply for construction
         */
-        CommandReply(redisReply* reply);
+        CommandReply shallow_clone(redisReply* reply);
+
+        /*!
+        *   \brief Helper function for doing a deep copy of a
+        *          redisReply
+        *   \param reply redisReply to copy
+        */
+        redisReply* deep_clone_reply(redisReply* reply);
 
         /*!
         *   \brief RedisReplyUPtr that can hold redis reply data

--- a/src/cpp/commandreply.cpp
+++ b/src/cpp/commandreply.cpp
@@ -36,7 +36,7 @@ CommandReply::CommandReply(const CommandReply& reply)
     _reply = _uptr_reply.get();
 }
 
-CommandReply::CommandReply(redisReply* reply)
+CommandReply::CommandReply(const redisReply* reply)
 {
     _uptr_reply = RedisReplyUPtr(deep_clone_reply(reply), sw::redis::ReplyDeleter());
     _reply = _uptr_reply.get();
@@ -71,7 +71,7 @@ CommandReply& CommandReply::operator=(const CommandReply& reply)
     return *this;
 }
 
-CommandReply& CommandReply::operator=(redisReply* reply)
+CommandReply& CommandReply::operator=(const redisReply* reply)
 {
     _uptr_reply.reset(NULL);
     _uptr_reply = RedisReplyUPtr(deep_clone_reply(reply), sw::redis::ReplyDeleter());
@@ -294,7 +294,7 @@ void CommandReply::print_reply_structure(std::string index_tracker)
     return;
 }
 
-redisReply* CommandReply::deep_clone_reply(redisReply* reply)
+redisReply* CommandReply::deep_clone_reply(const redisReply* reply)
 {
     if(reply == NULL)
         return NULL;

--- a/src/cpp/commandreply.cpp
+++ b/src/cpp/commandreply.cpp
@@ -32,29 +32,29 @@ using namespace SmartRedis;
 
 CommandReply::CommandReply(redisReply* reply)
 {
-  this->_uptr_reply = 0;
-  this->_reply = reply;
+    this->_uptr_reply = 0;
+    this->_reply = reply;
 }
 
 CommandReply::CommandReply(RedisReplyUPtr&& reply)
 {
-  this->_uptr_reply = std::move(reply);
-  this->_reply = this->_uptr_reply.get();
-  return;
+    this->_uptr_reply = std::move(reply);
+    this->_reply = this->_uptr_reply.get();
+    return;
 }
 
 CommandReply::CommandReply(redisReply*&& reply)
 {
-  this->_uptr_reply = 0;
-  this->_reply = std::move(reply);
-  return;
+    this->_uptr_reply = 0;
+    this->_reply = std::move(reply);
+    return;
 }
 
 CommandReply::CommandReply(CommandReply&& reply)
 {
-  this->_uptr_reply = std::move(reply._uptr_reply);
-  this->_reply = this->_uptr_reply.get();
-  return;
+    this->_uptr_reply = std::move(reply._uptr_reply);
+    this->_reply = this->_uptr_reply.get();
+    return;
 }
 
 CommandReply& CommandReply::operator=(RedisReplyUPtr&& reply)
@@ -73,70 +73,70 @@ CommandReply& CommandReply::operator=(redisReply*&& reply)
 
 CommandReply& CommandReply::operator=(CommandReply&& reply)
 {
-  if(this!=&reply) {
-    this->_uptr_reply = std::move(reply._uptr_reply);
-    this->_reply = this->_uptr_reply.get();
-  }
-  return *this;
+    if(this!=&reply) {
+        this->_uptr_reply = std::move(reply._uptr_reply);
+        this->_reply = this->_uptr_reply.get();
+    }
+    return *this;
 }
 
 char* CommandReply::str()
 {
-  if(this->_reply->type!=REDIS_REPLY_STRING)
-    throw std::runtime_error("A pointer to the reply str "\
-                             "cannot be returned because the "\
-                             "the reply type is " +
-                             this->redis_reply_type());
-  return this->_reply->str;
+    if(this->_reply->type!=REDIS_REPLY_STRING)
+        throw std::runtime_error("A pointer to the reply str "\
+                                 "cannot be returned because the "\
+                                 "the reply type is " +
+                                 this->redis_reply_type());
+    return this->_reply->str;
 }
 
 long long CommandReply::integer()
 {
-  if(this->_reply->type!=REDIS_REPLY_INTEGER)
-    throw std::runtime_error("The reply integer "\
-                             "cannot be returned because the "\
-                             "the reply type is " +
-                             this->redis_reply_type());
-  return this->_reply->integer;
+    if(this->_reply->type!=REDIS_REPLY_INTEGER)
+        throw std::runtime_error("The reply integer "\
+                                 "cannot be returned because the "\
+                                 "the reply type is " +
+                                 this->redis_reply_type());
+    return this->_reply->integer;
 }
 
 double CommandReply::dbl()
 {
-  if(this->_reply->type!=REDIS_REPLY_DOUBLE)
-    throw std::runtime_error("The reply double "\
-                             "cannot be returned because the "\
-                             "the reply type is " +
-                             this->redis_reply_type());
-  return this->_reply->dval;
+    if(this->_reply->type!=REDIS_REPLY_DOUBLE)
+        throw std::runtime_error("The reply double "\
+                                 "cannot be returned because the "\
+                                 "the reply type is " +
+                                 this->redis_reply_type());
+    return this->_reply->dval;
 }
 
 CommandReply CommandReply::operator[](int index)
 {
-  if(this->_reply->type!=REDIS_REPLY_ARRAY)
-    throw std::runtime_error("The reply cannot be indexed "\
-                             "because the reply type is " +
-                             this->redis_reply_type());
-  return CommandReply(this->_reply->element[index]);
+    if(this->_reply->type!=REDIS_REPLY_ARRAY)
+        throw std::runtime_error("The reply cannot be indexed "\
+                                 "because the reply type is " +
+                                 this->redis_reply_type());
+    return CommandReply(this->_reply->element[index]);
 }
 
 size_t CommandReply::str_len()
 {
-  if(this->_reply->type!=REDIS_REPLY_STRING)
-    throw std::runtime_error("The length of the reply str "\
-                             "cannot be returned because the "\
-                             "the reply type is " +
-                             this->redis_reply_type());
-  return this->_reply->len;
+    if(this->_reply->type!=REDIS_REPLY_STRING)
+        throw std::runtime_error("The length of the reply str "\
+                                 "cannot be returned because the "\
+                                 "the reply type is " +
+                                 this->redis_reply_type());
+    return this->_reply->len;
 }
 
 size_t CommandReply::n_elements()
 {
-  if(this->_reply->type!=REDIS_REPLY_ARRAY)
-    throw std::runtime_error("The number of elements "\
-                             "cannot be returned because the "\
-                             "the reply type is " +
-                             this->redis_reply_type());
-  return this->_reply->elements;
+    if(this->_reply->type!=REDIS_REPLY_ARRAY)
+        throw std::runtime_error("The number of elements "\
+                                 "cannot be returned because the "\
+                                 "the reply type is " +
+                                 this->redis_reply_type());
+    return this->_reply->elements;
 }
 
 int CommandReply::has_error()
@@ -146,8 +146,8 @@ int CommandReply::has_error()
         num_errors++;
     else if(this->_reply->type == REDIS_REPLY_ARRAY) {
         for(size_t i=0; i<this->_reply->elements; i++) {
-          CommandReply tmp = (*this)[i];
-          num_errors += tmp.has_error();
+            CommandReply tmp = (*this)[i];
+            num_errors += tmp.has_error();
         }
     }
     return num_errors;
@@ -162,8 +162,8 @@ void CommandReply::print_reply_error()
     }
     else if(this->_reply->type == REDIS_REPLY_ARRAY) {
         for(size_t i=0; i<this->_reply->elements; i++) {
-          CommandReply tmp = (*this)[i];
-          tmp.print_reply_error();
+            CommandReply tmp = (*this)[i];
+            tmp.print_reply_error();
         }
     }
     return;
@@ -171,95 +171,95 @@ void CommandReply::print_reply_error()
 
 std::string CommandReply::redis_reply_type()
 {
-  switch (this->_reply->type) {
-    case REDIS_REPLY_STRING:
-      return "REDIS_REPLY_STRING";
-      break;
-    case REDIS_REPLY_ARRAY:
-      return "REDIS_REPLY_ARRAY";
-      break;
-    case REDIS_REPLY_INTEGER:
-      return "REDIS_REPLY_INTEGER";
-      break;
-    case REDIS_REPLY_NIL:
-      return "REDIS_REPLY_NIL";
-      break;
-    case REDIS_REPLY_STATUS:
-      return "REDIS_REPLY_STATUS";
-      break;
-    case REDIS_REPLY_ERROR:
-      return "REDIS_REPLY_ERROR";
-      break;
-    case REDIS_REPLY_DOUBLE:
-      return "REDIS_REPLY_DOUBLE";
-      break;
-    case REDIS_REPLY_BOOL:
-      return "REDIS_REPLY_BOOL";
-      break;
-    case REDIS_REPLY_MAP:
-      return "REDIS_REPLY_MAP";
-      break;
-    case REDIS_REPLY_SET:
-      return "REDIS_REPLY_SET";
-      break;
-    case REDIS_REPLY_ATTR:
-      return "REDIS_REPLY_ATTR";
-      break;
-    case REDIS_REPLY_PUSH:
-      return "REDIS_REPLY_PUSH";
-      break;
-    case REDIS_REPLY_BIGNUM:
-      return "REDIS_REPLY_BIGNUM";
-      break;
-    case REDIS_REPLY_VERB:
-      return "REDIS_REPLY_VERB";
-      break;
-    default:
-      throw std::runtime_error("Invalid Redis reply type");
+    switch (this->_reply->type) {
+        case REDIS_REPLY_STRING:
+            return "REDIS_REPLY_STRING";
+            break;
+        case REDIS_REPLY_ARRAY:
+            return "REDIS_REPLY_ARRAY";
+            break;
+        case REDIS_REPLY_INTEGER:
+            return "REDIS_REPLY_INTEGER";
+            break;
+        case REDIS_REPLY_NIL:
+            return "REDIS_REPLY_NIL";
+            break;
+        case REDIS_REPLY_STATUS:
+            return "REDIS_REPLY_STATUS";
+            break;
+        case REDIS_REPLY_ERROR:
+            return "REDIS_REPLY_ERROR";
+            break;
+        case REDIS_REPLY_DOUBLE:
+            return "REDIS_REPLY_DOUBLE";
+            break;
+        case REDIS_REPLY_BOOL:
+            return "REDIS_REPLY_BOOL";
+            break;
+        case REDIS_REPLY_MAP:
+            return "REDIS_REPLY_MAP";
+            break;
+        case REDIS_REPLY_SET:
+            return "REDIS_REPLY_SET";
+            break;
+        case REDIS_REPLY_ATTR:
+            return "REDIS_REPLY_ATTR";
+            break;
+        case REDIS_REPLY_PUSH:
+            return "REDIS_REPLY_PUSH";
+            break;
+        case REDIS_REPLY_BIGNUM:
+            return "REDIS_REPLY_BIGNUM";
+            break;
+        case REDIS_REPLY_VERB:
+            return "REDIS_REPLY_VERB";
+            break;
+        default:
+            throw std::runtime_error("Invalid Redis reply type");
   }
 }
 
 void CommandReply::print_reply_structure(std::string index_tracker)
 {
-  //TODO these recursive functions can't use 'this' unless
-  //we have a constructor that takes redisReply*
-  std::cout<<index_tracker + " type: "
-           <<this->redis_reply_type()<<std::endl;
-  switch(this->_reply->type) {
-    case REDIS_REPLY_STRING:
-      std::cout<<index_tracker + " value: "
-               <<std::string(this->str(),
-                             this->str_len())
-               <<std::endl;
-      break;
-    case REDIS_REPLY_ARRAY:
-      for(size_t i=0; i<this->n_elements(); i++) {
-        std::string r_prefix = index_tracker + "[" +
-                               std::to_string(i) + "]";
-        CommandReply tmp = (*this)[i];
-        tmp.print_reply_structure(r_prefix);
-      }
-      break;
-    case REDIS_REPLY_INTEGER:
-      std::cout<<index_tracker + " value: "
-               <<this->_reply->integer<<std::endl;
-      break;
-    case REDIS_REPLY_DOUBLE:
-      std::cout<<index_tracker + " value: "
-               <<this->_reply->dval<<std::endl;
-      break;
-    case REDIS_REPLY_ERROR:
-      std::cout<<index_tracker + " value: "
-               <<std::string(this->str(), this->str_len())
-               <<std::endl;
-      break;
-    case REDIS_REPLY_BOOL:
-      std::cout<<index_tracker + " value: "
-               <<this->_reply->integer<<std::endl;
-      break;
-    default:
-      std::cout<<index_tracker
-               <<" value type not supported."<<std::endl;
-  }
-  return;
+    //TODO these recursive functions can't use 'this' unless
+    //we have a constructor that takes redisReply*
+    std::cout<<index_tracker + " type: "
+             <<this->redis_reply_type()<<std::endl;
+    switch(this->_reply->type) {
+        case REDIS_REPLY_STRING:
+            std::cout<<index_tracker + " value: "
+                     <<std::string(this->str(),
+                                   this->str_len())
+                     <<std::endl;
+            break;
+        case REDIS_REPLY_ARRAY:
+            for(size_t i=0; i<this->n_elements(); i++) {
+              std::string r_prefix = index_tracker + "[" +
+                                     std::to_string(i) + "]";
+              CommandReply tmp = (*this)[i];
+              tmp.print_reply_structure(r_prefix);
+            }
+            break;
+        case REDIS_REPLY_INTEGER:
+            std::cout<<index_tracker + " value: "
+                     <<this->_reply->integer<<std::endl;
+            break;
+        case REDIS_REPLY_DOUBLE:
+            std::cout<<index_tracker + " value: "
+                     <<this->_reply->dval<<std::endl;
+            break;
+        case REDIS_REPLY_ERROR:
+            std::cout<<index_tracker + " value: "
+                     <<std::string(this->str(), this->str_len())
+                     <<std::endl;
+            break;
+        case REDIS_REPLY_BOOL:
+            std::cout<<index_tracker + " value: "
+                     <<this->_reply->integer<<std::endl;
+            break;
+        default:
+            std::cout<<index_tracker
+                     <<" value type not supported."<<std::endl;
+    }
+    return;
 }

--- a/tests/cpp/unit-tests/test_commandreply.cpp
+++ b/tests/cpp/unit-tests/test_commandreply.cpp
@@ -3,12 +3,69 @@
 
 using namespace SmartRedis;
 
+/*
+*   ----------------------------
+*   HELPER FUNCTIONS FOR TESTING
+*   ----------------------------
+*/
+
 // utility function for quickly creating RedisReplyUPtr
 RedisReplyUPtr create_reply_uptr(redisReply* reply)
 {
     return std::unique_ptr<redisReply, sw::redis::ReplyDeleter>
            (reply, sw::redis::ReplyDeleter());
 }
+
+// utility function for building up a simple rediReply e.g. REDIS_REPLY_INTEGER
+void fill_reply_integer(redisReply*& reply, int val)
+{
+    reply->type = REDIS_REPLY_INTEGER;
+    reply->integer = val;
+}
+
+// utility function for build up REDIS_REPLY_STRING
+// and REDIS_REPLY_DOUBLE and REDIS_REPLY_ERROR
+void fill_reply_str(redisReply*& reply, int type, char const* str,
+                    size_t len, double val=0.0)
+{
+    if(type != REDIS_REPLY_STRING &&
+       type != REDIS_REPLY_DOUBLE &&
+       type != REDIS_REPLY_ERROR)
+        return;
+    reply->type = type;
+    reply->len = len;
+    if(len > 0) {
+        reply->str = new char[len];
+        std::strcpy(reply->str, str);
+        if(type == REDIS_REPLY_DOUBLE)
+            reply->dval = val;
+    }
+    else
+        reply->str = NULL;
+}
+
+// utility function for building up redisReply of type REDIS_REPLY_ARRAY
+void fill_reply_array(redisReply*& reply, int num_of_children)
+{
+    reply->type = REDIS_REPLY_ARRAY;
+    reply->elements = num_of_children;
+    if(num_of_children > 0) {
+        reply->element = new redisReply*[num_of_children];
+        for(size_t i=0; i<num_of_children; i++) {
+            // memory has been allocated. Ensure it is filled in
+            // a subsequent call to a utility function
+            reply->element[i] = new redisReply;
+        }
+    }
+    else
+        reply->element = NULL;
+}
+
+/*
+*   -----
+*   TESTS
+*   -----
+*/
 
 SCENARIO("Testing CommandReply object", "[CommandReply]")
 {
@@ -66,6 +123,218 @@ SCENARIO("Testing CommandReply object", "[CommandReply]")
              "type is attempted to be retrieved")
         {
             CHECK_THROWS_AS(cmd_reply.redis_reply_type(), std::runtime_error);
+        }
+    }
+}
+
+SCENARIO("Test CommandReply copy assignment operator and copy "
+         "constructor on simple REDIS_REPLY_TYPES")
+{
+
+    GIVEN("A CommandReply")
+    {
+        redisReply* reply = new redisReply;
+        fill_reply_integer(reply, 70);
+        CommandReply rvalue = std::move(create_reply_uptr(reply));
+
+        WHEN("The CommandReply is copied with the copy constructor")
+        {
+            CommandReply lvalue(rvalue);
+
+            THEN("The two CommandReply objects have the same structure")
+            {
+                CHECK(lvalue.redis_reply_type() == rvalue.redis_reply_type());
+            }
+        }
+    }
+
+    AND_GIVEN("Two CommandReplys")
+    {
+        redisReply* r_reply = new redisReply;
+        fill_reply_integer(r_reply, 70);
+        CommandReply rvalue = std::move(create_reply_uptr(r_reply));
+
+        redisReply* l_reply = new redisReply;
+        l_reply->type = REDIS_REPLY_ARRAY;
+        l_reply->elements = 0;
+        l_reply->element = NULL;
+        CommandReply lvalue = std::move(create_reply_uptr(l_reply));
+
+        WHEN("rvalue is copied into lvalue with the copy assignment operator")
+        {
+            lvalue = rvalue;
+
+            THEN("The two CommandReply objects have the same structure")
+            {
+                CHECK(lvalue.integer() == 70);
+                CHECK(rvalue.integer() == 70);
+            }
+        }
+    }
+}
+
+SCENARIO("Test CommandReply::has_error")
+{
+
+    GIVEN("A parent and child redisReply")
+    {
+        char const* str = "ERR";
+        redisReply* parent_reply = new redisReply;
+        redisReply* child_reply = new redisReply;
+        fill_reply_array(parent_reply, 1);
+        fill_reply_str(child_reply, REDIS_REPLY_ERROR, str, 4);
+        parent_reply->element[0] = child_reply;
+
+        WHEN("A CommandReply is constructed and copied")
+        {
+            CommandReply rvalue = std::move(create_reply_uptr(parent_reply));
+            CommandReply lvalue = rvalue;
+
+            THEN("The child error is copied correctly")
+            {
+                CHECK(lvalue.has_error() == 1);
+            }
+        }
+    }
+
+}
+
+SCENARIO("CommandReply copy assignment operator preserves the state of the "
+         "rvalue and the lvalue when one of the objects are deleted")
+{
+
+    GIVEN("Two dynamically allocated CommandReply. One with a complex "
+          "redisReply, and the other with a simple redisReply")
+    {
+        // create complex CommandReply
+        char const* strs[] = {"zero", "one", "two", "three", "four", "five",
+                              "six", "seven", "eight", "nine", "ten", "eleven",
+                              "twelve", "thirteen", "fourteen", "fifteen"};
+        int lens[] = {5, 4, 4, 6, 5, 5, 4, 6, 6, 5, 4, 7, 7, 9, 9, 8};
+
+        /* create a redisReply that has 4 children, each being
+           REDIS_REPLY_ARRAY. Each child has four of its own children,
+           each being REDIS_REPLY_STR. In total, the base redisReply
+           has 16 ancestors. This is a perfect 4-ary tree of height 3. */
+        redisReply* reply = new redisReply;
+        fill_reply_array(reply, 4);
+        for(size_t i=0; i<reply->elements; i++) {
+            fill_reply_array(reply->element[i], 4);
+            for(size_t j=0; j<reply->element[i]->elements; j++)
+                fill_reply_str(reply->element[i]->element[j],
+                               REDIS_REPLY_STRING,
+                               strs[4*i+j],
+                               lens[4*i+j]);
+        }
+        CommandReply* rvalue = new CommandReply(create_reply_uptr(reply));
+
+        // create simple CommmandReply
+        char const* str = "10.0";
+        redisReply* simple_reply = new redisReply;
+        fill_reply_str(simple_reply, REDIS_REPLY_DOUBLE, str, 5, 10.0);
+        CommandReply* lvalue =
+            new CommandReply(create_reply_uptr(simple_reply));
+
+        WHEN("The original CommandReply is copied and then deleted")
+        {
+            *lvalue = *rvalue;
+            delete rvalue;
+
+            THEN("The state of the copy is preserved")
+            {
+                REQUIRE(lvalue->redis_reply_type() == "REDIS_REPLY_ARRAY");
+                REQUIRE(lvalue->n_elements() == 4);
+                for(size_t i=0; i<lvalue->n_elements(); i++) {
+                    CommandReply child = lvalue[0][i];
+                    REQUIRE(child.redis_reply_type() == "REDIS_REPLY_ARRAY");
+                    REQUIRE(child.n_elements() == 4);
+                    for(size_t j=0; j<child.n_elements(); j++) {
+                        CommandReply g_child = child[j];
+                        REQUIRE(g_child.redis_reply_type() ==
+                               "REDIS_REPLY_STRING");
+                        CHECK(g_child.str_len() == lens[4*i+j]);
+                        CHECK(std::strcmp(g_child.str(), strs[4*i+j]) == 0);
+                    }
+                }
+                delete lvalue;
+            }
+        }
+        WHEN("The original CommandReply is copied "
+             "and then the copy is deleted")
+        {
+            *lvalue = *rvalue;
+            delete lvalue;
+
+            THEN("The state of the CommandReply that was copied is preserved")
+            {
+                REQUIRE(rvalue->redis_reply_type() == "REDIS_REPLY_ARRAY");
+                REQUIRE(rvalue->n_elements() == 4);
+                for(size_t i=0; i<rvalue->n_elements(); i++) {
+                    CommandReply child = rvalue[0][i];
+                    REQUIRE(child.redis_reply_type() == "REDIS_REPLY_ARRAY");
+                    REQUIRE(child.n_elements() == 4);
+                    for(size_t j=0; j<child.n_elements(); j++) {
+                        CommandReply g_child = child[j];
+                        REQUIRE(g_child.redis_reply_type() ==
+                               "REDIS_REPLY_STRING");
+                        CHECK(g_child.str_len() == lens[4*i+j]);
+                        CHECK(std::strcmp(g_child.str(), strs[4*i+j]) == 0);
+                    }
+                }
+                delete rvalue;
+                rvalue = NULL;
+            }
+        }
+    }
+}
+
+SCENARIO("Simple tests on CommandReply constructors that use redisReply*")
+{
+
+    GIVEN("A redisReply")
+    {
+        char const* str = "100.0";
+        redisReply* reply = new redisReply;
+        fill_reply_str(reply, REDIS_REPLY_DOUBLE, str, 6, 100.0);
+
+        WHEN("A CommandReply is constructed with the "
+             "redisReply that is later deleted")
+        {
+
+            CommandReply cmd_reply(reply);
+            delete reply;
+
+            THEN("The state of the CommandReply is preserved")
+            {
+                REQUIRE(cmd_reply.redis_reply_type() == "REDIS_REPLY_DOUBLE");
+                CHECK(cmd_reply.dbl() == 100.0);
+                // uncomment the following lines once CommandReply::str
+                // and CommandReply::str_len are fixed
+                // CHECK(cmd_reply.str_len() == 6);
+                // CHECK(std::strcmp(cmd_reply.str(), str) == 0);
+            }
+        }
+
+        AND_WHEN("A CommandReply is set equal to a "
+                 "redisReply that is later deleted")
+        {
+            redisReply* simple_reply = new redisReply;
+            fill_reply_integer(simple_reply, 5);
+            CommandReply cmd_reply(simple_reply);
+            delete simple_reply;
+            cmd_reply = reply;
+            delete reply;
+
+            THEN("The state of the CommandReply is preserved")
+            {
+                REQUIRE(cmd_reply.redis_reply_type() == "REDIS_REPLY_DOUBLE");
+                CHECK(cmd_reply.dbl() == 100.0);
+                // uncomment the following lines once CommandReply::str
+                // and CommandReply::str_len are fixed
+                // CHECK(cmd_reply.str_len() == 6);
+                // CHECK(std::strcmp(cmd_reply.str(), str) == 0);
+
+            }
         }
     }
 }


### PR DESCRIPTION
This PR addresses issue #59 along with some additional features.

Things added:

- CommandReply copy constructor. `CommandReply(const CommandReply& reply)`
- CommandReply copy constructor with `redisReply*` as input. `CommandReply(const redisReply* reply)`
- CommandReply copy assignment operator. `CommandReply& operator=(const CommandReply& reply)`
- CommandReply copy assignment operator with `redisReply*` as input. `CommandReply& operator=(const redisReply* reply)`
- Private helper function for deep copying a `redisReply*`.  `redisReply* deep_clone_reply(const redisReply* reply)`
- Unit tests that cover new features and slightly increase overall test coverage.

Things changed:

- The private CommandReply shallow copy constructor with `redisReply*` as input was renamed to `CommandReply shallow_clone(const redisReply* reply)`
- Made tab sizes consistent (size 4)