### PR TITLE
Add SmartRedis namespace to srassert.h.

### DIFF
--- a/include/srassert.h
+++ b/include/srassert.h
@@ -31,6 +31,8 @@
 
 #include "srexception.h"
 
+using namespace SmartRedis;
+
 ///@file
 
 /*!


### PR DESCRIPTION
This PR adds SmartRedis namespace to srassert.h to address #190 .  This is a fix to help developers and does not affect user space functions.