### PR TITLE
Fix  in the Python client.get_dataset() return type.

### DIFF
--- a/include/pydataset.h
+++ b/include/pydataset.h
@@ -42,28 +42,98 @@ class PyDataset
 {
     public:
 
+        /*!
+        *   \brief PyDataset constructor
+        *   \param name The name of the dataset
+        */
         PyDataset(const std::string& name);
-        PyDataset(DataSet& dataset);
+
+        /*!
+        *   \brief PyDataset constructor from a
+        *          SmartRedis::DataSet object
+        *   \param dataset A SmartRedis::DataSet pointer to
+        *                  a SmartRedis::DataSet allocated on
+        *                  the heap.  The SmartRedis::DataSet
+        *                  will be deleted upton PyDataset
+        *                  deletion.
+        */
+        PyDataset(DataSet* dataset);
+
+        /*!
+        *   \brief PyDataset destructor
+        */
         ~PyDataset();
 
+        /*!
+        *   \brief Add a tensor to the PyDataset
+        *   \param name The name of the tensor
+        *   \param data A py::array containing the tensor data
+        *   \param type A std::string corresponding to the tensor
+        *               data type
+        */
         void add_tensor(const std::string& name,
                         py::array data,
                         std::string& type);
 
+        /*!
+        *   \brief Retrieve a tensor from the PyDataset
+        *   \param name The name of the tensor
+        *   \return py::array containing the tensor data
+        */
         py::array get_tensor(const std::string& name);
 
+        /*!
+        *   \brief Add a metadata scalar to the PyDataset.
+        *          If the field already exists, the value
+        *          will be appended to the field.
+        *   \param name The name of scalar field
+        *   \param data A py::array containing the
+        *               scalar value.  The array
+        *               must only be of length 1.
+        *   \param type The type associated with the
+        *               scalar.
+        */
         void add_meta_scalar(const std::string& name,
                             py::array data,
                             std::string& type);
 
+        /*!
+        *   \brief Add a metadata string to the PyDataset.
+        *          If the field already exists, the value
+        *          will be appended to the field.
+        *   \param name The name of string field
+        *   \param data The string to add
+        */
         void add_meta_string(const std::string& name,
                             const std::string& data);
 
+        /*!
+        *   \brief Get a metadata scalar field from the
+        *          PyDataset
+        *   \param name The name of the field
+        *   \returns A py::array with all of the field values
+        */
         py::array get_meta_scalars(const std::string& name);
 
+        /*!
+        *   \brief Get a metadata scalar field from the
+        *          PyDataset
+        *   \param name The name of the field
+        *   \returns A py::array with all of the field values
+        */
         py::list get_meta_strings(const std::string& name);
 
+        /*!
+        *   \brief Get the name of the PyDataset
+        *   \returns std::string of the PyDataset name
+        */
+        std::string get_name();
 
+        /*!
+        *   \brief Retrieve a pointer to the underlying
+        *          SmartRedis::DataSet object
+        *   \returns DataSet pointer within PyDataset
+        */
         DataSet* get();
 
     private:

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -850,7 +850,10 @@ void Client::_append_dataset_metadata_commands(CommandList& cmd_list,
                                  "a DataSet into the database that "\
                                  "does not contain any fields or "\
                                  "tensors.");
-    // SingleKeyCommand* cmd = new SingleKeyCommand();
+    SingleKeyCommand* del_cmd = cmd_list.add_command<SingleKeyCommand>();
+    del_cmd->add_field("DEL");
+    del_cmd->add_field(meta_key, true);
+
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
     cmd->add_field("HMSET");
     cmd->add_field (meta_key, true);

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -76,6 +76,7 @@ PYBIND11_MODULE(smartredisPy, m) {
         .def("add_meta_scalar", &PyDataset::add_meta_scalar)
         .def("add_meta_string", &PyDataset::add_meta_string)
         .def("get_meta_scalars", &PyDataset::get_meta_scalars)
-        .def("get_meta_strings", &PyDataset::get_meta_strings);
+        .def("get_meta_strings", &PyDataset::get_meta_strings)
+        .def("get_name", &PyDataset::get_name);
 }
 

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -146,7 +146,8 @@ class Client(PyClient):
         if not isinstance(dataset, Dataset):
             raise TypeError("Argument to put_dataset was not of type Dataset")
         try:
-            super().put_dataset(dataset)
+            pybind_dataset = dataset.get_data()
+            super().put_dataset(pybind_dataset)
         except RuntimeError as e:
             raise RedisReplyError(str(e), "put_dataset") from None
 
@@ -161,7 +162,8 @@ class Client(PyClient):
         """
         try:
             dataset = super().get_dataset(key)
-            return dataset
+            python_dataset = Dataset.from_pybind(dataset)
+            return python_dataset
         except RuntimeError as e:
             raise RedisReplyError(str(e), "get_dataset", key=key) from None
 
@@ -635,7 +637,7 @@ class Client(PyClient):
         :rtype: list[dict]
         :raises RedisReplyError: if there is an error in
                   in command execution or the address
-                  is not reachable by the client.  
+                  is not reachable by the client.
                   In the case of using a cluster of database nodes,
                   it is best practice to bind each node in the cluster
                   to a specific adddress to avoid inconsistencies in

--- a/src/python/module/smartredis/dataset.py
+++ b/src/python/module/smartredis/dataset.py
@@ -32,14 +32,56 @@ from .smartredisPy import PyDataset
 from .util import Dtypes
 
 
-class Dataset(PyDataset):
+class Dataset():
+
     def __init__(self, name):
         """Initialize a Dataset object
 
         :param name: name of dataset
         :type name: str
         """
-        super().__init__(name)
+        self._data = PyDataset(name)
+
+    @staticmethod
+    def from_pybind(dataset):
+        """Initialize a Dataset object from
+        a PyDataset object
+
+        :param dataset: The pybind PyDataset object
+                        to use for construction
+        :type dataset: PyDataset
+        :return: The newly constructor Dataset from
+                 the PyDataset
+        :rtype: Dataset
+        """
+
+        if not isinstance(dataset, PyDataset):
+            raise TypeError("Argument provided must be of "\
+                            "type PyDataset.")
+        new_dataset = Dataset(dataset.get_name())
+        new_dataset.set_data(dataset)
+        return new_dataset
+
+    def get_data(self):
+        """Return the PyDataset attribute
+
+        :return: The PyDataset attribute containing
+                 the dataset information
+        :rtype: PyDataset
+        """
+        return self._data
+
+    def set_data(self, dataset):
+        """Set the PyDataset attribute
+
+        :param dataset: The PyDataset object
+        :type dataset: PyDataset
+        """
+
+        if not isinstance(dataset, PyDataset):
+            raise TypeError("The parameter provided must "\
+                            "be of type PyDataset.")
+        self._data = dataset
 
     def add_tensor(self, name, data):
         """Add a named tensor to this dataset
@@ -52,7 +94,7 @@ class Dataset(PyDataset):
         if not isinstance(data, np.ndarray):
             raise TypeError("Argument provided was not a numpy array")
         dtype = Dtypes.tensor_from_numpy(data)
-        super().add_tensor(name, data, dtype)
+        self._data.add_tensor(name, data, dtype)
 
     def get_tensor(self, name):
         """Get a tensor from the Dataset
@@ -62,7 +104,7 @@ class Dataset(PyDataset):
         :return: a numpy array of tensor data
         :rtype: np.array
         """
-        return super().get_tensor(name)
+        return self._data.get_tensor(name)
 
     def add_meta_scalar(self, name, data):
         """Add metadata scalar field (non-string) with value to the DataSet
@@ -84,7 +126,7 @@ class Dataset(PyDataset):
             raise TypeError("Argument provided is not a scalar")
         # We keep dtype, in case data has a non-standard python format
         dtype = Dtypes.metadata_from_numpy(data_as_array)
-        super().add_meta_scalar(name, data_as_array, dtype)
+        self._data.add_meta_scalar(name, data_as_array, dtype)
 
     def add_meta_string(self, name, data):
         """Add metadata string field with value to the DataSet
@@ -99,7 +141,7 @@ class Dataset(PyDataset):
         :param data: The string to add to the field
         :type data: str
         """
-        super().add_meta_string(name, data)
+        self._data.add_meta_string(name, data)
 
     def get_meta_scalars(self, name):
         """Get the metadata scalar field values from the DataSet
@@ -108,7 +150,7 @@ class Dataset(PyDataset):
                      field in the DataSet
         :type name: str
         """
-        return super().get_meta_scalars(name)
+        return self._data.get_meta_scalars(name)
 
     def get_meta_strings(self, name):
         """Get the metadata scalar field values from the DataSet
@@ -117,4 +159,4 @@ class Dataset(PyDataset):
                         field in the DataSet
         :type name: str
         """
-        return super().get_meta_strings(name)
+        return self._data.get_meta_strings(name)

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -243,7 +243,7 @@ PyDataset* PyClient::get_dataset(const std::string& name)
                                  "was encountered during client "\
                                  "get_dataset execution.");
     }
-    PyDataset* dataset = new PyDataset(*data);
+    PyDataset* dataset = new PyDataset(data);
     return dataset;
 }
 

--- a/src/python/src/pydataset.cpp
+++ b/src/python/src/pydataset.cpp
@@ -38,12 +38,15 @@ PyDataset::PyDataset(const std::string& name) {
   this->_dataset = dataset;
 }
 
-PyDataset::PyDataset(DataSet& dataset) {
-  this->_dataset = &dataset;
+PyDataset::PyDataset(DataSet* dataset) {
+  this->_dataset = dataset;
 }
 
 PyDataset::~PyDataset() {
-  delete this->_dataset;
+    if(this->_dataset != NULL) {
+      delete this->_dataset;
+      this->_dataset = NULL;
+    }
 }
 
 DataSet* PyDataset::get() {
@@ -207,6 +210,10 @@ py::array PyDataset::get_meta_scalars(const std::string& name) {
       break;
   }
 
+}
+
+std::string PyDataset::get_name() {
+    return this->_dataset->name;
 }
 
 py::list PyDataset::get_meta_strings(const std::string& name) {

--- a/tests/python/test_errors.py
+++ b/tests/python/test_errors.py
@@ -138,6 +138,22 @@ def test_wrong_model_name_from_file(mock_data, mock_model, use_cluster):
     finally:
         os.remove("torch_cnn.pt")
 
+def test_set_data_wrong_type():
+    """A call to Dataset.set_data is made with the wrong
+    type (i.e. not Pydataset).
+    """
+    d = Dataset("test_dataset")
+    input_param = Dataset("wrong_input_param")
+    with pytest.raises(TypeError):
+        d.set_data(input_param)
+
+def test_from_pybind_wrong_type():
+    """A call to Dataset.set_data is made with the wrong
+    type (i.e. not Pydataset).
+    """
+    input_param = Dataset("wrong_input_param")
+    with pytest.raises(TypeError):
+        d = Dataset.from_pybind(input_param)
 
 def bad_function(data):
     """Bad function which only raises an exception"""

--- a/tests/python/test_put_get_dataset.py
+++ b/tests/python/test_put_get_dataset.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from smartredis import Client, Dataset
 
-
 def test_put_get_dataset(mock_data, use_cluster):
     """test sending and recieving a dataset with 2D tensors
     of every datatype
@@ -31,3 +30,74 @@ def test_put_get_dataset(mock_data, use_cluster):
             tensor,
             "Dataset returned from get_dataset not the same as sent dataset",
         )
+
+
+def test_augment_dataset(mock_data, use_cluster):
+    """Test sending, receiving, altering, and sending
+    a Dataset.
+    """
+    # Create mock test data
+    data = mock_data.create_data((10, 10))
+
+    # Set test dataset name
+    dataset_name = "augment-dataset"
+
+    # Initialize a client
+    client = Client(None, use_cluster)
+
+    # Create a dataset to put into the database
+    dataset = Dataset(dataset_name)
+    for index, tensor in enumerate(data):
+        tensor_name = f"tensor_{str(index)}"
+        dataset.add_tensor(tensor_name, tensor)
+
+    # Send the dataset
+    client.put_dataset(dataset)
+
+    # Retrieve the dataset
+    rdataset = client.get_dataset(dataset_name)
+
+    # Add a new tensor to the retrieved dataset
+    new_tensor = np.array([1.0, 2.0, 3.0])
+    rdataset.add_tensor("new_tensor", new_tensor)
+
+    # Add a metadata scalar field to the dataset
+    scalar_field = 1.0
+    scalar_name = "scalar_field_1"
+    rdataset.add_meta_scalar(scalar_name, scalar_field)
+
+    # Add a metadata string field to the dataset
+    string_field = "test_string"
+    string_name = "string_field"
+    rdataset.add_meta_string(string_name, string_field)
+
+    # Send the augmented dataset
+    client.put_dataset(rdataset)
+
+    # Retrieve the augmented dataset
+    aug_dataset = client.get_dataset(dataset_name)
+
+    # Check the accuracy of the augmented dataset
+    for index, tensor in enumerate(data):
+        tensor_name = f"tensor_{str(index)}"
+        rtensor = aug_dataset.get_tensor(tensor_name)
+        np.testing.assert_array_equal(
+            rtensor,
+            tensor,
+            "Dataset returned from get_dataset not the same as sent dataset",
+
+        )
+
+    rtensor = aug_dataset.get_tensor("new_tensor")
+    np.testing.assert_array_equal(
+        rtensor,
+        new_tensor,
+        "Dataset returned did not return the correct additional tensor",
+
+    )
+
+    # Check the accuracy of the metadat fields
+    assert(aug_dataset.get_meta_scalars(scalar_name).size==1)
+    assert(len(aug_dataset.get_meta_strings(string_name))==1)
+    assert(aug_dataset.get_meta_scalars(scalar_name)[0]==scalar_field)
+    assert(aug_dataset.get_meta_strings(string_name)[0]==string_field)


### PR DESCRIPTION
Currently the python client returns the type PyDataset
(the pybind type) instead of the Dataset type.  
To fix this, the Dataset type no longer inherits from PyDataset, 
but Dataset has a PyDataset member variable.  
A test was written that sets a dataset, retrieves the dataset,
adds a tensor and metadata, sets the augmented dataset,
and then retrieves the augmented dataset.  While writing this test
for this return type fix, it was discovered that HDEL was not
being run before setting the metadata field for a DataSet.
This means that the HMSET would only be appending to the key
instead of clearing the key and then writing it.  The HDEL command
has been add to the put_dataset() command.