### PR TITLE
Add CI for all SmartRedis tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
-        gcc_v: [8] # Version of GFortran we want to use.
-        rai: [1.2.4] # add 1.2.5 in the future
+        os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
+        gcc_v: [8] # Version of gcc/gfortran we want to use.
+        rai: [1.2.4] # currently supported verison of RedisAI
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
@@ -46,6 +46,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v2
@@ -67,10 +70,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
           --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V}
 
-      - name: Install GFortran macOS
-        if: contains(matrix.os, 'macos')
-        run: brew install gcc@${GCC_V} || brew upgrade gcc@${GCC_V} || true
-
       - name: Build SmartRedis python and install
         run: python -m pip install -e .[dev]
 
@@ -81,4 +80,5 @@ jobs:
             bash ../build-scripts/build-catch.sh &&
             cd ../ && make test-verbose
         env:
-          SSDB: "localhost:6379"
+          SSDB: "127.0.0.1:6379"
+          SMARTREDIS_TEST_CLUSTER: False

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,86 @@
+name: run_tests
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+env:
+  HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker
+  HOMEBREW_NO_AUTO_UPDATE: "ON"
+  HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
+  HOMEBREW_NO_GITHUB_API: "ON"
+  HOMEBREW_NO_INSTALL_CLEANUP: "ON"
+  SMARTREDIS_TEST_CLUSTER: "False"
+  SSDB: "127.0.0.1:6379"
+
+jobs:
+
+  run_tests:
+    name: Run smartredis tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+        gcc_v: [8] # Version of GFortran we want to use.
+        rai: [1.2.4] # add 1.2.5 in the future
+    env:
+      FC: gfortran-${{ matrix.gcc_v }}
+      GCC_V: ${{ matrix.gcc_v }}
+
+
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      redis:
+        # Docker Hub image
+        image: ${{ matrix.rai }}-cpu-xenial
+
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.x'
+
+      - name: Set up common
+        run: python -m pip install --upgrade cmake
+
+      - name: Install GFortran Linux
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update &&
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test &&
+          sudo apt-get update &&
+          sudo apt-get install -y gcc-${GCC_V} gfortran-${GCC_V} &&
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
+          --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V}
+
+      - name: Install GFortran macOS
+        if: contains(matrix.os, 'macos')
+        run: brew install gcc@${GCC_V} || brew upgrade gcc@${GCC_V} || true
+
+      - name: Build SmartRedis python and install
+        run: python -m pip install -e .[dev]
+
+      - name: Run tests
+        run: |
+            mkdir -p ./third-party && cd ./third-party &&
+            bash ../build-scripts/build-lcov.sh &&
+            bash ../build-scripts/build-catch.sh &&
+            cd ../ && make test-verbose
+        env:
+          SSDB: "localhost:6379"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,13 +34,11 @@ jobs:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
 
-
-    # Service containers to run with `container-job`
     services:
       # Label used to access the service container
       redis:
         # Docker Hub image
-        image: ${{ matrix.rai }}-cpu-xenial
+        image: redislabs/redisai:${{ matrix.rai }}-cpu-xenial
 
         # Set health checks to wait until redis has started
         options: >-

--- a/tests/c/test_c_client.py
+++ b/tests/c/test_c_client.py
@@ -18,15 +18,6 @@ def get_test_names():
                                 id=osp.basename(test))) for test in test_names]
     return test_names
 
-def get_run_command():
-    """Get run command for specific platform"""
-    if which("aprun"):
-        return [which("aprun"), "--pes", f"{RANKS}"]
-    if which("srun"):
-        return [which("srun"), "-n", f"{RANKS}"]
-    if which("mpirun"):
-        return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_c_client(test, use_cluster):
@@ -36,13 +27,13 @@ def test_c_client(test, use_cluster):
     :param test: a path to a test to run
     :type test: str
     """
-    cmd = get_run_command()
+    cmd = []
     cmd.append(test)
     print(f"Running test: {osp.basename(test)}")
     print(f"Test command {' '.join(cmd)}")
     print(f"Using cluster: {use_cluster}")
     execute_cmd(cmd)
-    time.sleep(2)
+    time.sleep(1)
 
 def execute_cmd(cmd_list):
     """Execute a command """
@@ -75,4 +66,3 @@ def execute_cmd(cmd_list):
         print("OUTPUT:", output.decode("utf-8"))
         print("ERROR:", errs.decode("utf-8"))
         assert(False)
-

--- a/tests/cpp/test_cpp_client.py
+++ b/tests/cpp/test_cpp_client.py
@@ -18,25 +18,15 @@ def get_test_names():
                                 id=osp.basename(test))) for test in test_names]
     return test_names
 
-def get_run_command():
-    """Get run command for specific platform"""
-    if which("aprun"):
-        return [which("aprun"), "--pes", f"{RANKS}"]
-    if which("srun"):
-        return [which("srun"), "-n", f"{RANKS}"]
-    if which("mpirun"):
-        return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
-
 @pytest.mark.parametrize("test", get_test_names())
 def test_cpp_client(test, use_cluster):
-    cmd = get_run_command()
+    cmd = []
     cmd.append(test)
     print(f"Running test: {osp.basename(test)}")
     print(f"Test command {' '.join(cmd)}")
     print(f"Using cluster: {use_cluster}")
     execute_cmd(cmd)
-    time.sleep(2)
+    time.sleep(1)
 
 def execute_cmd(cmd_list):
     """Execute a command """
@@ -69,4 +59,3 @@ def execute_cmd(cmd_list):
         print("OUTPUT:", output.decode("utf-8"))
         print("ERROR:", errs.decode("utf-8"))
         assert(False)
-

--- a/tests/cpp/unit-tests/test_unit_cpp_client.py
+++ b/tests/cpp/unit-tests/test_unit_cpp_client.py
@@ -20,25 +20,16 @@ def get_test_names():
     #test_names = [("build/test", "unit_tests")]
     return test_names
 
-def get_run_command():
-    """Get run command for specific platform"""
-    if which("aprun"):
-        return [which("aprun"), "--pes", f"{RANKS}"]
-    if which("srun"):
-        return [which("srun"), "-n", f"{RANKS}"]
-    if which("mpirun"):
-        return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_unit_cpp_client(test, use_cluster):
-    cmd = get_run_command()
+    cmd = []
     cmd.append(test)
     print(f"Running test: {osp.basename(test)}")
     print(f"Test command {' '.join(cmd)}")
     print(f"Using cluster: {use_cluster}")
     execute_cmd(cmd)
-    time.sleep(2)
+    time.sleep(1)
 
 def execute_cmd(cmd_list):
     """Execute a command """

--- a/tests/fortran/test_fortran_client.py
+++ b/tests/fortran/test_fortran_client.py
@@ -18,15 +18,6 @@ def get_test_names():
                                 id=osp.basename(test))) for test in test_names]
     return test_names
 
-def get_run_command():
-    """Get run command for specific platform"""
-    if which("aprun"):
-        return [which("aprun"), "--pes", f"{RANKS}"]
-    if which("srun"):
-        return [which("srun"), "-n", f"{RANKS}"]
-    if which("mpirun"):
-        return [which("mpirun"), "-np", f"{RANKS}"]
-    raise ModuleNotFoundError("mpirun is not installed (hint: install open-mpi)")
 
 @pytest.mark.parametrize("test", get_test_names())
 def test_fortran_client(test):
@@ -36,12 +27,12 @@ def test_fortran_client(test):
     :param test: a path to a test to run
     :type test: str
     """
-    cmd = get_run_command()
+    cmd = []
     cmd.append(test)
     print(f"Running test: {osp.basename(test)}")
     print(f"Test command {' '.join(cmd)}")
     execute_cmd(cmd)
-    time.sleep(2)
+    time.sleep(1)
 
 def execute_cmd(cmd_list):
     """Execute a command """
@@ -74,4 +65,3 @@ def execute_cmd(cmd_list):
         print("OUTPUT:", output.decode("utf-8"))
         print("ERROR:", errs.decode("utf-8"))
         assert(False)
-


### PR DESCRIPTION
# Description

Pull request for enabling the CI (github actions) on github instead of jenkins. 

### testing Implementation
 - macOS not tested explicitly as docker commands not supported in macOS github actions
 - uses RedisAI service container which can be switched based on versions
 - only runs non-cluster tests
 - runs all unit tests and tests for all languages in one job (probably not optimal)

Changes to tests
 - run command (i.e. mpirun) taken out of tests so we don't have that testing dependency


# Helpful resources
 - [Python Setup action](https://github.com/actions/setup-python)
 - [Redis Service containers](https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers)
 - [Apt timeouts](https://github.com/actions/virtual-environments/issues/675)
 - [CodeCov](https://about.codecov.io/)
 - [Ci for Pandas](https://github.com/pandas-dev/pandas/blob/master/.github/workflows/ci.yml)

