### PR TITLE
Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,19 +1,89 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
 name: 'build_docker'
 
 on: [push, pull_request]
 
 jobs:
     run_docker_build:
-        name: Build docker image on ${{ matrix.os }}
+        name: Build docker image on ${{ matrix.os }}, RedisAI ${{ matrix.rai_v }}
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: false
+            fail-fast: true
             matrix:
               os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
+              rai_v: [1.2.4, 1.2.5] # verisons of RedisAI
+
+        # Service containers to run with docker tests
+        services:
+          # Label used to access the service container
+          redis:
+            # Docker Hub image
+            image: redislabs/redisai:${{ matrix.rai_v }}-cpu-xenial
+            # Set health checks to wait until redis has started
+            options: >-
+              --health-cmd "redis-cli ping"
+              --health-interval 10s
+              --health-timeout 5s
+              --health-retries 5
+            ports:
+              # map port 6379 on service container to the host
+              - 6379:6379
         steps:
-            - name: 'Checkout'
+            - name: 'Checkout SmartRedis'
               uses: actions/checkout@v2
-            - name: 'Build'
+            - name: 'Build base SmartRedis docker image'
               run: |
                 cd ./images
                 docker build -t smartredis .
+                cd ../
+            - name: 'Build C++ docker application'
+              run: |
+                cd ./tests/docker/cpp
+                docker build -t cpp_docker_test .
+                cd ../../../
+                docker run -d --env SSDB="redis:6379" cpp_docker_test
+            - name: 'Build C docker application'
+              run: |
+                cd ./tests/docker/c
+                docker build -t c_docker_test .
+                docker run -d --env SSDB="redis:6379" c_docker_test
+                cd ../../../
+            - name: 'Build Fortran docker application'
+              run: |
+                cd ./tests/docker/fortran
+                docker build -t fortran_docker_test .
+                docker run -d --env SSDB="redis:6379" fortran_docker_test
+                cd ../../../
+            - name: 'Build Python docker application'
+              run: |
+                cd ./tests/docker/python
+                docker build -t python_docker_test .
+                docker run -d --env SSDB="redis:6379" python_docker_test
+                cd ../../../

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,8 @@ jobs:
             - name: 'Build base SmartRedis docker image'
               run: |
                 cd ./images
-                docker build -t smartredis .
+                docker build --build-arg REMOTE=https://github.com/${GITHUB_REPOSITORY}.git \
+                --build-arg BRANCH=$GITHUB_REF_NAME -t smartredis .
                 cd ../
             - name: 'Build C++ docker application'
               run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,19 @@
+name: 'build_docker'
+
+on: [push, pull_request]
+
+jobs:
+    run_docker_build:
+        name: Build docker image on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+              os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
+        steps:
+            - name: 'Checkout'
+              uses: actions/checkout@v2
+            - name: 'Build'
+              run: |
+                cd ./images
+                docker build -t smartredis .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,8 +61,7 @@ jobs:
             - name: 'Build base SmartRedis docker image'
               run: |
                 cd ./images
-                docker build --build-arg REMOTE=https://github.com/${GITHUB_REPOSITORY}.git \
-                --build-arg BRANCH=$GITHUB_REF_NAME -t smartredis .
+                ./build.sh
                 cd ../
             - name: 'Build C++ docker application'
               run: |

--- a/doc/install/docker.rst
+++ b/doc/install/docker.rst
@@ -1,0 +1,250 @@
+
+Docker Build
+------------
+
+SmartRedis is distributed with a Dockerfile to enable
+the use of SmartRedis in application containers.
+A sample Dockerfile is provided in
+``./images/Dockerfile``, relative to the top-level
+SmartRedis directory.  The SmartRedis Docker image
+can be built by executing the following commands
+in the top-level SmartRedis directory:
+
+.. code-block:: bash
+
+    cd ./images/Dockerfile
+    bash ./build.sh
+
+The ``build.sh`` script will execute ``docker build`` and
+produce a ``smartredis`` image.
+
+.. note::
+
+    By default, the ``smartredis`` Docker image is built
+    from copying the current contents of the SmartRedis
+    top-level directory.  This means that any local changes
+    that have been made will be incorporated into the
+    Docker build.  To build from a separate repository
+    and/or branch, a user can uncomment the ``WORKDIR`` and
+    ``RUN`` commands provided in ``./images/Dockerfile`` and
+    remove the ``COPY .  /usr/local/src/SmartRedis`` command.
+    Comments have been left in the Dockefile to assist in making
+    these changes.
+
+
+Subsequent container applications can simply use the
+Docker command ``FROM smartredis`` to build off of the
+``smartredis`` image.  In the following sections,
+additional details are provided for building and
+running applications using the ``smartredis`` image.
+
+Using the SmartRedis Docker Image
+---------------------------------
+
+Examples of building C++, C, Fortran, and Python applications
+can be found in the the ``./tests/docker`` directory.  Below
+are some notes and comments on building an application in each
+language.
+
+**C++ and C**
+
+The ``smartredis`` Docker image has the SmartRedis dynamic
+library installed in ``/usr/local/lib/``  and library
+header files installed in ``/usr/local/include/smartredis/``.
+An application can be built using the SmartRedis library
+inside a container derived from the ``smartredis`` image
+using these installed files.
+
+Example CMake files that build C++ and C applications
+using the ``smartredis` image can be found
+at ``./tests/docker/cpp/CMakeLists.txt`` and
+``./tests/docker/c/CMakeLists.txt``, respectively.
+These CMake files are also shown below along with
+example Docker files that invoke the CMake files
+for a containerized application.
+
+.. code-block:: text
+
+    # C++ containerized CMake file
+
+    project(DockerTester)
+
+    cmake_minimum_required(VERSION 3.10)
+
+    set(CMAKE_CXX_STANDARD 17)
+
+    find_library(SR_LIB smartredis)
+
+    include_directories(SYSTEM
+        /usr/local/include/smartredis
+    )
+
+    # Build executables
+
+    add_executable(docker_test
+        docker_test.cpp
+    )
+    target_link_libraries(docker_test ${SR_LIB} pthread)
+
+
+.. code-block:: docker
+
+    # C++ Docker application Dockerfile
+
+    FROM smartredis
+
+    # Copy source and build files into the container
+    COPY ./CMakeLists.txt /usr/local/src/DockerTest/
+    COPY ./docker_test.cpp /usr/local/src/DockerTest/
+
+    # Change working directory to the application folder
+    WORKDIR /usr/local/src/DockerTest
+
+    # Run CMake and make
+    RUN mkdir build && cd build && cmake .. && make && cd ../
+
+    # Default command for container execution
+    CMD ["/usr/local/src/DockerTest/build/docker_test"]
+
+
+.. code-block:: text
+
+    # C containerized CMake file
+
+    project(DockerTester)
+
+    cmake_minimum_required(VERSION 3.10)
+
+    set(CMAKE_CXX_STANDARD 17)
+
+    find_library(SR_LIB smartredis)
+
+    include_directories(SYSTEM
+        /usr/local/include/smartredis
+    )
+
+    # Build executables
+
+    add_executable(docker_test
+        test_docker.c
+    )
+    target_link_libraries(docker_test ${SR_LIB} pthread)
+
+.. code-block:: docker
+
+    # C Docker application Dockerfile
+
+    FROM smartredis
+
+    # Copy source and build files into the container
+    COPY ./CMakeLists.txt /usr/local/src/DockerTest/
+    COPY ./test_docker.c /usr/local/src/DockerTest/
+
+    # Change working directory to the application folder
+    WORKDIR /usr/local/src/DockerTest
+
+    # Run CMake and make
+    RUN mkdir build && cd build && cmake .. && make && cd ../
+
+    # Default command for container execution
+    CMD ["/usr/local/src/DockerTest/build/docker_test"]
+
+**Fortran**
+
+In addition to the SmartRedis dynamic
+library installed in ``/usr/local/lib/``  and library
+header files installed in ``/usr/local/include/smartredis/``,
+the Fortran source files needed to compile a Fortran application
+with SmartRedis are installed in
+``/usr/local/src/SmartRedis/src/fortran/``.
+
+An example CMake file that builds a Fortran application
+using the ``smartredis`` image can be found
+at ``./tests/docker/fortran/CMakeLists.txt``.
+This CMake file is also shown below along with an
+example Docker file that invokes the CMake files
+for a containerized application.
+
+.. code-block:: text
+
+    # Fortran containerized CMake file
+
+    project(DockerTester)
+
+    cmake_minimum_required(VERSION 3.10)
+
+    enable_language(Fortran)
+
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_C_STANDARD 99)
+
+    set(ftn_client_src
+        /usr/local/src/SmartRedis/src/fortran/fortran_c_interop.F90
+        /usr/local/src/SmartRedis/src/fortran/dataset.F90
+        /usr/local/src/SmartRedis/src/fortran/client.F90
+    )
+
+    find_library(SR_LIB smartredis)
+
+    include_directories(SYSTEM
+        /usr/local/include/smartredis
+    )
+
+    add_executable(docker_test
+        test_docker.F90
+        ${ftn_client_src}
+    )
+
+    target_link_libraries(docker_test ${SR_LIB} pthread)
+
+
+.. code-block:: docker
+
+    # Fortran Docker application Dockerfile
+
+    FROM smartredis
+
+    # Install Fortran compiler
+    RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
+        gfortran && \
+        rm -rf /var/lib/apt/lists/*
+
+    # Copy source and build files into the container
+    COPY ./CMakeLists.txt /usr/local/src/DockerTest/
+    COPY ./test_docker.F90 /usr/local/src/DockerTest/
+
+    # Change working directory to the application folder
+    WORKDIR /usr/local/src/DockerTest
+
+    # Run CMake and make
+    RUN mkdir build && cd build && cmake .. && make && cd ../
+
+    # Default command for container execution
+    CMD ["/usr/local/src/DockerTest/build/docker_test"]
+
+**Python**
+
+The ``smartredis`` docker image includes the
+SmartRedis Python module installed via pip into the
+Python environment.  As a result, any containerized
+Python script can import the SmartRedis module
+without additional steps.
+
+An example Dockerfile that containerizes a Python
+script using SmartRedis is shown below and is
+available at:
+``./tests/docker/python/Dockerfile``.
+
+
+.. code-block:: docker
+
+    # Python Docker application Dockerfile
+
+    FROM smartredis as builder
+
+    # Copy application script
+    COPY ./test_docker.py /usr/local/src/SmartRedis
+
+    # Default command for container execution
+    CMD ["python", "/usr/local/src/SmartRedis/test_docker.py"]

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -82,3 +82,8 @@ Build SmartRedis from Source
 ============================
 
 .. include:: ./install/from_source.rst
+
+Build SmartRedis Docker Image
+=============================
+
+.. include:: ./install/docker.rst

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -29,6 +29,10 @@
 ## Builder image
 FROM ubuntu:21.04 as builder
 
+# Define default arguments for building
+ARG REMOTE=https://github.com/CrayLabs/SmartRedis.git
+ARG BRANCH=develop
+
 # Install tooling
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
@@ -41,7 +45,7 @@ RUN pip3 install cmake
 # Get source code
 WORKDIR /usr/local/src/
 RUN git config --global advice.detachedHead false && \
-    git clone https://github.com/CrayLabs/SmartRedis.git
+    git clone $REMOTE --branch $BRANCH
 
 # Compile and install
 WORKDIR /usr/local/src/SmartRedis

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -33,7 +33,8 @@ FROM ubuntu:21.04 as builder
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
     ca-certificates git \
-    make cmake gcc g++ libc6-dev python3 libpython3-dev pip
+    make cmake gcc g++ libc6-dev python3 libpython3-dev pip && \
+    rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install cmake
 
@@ -44,8 +45,11 @@ RUN git clone https://github.com/CrayLabs/SmartRedis.git
 
 # Compile and install
 WORKDIR /usr/local/src/SmartRedis
-RUN make lib
+RUN make lib && pip install .
 
-## Runtime image
-FROM ubuntu:21.04
-COPY --from=builder /usr/local/src/SmartRedis/install/lib/libsmartredis.so /usr/local/lib/
+# Copy install files and directories to /usr/local/lib and
+# usr/local/include and delete unnecessary build files
+RUN cp -r /usr/local/src/SmartRedis/install/lib/* /usr/local/lib/ && \
+    mkdir /usr/local/include/smartredis && \
+    cp -r /usr/local/src/SmartRedis/install/include/* /usr/local/include/smartredis/ && \
+    rm -r /usr/local/src/SmartRedis

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -40,8 +40,8 @@ RUN pip3 install cmake
 
 # Get source code
 WORKDIR /usr/local/src/
-RUN git config --global advice.detachedHead false
-RUN git clone https://github.com/CrayLabs/SmartRedis.git
+RUN git config --global advice.detachedHead false && \
+    git clone https://github.com/CrayLabs/SmartRedis.git
 
 # Compile and install
 WORKDIR /usr/local/src/SmartRedis

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,51 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+## Builder image
+FROM ubuntu:21.04 as builder
+
+# Install tooling
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
+    ca-certificates git \
+    make cmake gcc g++ libc6-dev python3 libpython3-dev pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN pip3 install cmake
+
+# Get source code
+WORKDIR /usr/local/src/
+RUN git config --global advice.detachedHead false
+RUN git clone https://github.com/CrayLabs/SmartRedis.git
+
+# Compile and install
+WORKDIR /usr/local/src/SmartRedis
+RUN make lib
+
+## Runtime image
+FROM ubuntu:21.04
+COPY --from=builder /usr/local/src/SmartRedis/install/lib/libsmartredis.so /usr/local/lib/

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -42,10 +42,15 @@ RUN apt-get update && \
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install cmake
 
-# Get source code
-WORKDIR /usr/local/src/
-RUN git config --global advice.detachedHead false && \
-    git clone $REMOTE --branch $BRANCH
+# Get source code from current clone
+COPY .  /usr/local/src/SmartRedis
+
+# To build a docker image from another repository,
+# users should uncomment the following WORKDIR and
+# RUN commands and remove the COPY command above.
+#WORKDIR /usr/local/src/
+#RUN git config --global advice.detachedHead false && \
+#    git clone https://github.com/CrayLabs/SmartRedis.git --branch develop
 
 # Compile and install
 WORKDIR /usr/local/src/SmartRedis

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -29,10 +29,6 @@
 ## Builder image
 FROM ubuntu:21.04 as builder
 
-# Define default arguments for building
-ARG REMOTE=https://github.com/CrayLabs/SmartRedis.git
-ARG BRANCH=develop
-
 # Install tooling
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
@@ -40,10 +36,10 @@ RUN apt-get update && \
     make cmake gcc g++ libc6-dev python3 libpython3-dev pip && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN pip3 install cmake
+RUN pip3 install cmake && rm -rf ~/.cache/pip
 
 # Get source code from current clone
-COPY .  /usr/local/src/SmartRedis
+COPY . /usr/local/src/SmartRedis
 
 # To build a docker image from another repository,
 # users should uncomment the following WORKDIR and
@@ -54,7 +50,8 @@ COPY .  /usr/local/src/SmartRedis
 
 # Compile and install
 WORKDIR /usr/local/src/SmartRedis
-RUN make lib && pip install .
+RUN make clobber && make lib && pip install . && rm -rf ~/.cache/pip \
+    && rm -rf build tests examples images utils third-party doc images
 
 # Copy install files and directories to /usr/local/lib and
 # usr/local/include and delete unnecessary build files

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -51,5 +51,4 @@ RUN make lib && pip install .
 # usr/local/include and delete unnecessary build files
 RUN cp -r /usr/local/src/SmartRedis/install/lib/* /usr/local/lib/ && \
     mkdir /usr/local/include/smartredis && \
-    cp -r /usr/local/src/SmartRedis/install/include/* /usr/local/include/smartredis/ && \
-    rm -r /usr/local/src/SmartRedis
+    cp -r /usr/local/src/SmartRedis/install/include/* /usr/local/include/smartredis/

--- a/images/build.sh
+++ b/images/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build . -t smartredis:latest

--- a/images/build.sh
+++ b/images/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build . -t smartredis:latest
+docker build -t smartredis:latest -f ./Dockerfile ../

--- a/tests/docker/c/CMakeLists.txt
+++ b/tests/docker/c/CMakeLists.txt
@@ -1,0 +1,48 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+project(DockerTester)
+
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_CXX_STANDARD 17)
+
+find_library(SR_LIB smartredis)
+
+include_directories(SYSTEM
+    /usr/local/include/smartredis
+)
+
+# Build executables
+
+add_executable(docker_test
+	test_docker.c
+)
+target_link_libraries(docker_test ${SR_LIB} pthread)

--- a/tests/docker/c/Dockerfile
+++ b/tests/docker/c/Dockerfile
@@ -28,9 +28,15 @@
 
 FROM smartredis
 
+# Copy source and build files into the container
 COPY ./CMakeLists.txt /usr/local/src/DockerTest/
 COPY ./test_docker.c /usr/local/src/DockerTest/
+
+# Change working directory to the application folder
 WORKDIR /usr/local/src/DockerTest
+
+# Run CMake and make
 RUN mkdir build && cd build && cmake .. && make && cd ../
 
+# Default command for container execution
 CMD ["/usr/local/src/DockerTest/build/docker_test"]

--- a/tests/docker/c/Dockerfile
+++ b/tests/docker/c/Dockerfile
@@ -1,0 +1,34 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+FROM smartredis
+
+COPY ./CMakeLists.txt /usr/local/src/DockerTest/
+COPY ./test_docker.c /usr/local/src/DockerTest/
+WORKDIR /usr/local/src/DockerTest
+RUN mkdir build && cd build && cmake .. && make && cd ../

--- a/tests/docker/c/Dockerfile
+++ b/tests/docker/c/Dockerfile
@@ -32,3 +32,5 @@ COPY ./CMakeLists.txt /usr/local/src/DockerTest/
 COPY ./test_docker.c /usr/local/src/DockerTest/
 WORKDIR /usr/local/src/DockerTest
 RUN mkdir build && cd build && cmake .. && make && cd ../
+
+CMD ["/usr/local/src/DockerTest/build/docker_test"]

--- a/tests/docker/c/test_docker.c
+++ b/tests/docker/c/test_docker.c
@@ -27,6 +27,7 @@
  */
 
 #include "stdio.h"
+#include "string.h"
 
 #include "c_client.h"
 #include "srexception.h"
@@ -53,10 +54,26 @@ int main(int argc, char* argv[]) {
     size_t n_dims = 1;
 
     return_code = put_tensor(client, key, key_length,
-                            (void*)(&tensor), &dims, n_dims, type, layout);
+                            (void*)(&tensor), (const size_t*)(&dims),
+                            n_dims, type, layout);
 
     if (return_code != SRNoError) {
         return -1;
+    }
+
+    double returned[3];
+
+    return_code = unpack_tensor(client, key, key_length,
+                                (void*)(&returned), (const size_t*)(&dims),
+                                n_dims, type, layout);
+
+    if (return_code != SRNoError) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < 3; i++) {
+        if (returned[i] != tensor[i])
+            return -1;
     }
 
     return 0;

--- a/tests/docker/c/test_docker.c
+++ b/tests/docker/c/test_docker.c
@@ -1,0 +1,63 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, Hewlett Packard Enterprise
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdio.h"
+
+#include "c_client.h"
+#include "srexception.h"
+#include "sr_enums.h"
+
+int main(int argc, char* argv[]) {
+
+    void* client = NULL;
+
+    SRError return_code = SRNoError;
+    return_code = SmartRedisCClient(false, &client);
+
+    if (return_code != SRNoError) {
+        return -1;
+    }
+
+    char* key = "c_docker_tensor";
+    size_t key_length = strlen(key);
+
+    double tensor[3] = {1.0, 2.0, 3.0};
+    SRTensorType type = SRTensorTypeDouble;
+    SRMemoryLayout layout = SRMemLayoutContiguous;
+    size_t dims[1] = {3};
+    size_t n_dims = 1;
+
+    return_code = put_tensor(client, key, key_length,
+                            (void*)(&tensor), &dims, n_dims, type, layout);
+
+    if (return_code != SRNoError) {
+        return -1;
+    }
+
+    return 0;
+}

--- a/tests/docker/cpp/CMakeLists.txt
+++ b/tests/docker/cpp/CMakeLists.txt
@@ -1,0 +1,48 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+project(DockerTester)
+
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_CXX_STANDARD 17)
+
+find_library(SR_LIB smartredis)
+
+include_directories(SYSTEM
+    /usr/local/include/smartredis
+)
+
+# Build executables
+
+add_executable(docker_test
+	docker_test.cpp
+)
+target_link_libraries(docker_test ${SR_LIB} pthread)

--- a/tests/docker/cpp/Dockerfile
+++ b/tests/docker/cpp/Dockerfile
@@ -28,9 +28,15 @@
 
 FROM smartredis
 
+# Copy source and build files into the container
 COPY ./CMakeLists.txt /usr/local/src/DockerTest/
 COPY ./docker_test.cpp /usr/local/src/DockerTest/
+
+# Change working directory to the application folder
 WORKDIR /usr/local/src/DockerTest
+
+# Run CMake and make
 RUN mkdir build && cd build && cmake .. && make && cd ../
 
+# Default command for container execution
 CMD ["/usr/local/src/DockerTest/build/docker_test"]

--- a/tests/docker/cpp/Dockerfile
+++ b/tests/docker/cpp/Dockerfile
@@ -1,0 +1,36 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+FROM smartredis
+
+COPY ./CMakeLists.txt /usr/local/src/DockerTest/
+COPY ./docker_test.cpp /usr/local/src/DockerTest/
+WORKDIR /usr/local/src/DockerTest
+RUN mkdir build && cd build && cmake .. && make && cd ../
+
+CMD ["/usr/local/src/DockerTest/build/docker_test"]

--- a/tests/docker/cpp/docker_test.cpp
+++ b/tests/docker/cpp/docker_test.cpp
@@ -1,0 +1,40 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, Hewlett Packard Enterprise
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "client.h"
+
+int main(int argc, char* argv[]) {
+
+    SmartRedis::Client client(false);
+
+    std::vector<double> data = {1.0, 2.0, 3.0};
+    std::vector<size_t> dims = {3};
+    client.put_tensor("cpp_docker_tensor", data.data(), dims,
+                      SRTensorTypeDouble, SRMemLayoutContiguous);
+    return 0;
+}

--- a/tests/docker/cpp/docker_test.cpp
+++ b/tests/docker/cpp/docker_test.cpp
@@ -34,7 +34,19 @@ int main(int argc, char* argv[]) {
 
     std::vector<double> data = {1.0, 2.0, 3.0};
     std::vector<size_t> dims = {3};
-    client.put_tensor("cpp_docker_tensor", data.data(), dims,
+    std::string tensor_key = "cpp_docker_tensor";
+
+    client.put_tensor(tensor_key, data.data(), dims,
                       SRTensorTypeDouble, SRMemLayoutContiguous);
+
+    std::vector<double> returned(3, 0.0);
+    client.unpack_tensor(tensor_key, returned.data(), dims,
+                         SRTensorTypeDouble, SRMemLayoutContiguous);
+
+    if (returned != data) {
+        throw std::runtime_error("The returned tensor is not equal "\
+                                 "to the sent tensor.");
+    }
+
     return 0;
 }

--- a/tests/docker/fortran/CMakeLists.txt
+++ b/tests/docker/fortran/CMakeLists.txt
@@ -1,0 +1,57 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+project(DockerTester)
+
+cmake_minimum_required(VERSION 3.10)
+
+enable_language(Fortran)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 99)
+
+set(ftn_client_src
+    /usr/local/src/SmartRedis/src/fortran/fortran_c_interop.F90
+    /usr/local/src/SmartRedis/src/fortran/dataset.F90
+    /usr/local/src/SmartRedis/src/fortran/client.F90
+)
+
+find_library(SR_LIB smartredis)
+
+include_directories(SYSTEM
+    /usr/local/include/smartredis
+)
+
+add_executable(docker_test
+	test_docker.F90
+	${ftn_client_src}
+)
+
+target_link_libraries(docker_test ${SR_LIB} pthread)

--- a/tests/docker/fortran/Dockerfile
+++ b/tests/docker/fortran/Dockerfile
@@ -37,3 +37,5 @@ COPY ./CMakeLists.txt /usr/local/src/DockerTest/
 COPY ./test_docker.F90 /usr/local/src/DockerTest/
 WORKDIR /usr/local/src/DockerTest
 RUN mkdir build && cd build && cmake .. && make && cd ../
+
+CMD ["/usr/local/src/DockerTest/build/docker_test"]

--- a/tests/docker/fortran/Dockerfile
+++ b/tests/docker/fortran/Dockerfile
@@ -28,14 +28,21 @@
 
 FROM smartredis
 
+# Install Fortran compiler
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
     gfortran && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy source and build files into the container
 COPY ./CMakeLists.txt /usr/local/src/DockerTest/
 COPY ./test_docker.F90 /usr/local/src/DockerTest/
+
+# Change working directory to the application folder
 WORKDIR /usr/local/src/DockerTest
+
+# Run CMake and make
 RUN mkdir build && cd build && cmake .. && make && cd ../
 
+# Default command for container execution
 CMD ["/usr/local/src/DockerTest/build/docker_test"]

--- a/tests/docker/fortran/Dockerfile
+++ b/tests/docker/fortran/Dockerfile
@@ -1,0 +1,39 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+FROM smartredis
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
+    gfortran && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ./CMakeLists.txt /usr/local/src/DockerTest/
+COPY ./test_docker.F90 /usr/local/src/DockerTest/
+WORKDIR /usr/local/src/DockerTest
+RUN mkdir build && cd build && cmake .. && make && cd ../

--- a/tests/docker/fortran/test_docker.F90
+++ b/tests/docker/fortran/test_docker.F90
@@ -36,6 +36,7 @@ program main
     type(client_type) :: client
     integer, parameter :: dim1 = 10
     real(kind=8), dimension(dim1) :: tensor
+    real(kind=8), dimension(dim1) :: returned
 
     result = client%initialize(.FALSE.)
     if (result .ne. SRNoError) stop
@@ -44,5 +45,10 @@ program main
 
     result = client%put_tensor("fortran_docker_tensor", tensor, shape(tensor))
     if (result .ne. SRNoError) stop
+
+    result = client%unpack_tensor("fortran_docker_tensor", returned, shape(returned))
+    if (result .ne. SRNoError) stop
+
+    if (.not. all(tensor == returned)) stop
 
 end program main

--- a/tests/docker/fortran/test_docker.F90
+++ b/tests/docker/fortran/test_docker.F90
@@ -1,0 +1,48 @@
+! BSD 2-Clause License
+!
+! Copyright (c) 2021, Hewlett Packard Enterprise
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this
+!    list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice,
+!    this list of conditions and the following disclaimer in the documentation
+!    and/or other materials provided with the distribution.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+! FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+! DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+! SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program main
+
+    use smartredis_client, only : client_type
+
+    implicit none
+
+#include "enum_fortran.inc"
+
+    integer(kind=enum_kind) :: result
+    type(client_type) :: client
+    integer, parameter :: dim1 = 10
+    real(kind=8), dimension(dim1) :: tensor
+
+    result = client%initialize(.FALSE.)
+    if (result .ne. SRNoError) stop
+
+    call random_number(tensor)
+
+    result = client%put_tensor("fortran_docker_tensor", tensor, shape(tensor))
+    if (result .ne. SRNoError) stop
+
+end program main

--- a/tests/docker/python/Dockerfile
+++ b/tests/docker/python/Dockerfile
@@ -1,0 +1,33 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+FROM smartredis as builder
+
+COPY ./test_docker.py /usr/local/src/SmartRedis
+
+CMD ["python", "/usr/local/src/SmartRedis/test_docker.py"]

--- a/tests/docker/python/Dockerfile
+++ b/tests/docker/python/Dockerfile
@@ -28,6 +28,8 @@
 
 FROM smartredis as builder
 
+# Copy appliction script
 COPY ./test_docker.py /usr/local/src/SmartRedis
 
+# Default command for container execution
 CMD ["python", "/usr/local/src/SmartRedis/test_docker.py"]

--- a/tests/docker/python/test_docker.py
+++ b/tests/docker/python/test_docker.py
@@ -1,0 +1,36 @@
+#
+# BSD 2-Clause License
+#
+# Copyright (c) 2021, Hewlett Packard Enterprise
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from smartredis import Client
+import numpy as np
+
+client = Client(None, False)
+
+tensor = np.random.randint(-10, 10, size=(2,4))
+
+client.put_tensor("python_docker_tensor", tensor)

--- a/tests/docker/python/test_docker.py
+++ b/tests/docker/python/test_docker.py
@@ -33,4 +33,10 @@ client = Client(None, False)
 
 tensor = np.random.randint(-10, 10, size=(2,4))
 
-client.put_tensor("python_docker_tensor", tensor)
+tensor_key = "python_docker_tensor"
+
+client.put_tensor(tensor_key, tensor)
+
+returned = client.get_tensor(tensor_key)
+
+assert np.array_equal(tensor, returned)


### PR DESCRIPTION
This PR builds on the work from #150 to create a Dockerfile for SmartRedis.  A couple of changes have been made from the original PR:

- The ``include`` directories are copied to ``/usr/local/include`` along with the ``lib`` directory to ``/usr/local/lib``
- In the original PR, a sequential build was used, with the last image being a clean derivative of ``ubuntu:21.04``.  In that derivative image, only the smartredis lib was copied over.  This leaves behind any pip install of the smartredis client as well as header files.  For now, the sequential build has been removed so that the installed smartredis python package and compiled client library are both accessible.

The final stage of the Dockerfile may need to be refiend to minimize image size and provide maximum extensibility for derivative images.