### PR TITLE
Replace TypeError with ModuleNotFoundError

### DIFF
--- a/tests/c/test_c_client.py
+++ b/tests/c/test_c_client.py
@@ -24,7 +24,7 @@ def get_run_command():
         return [which("srun"), "-n", f"{RANKS}"]
     if which("mpirun"):
         return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
+    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_c_client(test, use_cluster):

--- a/tests/c/test_c_client.py
+++ b/tests/c/test_c_client.py
@@ -22,7 +22,9 @@ def get_run_command():
     """Get run command for specific platform"""
     if which("srun"):
         return [which("srun"), "-n", f"{RANKS}"]
-    return [which("mpirun"),"-np", f"{RANKS}"]
+    if which("mpirun"):
+        return [which("mpirun"), "-np", f"{RANKS}"]
+    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_c_client(test, use_cluster):

--- a/tests/cpp/test_cpp_client.py
+++ b/tests/cpp/test_cpp_client.py
@@ -24,7 +24,7 @@ def get_run_command():
         return [which("srun"), "-n", f"{RANKS}"]
     if which("mpirun"):
         return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
+    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_cpp_client(test, use_cluster):

--- a/tests/cpp/test_cpp_client.py
+++ b/tests/cpp/test_cpp_client.py
@@ -22,7 +22,9 @@ def get_run_command():
     """Get run command for specific platform"""
     if which("srun"):
         return [which("srun"), "-n", f"{RANKS}"]
-    return [which("mpirun"),"-np", f"{RANKS}"]
+    if which("mpirun"):
+        return [which("mpirun"), "-np", f"{RANKS}"]
+    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_cpp_client(test, use_cluster):

--- a/tests/cpp/unit-tests/test_unit_cpp_client.py
+++ b/tests/cpp/unit-tests/test_unit_cpp_client.py
@@ -26,7 +26,7 @@ def get_run_command():
         return [which("srun"), "-n", f"{RANKS}"]
     if which("mpirun"):
         return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
+    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_unit_cpp_client(test, use_cluster):

--- a/tests/cpp/unit-tests/test_unit_cpp_client.py
+++ b/tests/cpp/unit-tests/test_unit_cpp_client.py
@@ -24,7 +24,9 @@ def get_run_command():
     """Get run command for specific platform"""
     if which("srun"):
         return [which("srun"), "-n", f"{RANKS}"]
-    return [which("mpirun"),"-np", f"{RANKS}"]
+    if which("mpirun"):
+        return [which("mpirun"), "-np", f"{RANKS}"]
+    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_unit_cpp_client(test, use_cluster):

--- a/tests/fortran/test_fortran_client.py
+++ b/tests/fortran/test_fortran_client.py
@@ -22,7 +22,9 @@ def get_run_command():
     """Get run command for specific platform"""
     if which("srun"):
         return [which("srun"), "-n", f"{RANKS}"]
-    return [which("mpirun"),"-np", f"{RANKS}"]
+    if which("mpirun"):
+        return [which("mpirun"), "-np", f"{RANKS}"]
+    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_fortran_client(test):

--- a/tests/fortran/test_fortran_client.py
+++ b/tests/fortran/test_fortran_client.py
@@ -24,7 +24,7 @@ def get_run_command():
         return [which("srun"), "-n", f"{RANKS}"]
     if which("mpirun"):
         return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: brew install open-mpi)")
+    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_fortran_client(test):


### PR DESCRIPTION
This PR replaces an unhelpful `TypeError` when running tests without openmpi installed with a `ModuleNotFoundError` and a helpful message. 

Before: `TypeError: sequence item 0: expected str instance, NoneType found`
After: `ModuleNotFoundError: mpirun is not installed (hint: install open-mpi)`