### PR TITLE
Move -Werror and -Wall to test build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,12 @@ set(CMAKE_BUILD_TYPE RELEASE)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install)
 add_link_options(-lpthread)
-add_compile_options(-Wall -Werror -fvisibility=default)
+
+add_compile_options(-fvisibility=default)
+
+if (WERROR)
+    add_compile_options(-Wall -Werror)
+endif()
 
 find_library(REDISPP redis++ PATHS ${CMAKE_SOURCE_DIR}/install/lib NO_DEFAULT_PATH REQUIRED)
 find_library(HIREDIS hiredis PATHS ${CMAKE_SOURCE_DIR}/install/lib NO_DEFAULT_PATH REQUIRED)

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,17 @@ deps: SHELL:=/bin/bash
 deps:
 	@bash ./build-scripts/build_deps.sh
 
-# help: lib                            - Build SmartRedis clients into a static library
+# help: lib                            - Build SmartRedis clients into a dynamic library
 .PHONY: lib
 lib: SHELL:=/bin/bash
 lib: deps
-	@bash ./build-scripts/build_lib.sh
+	@bash ./build-scripts/build_lib.sh $(LIB_BUILD_ARGS)
+
+# help: test-lib                       - Build SmartRedis clients into a dynamic library with least permissive compiler settings
+.PHONY: test-lib
+test-lib: SHELL:=/bin/bash
+test-lib: LIB_BUILD_ARGS="-DWERROR=ON"
+test-lib: lib
 
 # help: test-deps                      - Make SmartRedis testing dependencies
 .PHONY: test-deps
@@ -43,7 +49,7 @@ test-deps-gpu:
 
 # help: build-tests                    - build all tests (C, C++, Fortran)
 .PHONY: build-tests
-build-tests: lib
+build-tests: test-lib
 	./build-scripts/build_cpp_tests.sh
 	./build-scripts/build_cpp_unit_tests.sh
 	./build-scripts/build_c_tests.sh
@@ -52,24 +58,24 @@ build-tests: lib
 
 # help: build-test-cpp                 - build the C++ tests
 .PHONY: build-test-cpp
-build-test-cpp: lib
+build-test-cpp: test-lib
 	./build-scripts/build_cpp_tests.sh
 	./build-scripts/build_cpp_unit_tests.sh
 
 # help: build-unit-test-cpp            - build the C++ unit tests
 .PHONY: build-unit-test-cpp
-build-unit-test-cpp: lib
+build-unit-test-cpp: test-lib
 	./build-scripts/build_cpp_unit_tests.sh
 
 # help: build-test-c                   - build the C tests
 .PHONY: build-test-c
-build-test-c: lib
+build-test-c: test-lib
 	./build-scripts/build_c_tests.sh
 
 
 # help: build-test-fortran             - build the Fortran tests
 .PHONY: build-test-fortran
-build-test-fortran: lib
+build-test-fortran: test-lib
 	./build-scripts/build_fortran_tests.sh
 
 

--- a/build-scripts/build_lib.sh
+++ b/build-scripts/build_lib.sh
@@ -5,6 +5,9 @@ NPROC=$(python -c "import multiprocessing as mp; print(mp.cpu_count())")
 
 CMAKE=$(python -c "import cmake; import os; print(os.path.join(cmake.CMAKE_BIN_DIR, 'cmake'))")
 
+# Any command line arguments are assumed to be CMake arguments
+CMAKE_ARGS=$@
+
 # Remove existing module
 if [ -f ./src/python/module/smartredis/smartredisPy.*.so ]; then
     echo "Removing existing module installation"
@@ -19,7 +22,7 @@ fi
 # make a new build directory and invoke cmake
 mkdir build
 cd build
-$CMAKE ..
+$CMAKE .. $CMAKE_ARGS
 make -j $NPROC
 make install
 


### PR DESCRIPTION
This PR moves the ``-Werror`` and ``-Wall`` compile flags only to the test build.  The optional flags can be added via the ``WERROR`` CMake variable.  This variable is set initially in the library ``Makefile`` and passed through ``build_lib.sh``.   It was verified that the flags work correctly by injecting an unused variable into the SmartRedis code and observing that the library builds but the test suite does not.