### PR TITLE
Set pytest to ignore /tests/docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,14 +181,14 @@ cov:
 .PHONY: test
 test: build-tests
 test:
-	@PYTHONFAULTHANDLER=1 python -m pytest -vv ./tests
+	@PYTHONFAULTHANDLER=1 python -m pytest --ignore ./tests/docker -vv ./tests
 
 
 # help: test-verbose                   - Build and run all tests [verbosely]
 .PHONY: test-verbose
 test-verbose: build-tests
 test-verbose:
-	@PYTHONFAULTHANDLER=1 python -m pytest -vv -s ./tests
+	@PYTHONFAULTHANDLER=1 python -m pytest --ignore ./tests/docker -vv -s ./tests
 
 # help: test-c                         - Build and run all C tests
 .PHONY: test-c


### PR DESCRIPTION
This PR sets pytest to ignore /tests/docker when executing ``make test`` and ``make test-verbose``.  This should be the default behavior given that the docker tests are configured to run via github actions, not our ``make test`` commands.  This address #192 .