### PR TITLE
Add string representation retrieval capabilities for non REDIS_REPLY_STRING CommandReplys

### DIFF
--- a/include/commandreply.h
+++ b/include/commandreply.h
@@ -169,14 +169,32 @@ class CommandReply {
         *   \brief Get the status string of the reply
         *   \returns string for the CommandReply field
         *   \throw std::runtime_error if the CommandReply
-        *          does not have a status field
+        *          has a NULL str field
         */
         std::string status_str();
 
+        /*!
+        *   \brief Get the double string of the reply
+        *   \returns string for the CommandReply field
+        *   \throw std::runtime_error if the CommandReply
+        *          has a NULL str field
+        */
         std::string dbl_str();
 
+        /*!
+        *   \brief Get the bignum string of the reply
+        *   \returns string for the CommandReply field
+        *   \throw std::runtime_error if the CommandReply
+        *          has a NULL str field
+        */
         std::string bignum_str();
 
+        /*!
+        *   \brief Get the verbatim string of the reply
+        *   \returns string for the CommandReply field
+        *   \throw std::runtime_error if the CommandReply
+        *          has a NULL str field
+        */
         std::string verb_str();
 
         /*!
@@ -234,6 +252,11 @@ class CommandReply {
         */
         void print_reply_error();
 
+        /*!
+        *   \brief This will return all errors in the CommandReply
+        *          or nested CommandReply
+        *   \returns A vector of error strings
+        */
         std::vector<std::string> get_reply_errors();
 
         /*!

--- a/include/commandreply.h
+++ b/include/commandreply.h
@@ -32,6 +32,8 @@
 #include "stdlib.h"
 #include <sw/redis++/redis++.h>
 #include <iostream>
+#include <vector>
+#include <queue>
 
 namespace SmartRedis {
 
@@ -164,12 +166,18 @@ class CommandReply {
         char* str();
 
         /*!
-        *   \brief Get the string field of the reply
-        *   \returns C-str for the CommandReply field
+        *   \brief Get the status string of the reply
+        *   \returns string for the CommandReply field
         *   \throw std::runtime_error if the CommandReply
         *          does not have a status field
         */
-        char* status_str();
+        std::string status_str();
+
+        std::string dbl_str();
+
+        std::string bignum_str();
+
+        std::string verb_str();
 
         /*!
         *   \brief Get the integer field of the reply
@@ -225,6 +233,8 @@ class CommandReply {
         *          or nested CommandReply.
         */
         void print_reply_error();
+
+        std::vector<std::string> get_reply_errors();
 
         /*!
         *   \brief Return the type of the CommandReply

--- a/include/commandreply.h
+++ b/include/commandreply.h
@@ -254,7 +254,9 @@ class CommandReply {
 
         /*!
         *   \brief This will return all errors in the CommandReply
-        *          or nested CommandReply
+        *          or nested CommandReply. If there is more than one
+        *          error, the order in which the errors are retrieved is
+        *          done so through a level by level search.
         *   \returns A vector of error strings
         */
         std::vector<std::string> get_reply_errors();

--- a/src/cpp/commandreply.cpp
+++ b/src/cpp/commandreply.cpp
@@ -220,17 +220,6 @@ size_t CommandReply::str_len()
     return _reply->len;
 }
 
-// Get field length of REDIS_REPLY_STATUS
-size_t CommandReply::status_str_len()
-{
-  if(_reply->type!=REDIS_REPLY_STATUS)
-    throw std::runtime_error("The length of the reply str "\
-                             "cannot be returned because the "\
-                             "the reply type is " +
-                             redis_reply_type());
-  return _reply->len;
-}
-
 // Get the number of elements in the CommandReply
 size_t CommandReply::n_elements()
 {
@@ -280,7 +269,10 @@ std::vector<std::string> CommandReply::get_reply_errors()
     std::queue<redisReply*> q;
     q.push(_reply);
     while (q.size() > 0) {
-        redisReply* reply = q.pop();
+        redisReply* reply = q.front();
+        q.pop();
+        if (reply == NULL)
+            continue;
         if (reply->type == REDIS_REPLY_ERROR)
             errors.push_back(std::string(reply->str, reply->len));
         else if (reply->type == REDIS_REPLY_ARRAY) {

--- a/src/cpp/commandreply.cpp
+++ b/src/cpp/commandreply.cpp
@@ -124,23 +124,56 @@ CommandReply CommandReply::shallow_clone(redisReply* reply)
 // Get the string field of the reply
 char* CommandReply::str()
 {
-    if(_reply->type!=REDIS_REPLY_STRING)
+    if(_reply->type != REDIS_REPLY_STRING)
         throw std::runtime_error("A pointer to the reply str "\
-                                 "cannot be returned because the "\
+                                 "cannot be returned because "\
                                  "the reply type is " +
                                  redis_reply_type());
   return _reply->str;
 }
 
 // Get string field of REDIS_REPLY_STATUS
-char* CommandReply::status_str()
+std::string CommandReply::status_str()
 {
-  if(_reply->type!=REDIS_REPLY_STATUS)
+  if(_reply->type != REDIS_REPLY_STATUS)
     throw std::runtime_error("A pointer to the reply str "\
-                             "cannot be returned because the "\
+                             "cannot be returned because "\
                              "the reply type is " +
                              redis_reply_type());
-  return _reply->str;
+  return std::string(_reply->str, _reply->len);
+}
+
+// Get string field of REDIS_REPLY_DOUBLE
+std::string CommandReply::dbl_str()
+{
+  if(_reply->type != REDIS_REPLY_DOUBLE)
+    throw std::runtime_error("A pointer to the reply str "\
+                             "cannot be returned because "\
+                             "the reply type is " +
+                             redis_reply_type());
+  return std::string(_reply->str, _reply->len);
+}
+
+// Get string field of REDIS_REPLY_BIGNUM
+std::string CommandReply::bignum_str()
+{
+  if(_reply->type != REDIS_REPLY_BIGNUM)
+    throw std::runtime_error("A pointer to the reply str "\
+                             "cannot be returned because "\
+                             "the reply type is " +
+                             redis_reply_type());
+  return std::string(_reply->str, _reply->len);
+}
+
+// Get string field of REDIS_REPLY_VERB
+std::string CommandReply::verb_str()
+{
+  if(_reply->type != REDIS_REPLY_VERB)
+    throw std::runtime_error("A pointer to the reply str "\
+                             "cannot be returned because "\
+                             "the reply type is " +
+                             redis_reply_type());
+  return std::string(_reply->str, _reply->len);
 }
 
 // Get the integer field of the reply
@@ -238,6 +271,24 @@ void CommandReply::print_reply_error()
             tmp.print_reply_error();
         }
     }
+}
+
+// This will return any errors in the CommandReply or nested CommandReply.
+std::vector<std::string> CommandReply::get_reply_errors()
+{
+    std::vector<std::string> errors;
+    std::queue<redisReply*> q;
+    q.push(_reply);
+    while (q.size() > 0) {
+        redisReply* reply = q.pop();
+        if (reply->type == REDIS_REPLY_ERROR)
+            errors.push_back(std::string(reply->str, reply->len));
+        else if (reply->type == REDIS_REPLY_ARRAY) {
+            for (size_t i = 0; i < reply->elements; i++)
+                q.push(reply->element[i]);
+        }
+    }
+    return errors;
 }
 
 // Return the type of the CommandReply in the form of a string.


### PR DESCRIPTION
The redisReply struct defined in `hiredis.h` uses the `str` field for `REDIS_REPLY_ERROR`, `REDIS_REPLY_VERB`, `REDIS_REPLY_STATUS`, and `REDIS_REPLY_DOUBLE`. This PR adds the ability to retrieve the string representation for all of the aforementioned types through the `CommandReply` class. For `REDIS_REPLY_ERROR`, it is now possible to retrieve the error message in addition to the pre-existing capability of printing the error message. `CommandReply.get_reply_errors` supports the possibility of pipelined commands creating `CommandReply`s with multiple errors. 