### PR TITLE
Update redis-plus-plus from 1.2.3 to 1.3.2.

### DIFF
--- a/build-scripts/build_deps.sh
+++ b/build-scripts/build_deps.sh
@@ -40,7 +40,7 @@ if ls ../install/lib/libredis++.a 1>/dev/null 2>&1; then
     echo "Redis-plus-plus has already been installed"
 else
     if [[ ! -d "./redis-plus-plus" ]]; then
-        git clone https://github.com/sewenew/redis-plus-plus.git redis-plus-plus --branch 1.2.3 --depth=1
+        git clone https://github.com/sewenew/redis-plus-plus.git redis-plus-plus --branch 1.3.2 --depth=1
 	    echo "Redis-plus-plus downloaded"
     fi
     cd redis-plus-plus


### PR DESCRIPTION
This PR updates redis-plus-plus from 1.2.3 to 1.3.2.  Build and tests are successful on local (Mac OSX) and Cray XC (slurm system).  Waiting for compute resources to confirm scaling tests remain unchanged before merging.