### PR TITLE
Build matrix for CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,18 +22,18 @@ env:
 jobs:
 
   run_tests:
-    name: Run smartredis tests using ${{ matrix.os }}, Python ${{ matrix.py_v }}, and RedisAI ${{ matrix.rai_v }}
+    name: Run smartredis tests using ${{ matrix.os }}, Python ${{ matrix.py_v }}, RedisAI ${{ matrix.rai_v }}, and compiler ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
-        gcc_v: [8] # Version of gcc/gfortran we want to use.
-        rai_v: [1.2.4, 1.2.5] # currently supported verison of RedisAI
-        py_v: ['3.7.x', '3.8.x', '3.9.x']
+        compiler: [intel, 8, 9, 10] # intel compiler, and versions of GNU compiler
+        rai_v: [1.2.4, 1.2.5] # verisons of RedisAI
+        py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
     env:
-      FC: gfortran-${{ matrix.gcc_v }}
-      GCC_V: ${{ matrix.gcc_v }}
+      FC: gfortran-${{ matrix.compiler }}
+      GCC_V: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
 
     # Service containers to run with `container-job`
     services:
@@ -64,6 +64,7 @@ jobs:
         run: python -m pip install --upgrade cmake
 
       - name: Install GFortran Linux
+        if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
         run: |
           sudo apt-get update &&
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test &&
@@ -71,6 +72,21 @@ jobs:
           sudo apt-get install -y gcc-${GCC_V} gfortran-${GCC_V} &&
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
           --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V}
+
+      - name: Install Intel compiler
+        if: "contains( matrix.compiler, 'intel' )" # if using intel compiler
+        run: |
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
+          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
+          sudo apt-get update &&
+          sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          source /opt/intel/oneapi/setvars.sh &&
+          printenv >> $GITHUB_ENV &&
+          echo "CC=icc" >> $GITHUB_ENV &&
+          echo "CXX=icpc" >> $GITHUB_ENV &&
+          echo "FC=ifort" >> $GITHUB_ENV
 
       - name: Build SmartRedis python and install
         run: python -m pip install -e .[dev]

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
+        os: [ubuntu-20.04, ubuntu-18.04] # cannot test on macOS as docker isn't supported on Mac
         gcc_v: [8] # Version of gcc/gfortran we want to use.
         rai_v: [1.2.4] # currently supported verison of RedisAI
     env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
-        compiler: [intel, 8, 9, 10] # intel compiler, and versions of GNU compiler
+        compiler: [intel, 8, 9, 10, 11] # intel compiler, and versions of GNU compiler
         rai_v: [1.2.4, 1.2.5] # verisons of RedisAI
         py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
     env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,14 +22,15 @@ env:
 jobs:
 
   run_tests:
-    name: Run smartredis tests on ${{ matrix.os }}
+    name: Run smartredis tests using ${{ matrix.os }}, Python ${{ matrix.py_v }}, and RedisAI ${{ matrix.rai_v }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04] # cannot test on macOS as docker isn't supported on Mac
+        os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
         gcc_v: [8] # Version of gcc/gfortran we want to use.
-        rai_v: [1.2.4] # currently supported verison of RedisAI
+        rai_v: [1.2.4, 1.2.5] # currently supported verison of RedisAI
+        py_v: ['3.7.x', '3.8.x', '3.9.x']
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
@@ -57,13 +58,12 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.x'
+          python-version: ${{ matrix.py_v }}
 
       - name: Set up common
         run: python -m pip install --upgrade cmake
 
       - name: Install GFortran Linux
-        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update &&
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test &&
@@ -71,6 +71,7 @@ jobs:
           sudo apt-get install -y gcc-${GCC_V} gfortran-${GCC_V} &&
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
           --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V}
+
       - name: Build SmartRedis python and install
         run: python -m pip install -e .[dev]
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,26 +8,55 @@ can be compiled as a library that is linked with an application
 at compile time. For Python, the clients can be used just like
 any other pip library.
 
-SmartRedis is ran on these compilers and OS'es regularly:
+Before installation, it is recommended to use an OS and compiler that are known to be reliable with SmartRedis.
 
+SmartRedis is tested with the following operating systems on a daily basis:
 
 .. list-table::
-    :widths: 50 50 50
+    :widths: 50
     :header-rows: 1
     :align: center
 
-    * - OS
-      - Compiler
-      - Compiler Versions
+    * - OS (tested daily)
     * - MacOS
-      - Clang
-      - 12
-    * - Ubuntu 20.04
-      - GCC/GFortran
-      - 8 - 10
-    * - Ubuntu 20.04
-      - Intel
-      - 2021.4.0
+    * - Ubuntu
+
+
+SmartRedis is tested with the following compilers on a daily basis:
+
+.. list-table::
+    :widths: 50
+    :header-rows: 1
+    :align: center
+
+    * - Compilers (tested daily)
+    * - GNU (GCC/GFortran)
+    * - Intel (icc/icpc/ifort)
+    * - Apple Clang
+
+
+SmartRedis has been tested with the following compiler in the past, but on a less regular basis as the compilers listed above:
+
+.. list-table::
+    :widths: 50
+    :header-rows: 1
+    :align: center
+
+    * - Compilers (irregularly tested in the past)
+    * - Cray Clang
+
+
+SmartRedis has been used with the following compilers in the past, but they have not been tested. We do not imply that these compilers work for certain:
+
+.. list-table::
+    :widths: 50
+    :header-rows: 1
+    :align: center
+
+    * - Compilers (used in the past, but not tested)
+    * - Cray Classic
+    * - NVHPC
+    * - PGI
 
 
 This document will show how to:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,6 +8,28 @@ can be compiled as a library that is linked with an application
 at compile time. For Python, the clients can be used just like
 any other pip library.
 
+SmartRedis is ran on these compilers and OS'es regularly:
+
+
+.. list-table::
+    :widths: 50 50 50
+    :header-rows: 1
+    :align: center
+
+    * - OS
+      - Compiler
+      - Compiler Versions
+    * - MacOS
+      - Clang
+      - 12
+    * - Ubuntu 20.04
+      - GCC/GFortran
+      - 8 - 10
+    * - Ubuntu 20.04
+      - Intel
+      - 2021.4.0
+
+
 This document will show how to:
   1. Install the SmartRedis Python client from the release
   2. Build and install SmartRedis as a static lib from release


### PR DESCRIPTION
This PR implements the build matrix for the public CI on GitHub Actions for SmartRedis. The matrix has 24 combinations and looks like:

**OS:** ubuntu-20.04
**Compiler:** intel, GCC/GFortran 8, GCC/GFortran 9, GCC/GFortran 10
**RedisAI versions:** 1.2.4, 1.2.5
**Python versions:** 3.7.x, 3.8.x, 3.9.x
