### PR TITLE
Add environment variables for client runtime behavior

### DIFF
--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -66,7 +66,7 @@ class RedisServer {
         /*!
         *   \brief Default constructor
         */
-        RedisServer() = default;
+        RedisServer();
 
         /*!
         *   \brief Default destructor
@@ -316,6 +316,57 @@ class RedisServer {
         virtual CommandReply get_script(const std::string& key) = 0;
 
     protected:
+        /*!
+        *   \brief Timeout (in seconds) of connection attempt(s).
+        */
+        int _connection_timeout;
+
+        /*!
+        *   \brief Timeout (in seconds) of command attempt(s).
+        */
+        int _command_timeout;
+
+        /*!
+        *   \brief Interval (in milliseconcds) between connection attempts.
+        */
+        int _connection_interval;
+
+        /*!
+        *   \brief Interval (in milliseconcds) between command execution attempts.
+        */
+        int _command_interval;
+
+        /*!
+        *   \brief The number of client connection attempts
+        */
+        int _connection_attempts;
+
+        /*!
+        *   \brief The number of client connection attempts
+        */
+        int _command_attempts;
+
+        /*!
+        *   \brief Default value of connection timeout (seconds)
+        */
+        static constexpr double _DEFAULT_CONN_TIMEOUT = 200;
+
+        /*!
+        *   \brief Default value of connection attempt intervals (seconds)
+        */
+        static constexpr double _DEFAULT_CONN_INTERVAL = 2;
+
+        /*!
+        *   \brief Default value of command execution timeout (seconds)
+        */
+        static constexpr double _DEFAULT_CMD_TIMEOUT = 200;
+
+        /*!
+        *   \brief Default value of command execution attempt
+        *          intervals (seconds)
+        */
+        static constexpr double _DEFAULT_CMD_INTERVAL = 2;
+
 
         /*!
         *   \brief Retrieve a single address, randomly
@@ -339,6 +390,24 @@ class RedisServer {
         *          in SSDB environment variable format
         */
         void _check_ssdb_string(const std::string& env_str);
+
+        /*!
+        *   \brief Initialize a variable of type integer from an environment
+        *          variable.  If the environment variable is not present,
+        *          the default value is assigned.
+        *   \param value Reference to a integer value which will be assigned
+        *                a default value or environment variable value
+        *   \param env_var std::string of the environment variable name
+        *   \param default_value The default value to assign if the environment
+        *                        variable is not present.
+        *   \throw SmartRedis::RuntimeException if environment variable
+        *          retrieval fails, conversion to integer fails, or
+        *          if the value of the environment value contains
+        *          characters other than [0,9]
+        */
+        void _init_integer_from_env(int& value,
+                                    const std::string& env_var,
+                                    const int& default_value);
 
 };
 

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -331,12 +331,12 @@ class RedisServer {
         int _command_timeout;
 
         /*!
-        *   \brief Interval (in milliseconcds) between connection attempts.
+        *   \brief Interval (in milliseconds) between connection attempts.
         */
         int _connection_interval;
 
         /*!
-        *   \brief Interval (in milliseconcds) between command execution attempts.
+        *   \brief Interval (in milliseconds) between command execution attempts.
         */
         int _command_interval;
 

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -31,6 +31,7 @@
 
 #include <thread>
 #include <iostream>
+#include "limits.h"
 #include <sw/redis++/redis++.h>
 #include "command.h"
 #include "commandreply.h"
@@ -342,30 +343,30 @@ class RedisServer {
         int _connection_attempts;
 
         /*!
-        *   \brief The number of client connection attempts
+        *   \brief The number of client command execution attempts
         */
         int _command_attempts;
 
         /*!
         *   \brief Default value of connection timeout (seconds)
         */
-        static constexpr double _DEFAULT_CONN_TIMEOUT = 200;
+        static constexpr int _DEFAULT_CONN_TIMEOUT = 100;
 
         /*!
-        *   \brief Default value of connection attempt intervals (seconds)
+        *   \brief Default value of connection attempt intervals (milliseconds)
         */
-        static constexpr double _DEFAULT_CONN_INTERVAL = 2;
+        static constexpr int _DEFAULT_CONN_INTERVAL = 1000;
 
         /*!
         *   \brief Default value of command execution timeout (seconds)
         */
-        static constexpr double _DEFAULT_CMD_TIMEOUT = 200;
+        static constexpr int _DEFAULT_CMD_TIMEOUT = 100;
 
         /*!
         *   \brief Default value of command execution attempt
-        *          intervals (seconds)
+        *          intervals (milliseconds)
         */
-        static constexpr double _DEFAULT_CMD_INTERVAL = 2;
+        static constexpr int _DEFAULT_CMD_INTERVAL = 1000;
 
 
         /*!
@@ -393,22 +394,31 @@ class RedisServer {
 
         /*!
         *   \brief Initialize a variable of type integer from an environment
-        *          variable.  If the environment variable is not present,
+        *          variable.  If the environment variable is not set,
         *          the default value is assigned.
         *   \param value Reference to a integer value which will be assigned
         *                a default value or environment variable value
         *   \param env_var std::string of the environment variable name
         *   \param default_value The default value to assign if the environment
-        *                        variable is not present.
+        *                        variable is not set.
         *   \throw SmartRedis::RuntimeException if environment variable
         *          retrieval fails, conversion to integer fails, or
         *          if the value of the environment value contains
-        *          characters other than [0,9]
+        *          characters other than [0,9] or a negative sign ('-').
         */
         void _init_integer_from_env(int& value,
                                     const std::string& env_var,
                                     const int& default_value);
 
+        /*!
+        *   \brief This function checks that _connection_timeout,
+        *          _connection_interval, _command_timeout, and
+        *          _command_interval, which have been set from environment
+        *          variables, are within valid ranges.
+        *   \throw SmartRedis::RuntimeException if any of the runtime
+        *          settings is outside of the allowable range
+        */
+        void _check_runtime_variables();
 };
 
 } // namespace SmartRedis

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -32,7 +32,9 @@
 #include <thread>
 #include <iostream>
 #include "limits.h"
+
 #include <sw/redis++/redis++.h>
+
 #include "command.h"
 #include "commandreply.h"
 #include "commandlist.h"
@@ -317,6 +319,7 @@ class RedisServer {
         virtual CommandReply get_script(const std::string& key) = 0;
 
     protected:
+
         /*!
         *   \brief Timeout (in seconds) of connection attempt(s).
         */
@@ -368,6 +371,29 @@ class RedisServer {
         */
         static constexpr int _DEFAULT_CMD_INTERVAL = 1000;
 
+        /*!
+        *   \brief Environment variable for connection timeout
+        */
+        inline static const std::string _CONN_TIMEOUT_ENV_VAR =
+            "SR_CONN_TIMEOUT";
+
+        /*!
+        *   \brief Environment variable for connection interval
+        */
+        inline static const std::string _CONN_INTERVAL_ENV_VAR =
+            "SR_CONN_INTERVAL";
+
+        /*!
+        *   \brief Environment variable for command execution timeout
+        */
+        inline static const std::string _CMD_TIMEOUT_ENV_VAR =
+            "SR_CMD_TIMEOUT";
+
+        /*!
+        *   \brief Environment variable for command execution interval
+        */
+        inline static const std::string _CMD_INTERVAL_ENV_VAR =
+            "SR_CMD_INTERVAL";
 
         /*!
         *   \brief Retrieve a single address, randomly
@@ -419,6 +445,8 @@ class RedisServer {
         *          settings is outside of the allowable range
         */
         void _check_runtime_variables();
+
+
 };
 
 } // namespace SmartRedis

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -404,7 +404,7 @@ inline CommandReply Redis::_run(const Command& cmd)
                                       cmd.first_field() + " execution. ");
         }
 
-        std::this_thread::sleep_for(std::chrono::seconds(_command_interval));
+        std::this_thread::sleep_for(std::chrono::milliseconds(_command_interval));
     }
 
     // If we get here, we've either run out of retry attempts or gotten
@@ -480,7 +480,7 @@ inline void Redis::_connect(std::string address_port)
                                          " during client connection.");
             }
         }
-        std::this_thread::sleep_for(std::chrono::seconds(_connection_interval));
+        std::this_thread::sleep_for(std::chrono::milliseconds(_connection_interval));
     }
 
     // Should never get here

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -381,7 +381,7 @@ inline CommandReply Redis::_run(const Command& cmd)
 {
     CommandReply reply;
     bool executed = false;
-    for (int n_trial = 0; n_trial < 100; n_trial++) {
+    for (int i = 1; i <= _command_attempts; i++) {
         try {
             reply = _redis->command(cmd.cbegin(), cmd.cend());
             if (reply.has_error() == 0)
@@ -404,7 +404,7 @@ inline CommandReply Redis::_run(const Command& cmd)
                                       cmd.first_field() + " execution. ");
         }
 
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::seconds(_command_interval));
     }
 
     // If we get here, we've either run out of retry attempts or gotten
@@ -458,30 +458,29 @@ inline void Redis::_connect(std::string address_port)
 
     // Attempt to have the sw::redis::Redis object
     // make a connection using the PING command
-    const int n_trials = 10;
-    for (int i = 1; i <= n_trials; i++) {
+    for (int i = 1; i <= _connection_attempts; i++) {
         try {
             if (_redis->ping().compare("PONG") == 0) {
                 return;
             }
-            else if (i == n_trials) {
+            else if (i == _connection_attempts) {
                 throw SRTimeoutException(std::string("Connection attempt "\
                                          "failed after ") +
                                          std::to_string(i) + "tries");
             }
         }
         catch (std::exception& e) {
-            if (i == n_trials) {
+            if (i == _connection_attempts) {
                 throw SRRuntimeException(e.what());
             }
         }
         catch (...) {
-            if (i == n_trials) {
+            if (i == _connection_attempts) {
                 throw SRRuntimeException("A non-standard exception encountered"\
                                          " during client connection.");
             }
         }
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::seconds(_connection_interval));
     }
 
     // Should never get here

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -552,13 +552,12 @@ CommandReply RedisCluster::get_script(const std::string& key)
 
 inline CommandReply RedisCluster::_run(const Command& cmd, std::string db_prefix)
 {
-    const int n_trials = 100;
     std::string_view sv_prefix(db_prefix.data(), db_prefix.size());
 
     // Execute the commmand
     CommandReply reply;
     bool executed = false;
-    for (int trial = 0; trial < n_trials; trial++) {
+    for (int i = 1; i <= _command_attempts; i++) {
         try {
             sw::redis::Redis db = _redis_cluster->redis(sv_prefix, false);
             reply = db.command(cmd.cbegin(), cmd.cend());
@@ -585,7 +584,7 @@ inline CommandReply RedisCluster::_run(const Command& cmd, std::string db_prefix
         }
 
         // Sleep before the next attempt
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::seconds(_command_interval));
     }
 
     // If we get here, we've either run out of retry attempts or gotten
@@ -605,7 +604,7 @@ inline CommandReply RedisCluster::_run(const Command& cmd, std::string db_prefix
 inline void RedisCluster::_connect(std::string address_port)
 {
     const int n_trials = 10;
-    for (int i = 1; i <= n_trials; i++) {
+    for (int i = 1; i <= _connection_attempts; i++) {
         try {
             _redis_cluster = new sw::redis::RedisCluster(address_port);
             return;
@@ -650,7 +649,7 @@ inline void RedisCluster::_connect(std::string address_port)
 
     // If we get here, we failed to establish a connection
     throw SRTimeoutException(std::string("Connection attempt failed after ") +
-                                         std::to_string(n_trials) + "tries");
+                                         std::to_string(_connection_interval) + "tries");
 }
 
 // Map the RedisCluster via the CLUSTER SLOTS command

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -649,7 +649,7 @@ inline void RedisCluster::_connect(std::string address_port)
 
     // If we get here, we failed to establish a connection
     throw SRTimeoutException(std::string("Connection attempt failed after ") +
-                                         std::to_string(_connection_interval) + "tries");
+                                         std::to_string(_connection_attempts) + "tries");
 }
 
 // Map the RedisCluster via the CLUSTER SLOTS command

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -584,7 +584,7 @@ inline CommandReply RedisCluster::_run(const Command& cmd, std::string db_prefix
         }
 
         // Sleep before the next attempt
-        std::this_thread::sleep_for(std::chrono::seconds(_command_interval));
+        std::this_thread::sleep_for(std::chrono::milliseconds(_command_interval));
     }
 
     // If we get here, we've either run out of retry attempts or gotten
@@ -644,7 +644,7 @@ inline void RedisCluster::_connect(std::string address_port)
             delete _redis_cluster;
             _redis_cluster = NULL;
         }
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::milliseconds(_connection_interval));
     }
 
     // If we get here, we failed to establish a connection

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -158,33 +158,33 @@ void RedisServer::_init_integer_from_env(int& value,
 // Check that runtime variables are within valid ranges
 inline void RedisServer::_check_runtime_variables()
 {
-    if( _connection_timeout <= 0) {
+    if (_connection_timeout <= 0) {
         throw SRParameterException(_CONN_TIMEOUT_ENV_VAR +
                                    " must be greater than 0.");
     }
 
-    if( _connection_interval <= 0) {
+    if (_connection_interval <= 0) {
         throw SRParameterException(_CONN_INTERVAL_ENV_VAR +
                                    " must be greater than 0.");
     }
 
-    if( _command_timeout <= 0) {
+    if (_command_timeout <= 0) {
         throw SRParameterException(_CMD_TIMEOUT_ENV_VAR +
                                    " must be greater than 0.");
     }
 
-    if( _command_interval <= 0) {
+    if (_command_interval <= 0) {
         throw SRParameterException(_CMD_INTERVAL_ENV_VAR +
                                    " must be greater than 0.");
     }
 
-    if ( _connection_timeout > (INT_MAX / 1000) ) {
+    if (_connection_timeout > (INT_MAX / 1000)) {
         throw SRParameterException(_CONN_TIMEOUT_ENV_VAR +
                                    " must be less than "
                                    + std::to_string(INT_MAX / 1000));
     }
 
-    if ( _command_timeout > (INT_MAX / 1000) ) {
+    if (_command_timeout > (INT_MAX / 1000)) {
         throw SRParameterException(_CMD_TIMEOUT_ENV_VAR +
                                    " must be less than "
                                    + std::to_string(INT_MAX / 1000));

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -50,11 +50,11 @@ RedisServer::RedisServer()
 
     _check_runtime_variables();
 
-    _connection_attempts = ( _connection_timeout * 1000 ) /
-                             _connection_interval + 1;
+    _connection_attempts = (_connection_timeout * 1000) /
+                            _connection_interval + 1;
 
-    _command_attempts = ( _command_timeout * 1000 ) /
-                          _command_interval + 1;
+    _command_attempts = (_command_timeout * 1000) /
+                         _command_interval + 1;
 }
 
 // Retrieve a single address, randomly chosen from a list of addresses if
@@ -126,10 +126,10 @@ void RedisServer::_init_integer_from_env(int& value,
         // will truncate a string like "10xy" to 10.
         // We want to guard users from input errors they might have.
         char* c = env_char;
-        while (*c != 0) {
+        while (*c != '\0') {
             if (!isdigit(*c) && !(*c == '-' && c == env_char)) {
-                throw SRRuntimeException("The value of " + env_var +
-                                         " must be a valid number.");
+                throw SRParameterException("The value of " + env_var +
+                                           " must be a valid number.");
             }
             c++;
         }
@@ -138,16 +138,19 @@ void RedisServer::_init_integer_from_env(int& value,
             value = std::stoi(env_char);
         }
         catch (std::invalid_argument& e) {
-            throw SRRuntimeException("The value of " + env_var + " could "\
-                                     "not be converted to type integer.");
+            throw SRParameterException("The value of " + env_var + " could "\
+                                       "not be converted to type integer.");
         }
         catch (std::out_of_range& e) {
-            throw SRRuntimeException("The value of " + env_var + " is too "\
-                                     "large to be stored as an integer "\
-                                     "value.");
+            throw SRParameterException("The value of " + env_var + " is too "\
+                                       "large to be stored as an integer "\
+                                       "value.");
         }
         catch (std::exception& e) {
-            throw SRRuntimeException(e.what());
+            throw SRInternalException("An unexpected error occurred  "\
+                                      "while attempting to convert the "\
+                                      "environment variable " + env_var +
+                                      " to an integer.");
         }
     }
 }
@@ -156,34 +159,34 @@ void RedisServer::_init_integer_from_env(int& value,
 inline void RedisServer::_check_runtime_variables()
 {
     if( _connection_timeout <= 0) {
-        throw SRRuntimeException(_CONN_TIMEOUT_ENV_VAR +
-                                 " must be greater than 0.");
+        throw SRParameterException(_CONN_TIMEOUT_ENV_VAR +
+                                   " must be greater than 0.");
     }
 
     if( _connection_interval <= 0) {
-        throw SRRuntimeException(_CONN_INTERVAL_ENV_VAR +
-                                " must be greater than 0.");
+        throw SRParameterException(_CONN_INTERVAL_ENV_VAR +
+                                   " must be greater than 0.");
     }
 
     if( _command_timeout <= 0) {
-        throw SRRuntimeException(_CMD_TIMEOUT_ENV_VAR +
-                                 " must be greater than 0.");
+        throw SRParameterException(_CMD_TIMEOUT_ENV_VAR +
+                                   " must be greater than 0.");
     }
 
     if( _command_interval <= 0) {
-        throw SRRuntimeException(_CMD_INTERVAL_ENV_VAR +
-                                 " must be greater than 0.");
+        throw SRParameterException(_CMD_INTERVAL_ENV_VAR +
+                                   " must be greater than 0.");
     }
 
     if ( _connection_timeout > (INT_MAX / 1000) ) {
-        throw SRRuntimeException(_CONN_TIMEOUT_ENV_VAR +
-                                " must be less than "
-                                 + std::to_string(INT_MAX / 1000));
+        throw SRParameterException(_CONN_TIMEOUT_ENV_VAR +
+                                   " must be less than "
+                                   + std::to_string(INT_MAX / 1000));
     }
 
     if ( _command_timeout > (INT_MAX / 1000) ) {
-        throw SRRuntimeException(_CMD_TIMEOUT_ENV_VAR +
-                                 " must be less than "
-                                 + std::to_string(INT_MAX / 1000));
+        throw SRParameterException(_CMD_TIMEOUT_ENV_VAR +
+                                   " must be less than "
+                                   + std::to_string(INT_MAX / 1000));
     }
 }

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -39,13 +39,13 @@ static bool ___srand_seeded = false;
 // RedisServer constructor
 RedisServer::RedisServer()
 {
-    _init_integer_from_env(_connection_timeout, "SR_CONN_TIMEOUT",
+    _init_integer_from_env(_connection_timeout, _CONN_TIMEOUT_ENV_VAR,
                            _DEFAULT_CONN_TIMEOUT);
-    _init_integer_from_env(_connection_interval, "SR_CONN_INTERVAL",
+    _init_integer_from_env(_connection_interval, _CONN_INTERVAL_ENV_VAR,
                            _DEFAULT_CONN_INTERVAL);
-    _init_integer_from_env(_command_timeout, "SR_CMD_TIMEOUT",
+    _init_integer_from_env(_command_timeout, _CMD_TIMEOUT_ENV_VAR,
                            _DEFAULT_CMD_TIMEOUT);
-    _init_integer_from_env(_command_interval, "SR_CMD_INTERVAL",
+    _init_integer_from_env(_command_interval, _CMD_INTERVAL_ENV_VAR,
                            _DEFAULT_CMD_INTERVAL);
 
     _check_runtime_variables();
@@ -156,28 +156,34 @@ void RedisServer::_init_integer_from_env(int& value,
 inline void RedisServer::_check_runtime_variables()
 {
     if( _connection_timeout <= 0) {
-        throw SRRuntimeException("SR_CONN_TIMEOUT must be greater than 0.");
+        throw SRRuntimeException(_CONN_TIMEOUT_ENV_VAR +
+                                 " must be greater than 0.");
     }
 
     if( _connection_interval <= 0) {
-        throw SRRuntimeException("SR_CONN_INTERVAL must be greater than 0.");
+        throw SRRuntimeException(_CONN_INTERVAL_ENV_VAR +
+                                " must be greater than 0.");
     }
 
     if( _command_timeout <= 0) {
-        throw SRRuntimeException("SR_CMD_TIMEOUT must be greater than 0.");
+        throw SRRuntimeException(_CMD_TIMEOUT_ENV_VAR +
+                                 " must be greater than 0.");
     }
 
     if( _command_interval <= 0) {
-        throw SRRuntimeException("SR_CMD_INTERVAL must be greater than 0.");
+        throw SRRuntimeException(_CMD_INTERVAL_ENV_VAR +
+                                 " must be greater than 0.");
     }
 
     if ( _connection_timeout > (INT_MAX / 1000) ) {
-        throw SRRuntimeException("Connection timeout must be less than "
+        throw SRRuntimeException(_CONN_TIMEOUT_ENV_VAR +
+                                " must be less than "
                                  + std::to_string(INT_MAX / 1000));
     }
 
     if ( _command_timeout > (INT_MAX / 1000) ) {
-        throw SRRuntimeException("Command timeout must be less than "
+        throw SRRuntimeException(_CMD_TIMEOUT_ENV_VAR +
+                                 " must be less than "
                                  + std::to_string(INT_MAX / 1000));
     }
 }

--- a/tests/cpp/client_test_utils.h
+++ b/tests/cpp/client_test_utils.h
@@ -32,6 +32,10 @@
 #include <typeinfo>
 #include <random>
 
+#include "rediscluster.h"
+
+using namespace SmartRedis;
+
 class RedisClusterTestObject : public RedisCluster
 {
     public:

--- a/tests/cpp/unit-tests/CMakeLists.txt
+++ b/tests/cpp/unit-tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(UNIT_TESTS
 	test_addressanycommand.cpp
 	test_dbinfocommand.cpp
 	test_clusterinfocommand.cpp
+    test_redis.cpp
 )
 
 add_executable(cpp_unit_tests ${SOURCES} ${UNIT_TESTS})

--- a/tests/cpp/unit-tests/CMakeLists.txt
+++ b/tests/cpp/unit-tests/CMakeLists.txt
@@ -62,7 +62,7 @@ set(UNIT_TESTS
 	test_addressanycommand.cpp
 	test_dbinfocommand.cpp
 	test_clusterinfocommand.cpp
-    test_redis.cpp
+    test_redisserver.cpp
 )
 
 add_executable(cpp_unit_tests ${SOURCES} ${UNIT_TESTS})

--- a/tests/cpp/unit-tests/test_redis.cpp
+++ b/tests/cpp/unit-tests/test_redis.cpp
@@ -1,0 +1,295 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2021, Hewlett Packard Enterprise
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "limits.h"
+
+#include "../../../third-party/catch/catch.hpp"
+#include "../client_test_utils.h"
+
+#include "redisserver.h"
+#include "rediscluster.h"
+#include "redis.h"
+#include "srexception.h"
+
+using namespace SmartRedis;
+
+/*  Derived objects for Redis and RedisCluster are defined to access
+    protected members. There is slight code duplication, but
+    currently SmartRedis is not coded for diamond inheritance
+    (i.e. virtual base classes) of Redis and RedisCluster, and a
+    change like that does not seem warranted for testing purposes
+    only.  If virtual base classes are implemented, RedisTest and
+    RedisClusterTest can be merged.
+*/
+
+class RedisTest : public Redis
+{
+    public:
+        virtual int get_connection_timeout() {return _connection_timeout;}
+        virtual int get_connection_interval() {return _connection_interval;}
+        virtual int get_command_timeout() {return _command_timeout;}
+        virtual int get_command_interval() {return _command_interval;}
+        virtual int get_connection_attempts() {return _connection_attempts;}
+        virtual int get_command_attempts() {return _command_attempts;}
+        virtual int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
+        virtual int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
+        virtual int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
+        virtual int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
+};
+
+class RedisClusterTest : public RedisCluster
+{
+    public:
+        virtual int get_connection_timeout() {return _connection_timeout;}
+        virtual int get_connection_interval() {return _connection_interval;}
+        virtual int get_command_timeout() {return _command_timeout;}
+        virtual int get_command_interval() {return _command_interval;}
+        virtual int get_connection_attempts() {return _connection_attempts;}
+        virtual int get_command_attempts() {return _command_attempts;}
+        virtual int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
+        virtual int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
+        virtual int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
+        virtual int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
+};
+
+// Helper method to invoke the constructor when we expect an
+// error to be thrown
+void invoke_constructor()
+{
+    if (use_cluster()) {
+        RedisClusterTest cluster_obj;
+    }
+    else {
+        RedisTest non_cluster_obj;
+    }
+}
+
+// Helper function to unset all env so that there isn't any
+// cross-test contamination
+void unset_all_env_vars()
+{
+        unsetenv("SR_CONN_TIMEOUT");
+        unsetenv("SR_CONN_INTERVAL");
+        unsetenv("SR_CMD_TIMEOUT");
+        unsetenv("SR_CMD_INTERVAL");
+}
+
+// Helper function to check that all default values being used
+template <class T>
+void check_all_defaults(T& server)
+{
+    CHECK(server.get_connection_timeout() ==
+          server.get_default_conn_timeout());
+
+    CHECK(server.get_connection_interval() ==
+          server.get_default_conn_interval());
+
+    CHECK(server.get_command_timeout() ==
+          server.get_default_cmd_timeout());
+
+    CHECK(server.get_command_interval() ==
+          server.get_default_cmd_interval());
+}
+
+SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
+{
+    GIVEN("A Redis derived object created with all environment variables unset")
+    {
+        unset_all_env_vars();
+
+        if (use_cluster()) {
+            RedisClusterTest redis_server;
+            THEN("Default member variable values are used")
+            {
+                check_all_defaults(redis_server);
+            }
+        }
+        else {
+            RedisTest redis_server;
+            THEN("Default member variable values are used")
+            {
+                check_all_defaults(redis_server);
+            }
+        }
+    }
+    GIVEN("A Redis derived object with empty environment variables set")
+    {
+        unset_all_env_vars();
+        setenv("SR_CONN_TIMEOUT", "", true);
+        setenv("SR_CONN_INTERVAL", "", true);
+        setenv("SR_CMD_TIMEOUT", "", true);
+        setenv("SR_CMD_INTERVAL", "", true);
+
+        if (use_cluster()) {
+            RedisClusterTest redis_server;
+            THEN("Default member variable values are used")
+            {
+                check_all_defaults(redis_server);
+            }
+        }
+        else {
+            RedisTest redis_server;
+            THEN("Default member variable values are used")
+            {
+                check_all_defaults(redis_server);
+            }
+        }
+    }
+    GIVEN("A Redis derived object with valid environment variables set")
+    {
+        int conn_timeout = 5; //seconds
+        int conn_interval = 500; //milliseconds
+        int cmd_timeout = 2; //seconds
+        int cmd_interval = 250; //milliseconds
+        int expected_conn_attempts = 11;
+        int expected_cmd_attempts = 9;
+
+        unset_all_env_vars();
+        setenv("SR_CONN_TIMEOUT", std::to_string(conn_timeout).c_str(), true);
+        setenv("SR_CONN_INTERVAL", std::to_string(conn_interval).c_str(), true);
+        setenv("SR_CMD_TIMEOUT", std::to_string(cmd_timeout).c_str(), true);
+        setenv("SR_CMD_INTERVAL", std::to_string(cmd_interval).c_str(), true);
+
+        if (use_cluster()) {
+            RedisClusterTest redis_server;
+            THEN("Environment variables are used for member variables")
+            {
+                CHECK(redis_server.get_connection_timeout() ==
+                      conn_timeout);
+                CHECK(redis_server.get_connection_interval() ==
+                      conn_interval);
+                CHECK(redis_server.get_connection_attempts() ==
+                      expected_conn_attempts);
+
+                CHECK(redis_server.get_command_timeout() ==
+                      cmd_timeout);
+                CHECK(redis_server.get_command_interval() ==
+                      cmd_interval);
+                CHECK(redis_server.get_command_attempts() ==
+                      expected_cmd_attempts);
+            }
+        }
+        else {
+            RedisTest redis_server;
+            THEN("Environment variables are used for member variables")
+            {
+                CHECK(redis_server.get_connection_timeout() ==
+                      conn_timeout);
+                CHECK(redis_server.get_connection_interval() ==
+                      conn_interval);
+                CHECK(redis_server.get_connection_attempts() ==
+                      expected_conn_attempts);
+
+                CHECK(redis_server.get_command_timeout() ==
+                      cmd_timeout);
+                CHECK(redis_server.get_command_interval() ==
+                      cmd_interval);
+                CHECK(redis_server.get_command_attempts() ==
+                      expected_cmd_attempts);
+            }
+        }
+    }
+    GIVEN("A negative value of SR_CONN_TIMEOUT")
+    {
+        unset_all_env_vars();
+        setenv("SR_CONN_TIMEOUT", "-1", true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+    GIVEN("A negative value of SR_CONN_INTERVAL")
+    {
+        unset_all_env_vars();
+        setenv("SR_CONN_INTERVAL", "-2", true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+    GIVEN("A negative value of SR_CMD_TIMEOUT")
+    {
+        unset_all_env_vars();
+        setenv("SR_CMD_TIMEOUT", "-3", true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+
+    GIVEN("A negative value of SR_CMD_INTERVAL")
+    {
+        unset_all_env_vars();
+        setenv("SR_CMD_INTERVAL", "-4", true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+    GIVEN("An environment variable that includes non-digits")
+    {
+        unset_all_env_vars();
+        setenv("SR_CMD_INTERVAL", "425xkdfa4kd", true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+    GIVEN("An environment variable that is larger than integer storage size")
+    {
+        std::string env_var_str = std::to_string(INT_MAX) + "0";
+        unset_all_env_vars();
+        setenv("SR_CMD_INTERVAL", env_var_str.c_str(), true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+    GIVEN("An environment variable value of SR_CONN_TIMEOUT "\
+          "that is too large for conversion to number of attempts")
+    {
+        std::string env_var_str = std::to_string(INT_MAX/1000+1);
+        unset_all_env_vars();
+        setenv("SR_CONN_TIMEOUT", env_var_str.c_str(), true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+    GIVEN("An environment variable value of SR_CMD_TIMEOUT "\
+          "that is too large for conversion to number of attempts")
+    {
+        std::string env_var_str = std::to_string(INT_MAX/1000+1);
+        unset_all_env_vars();
+        setenv("SR_CMD_TIMEOUT", env_var_str.c_str(), true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), Exception);
+        }
+    }
+}

--- a/tests/cpp/unit-tests/test_redis.cpp
+++ b/tests/cpp/unit-tests/test_redis.cpp
@@ -50,32 +50,39 @@ using namespace SmartRedis;
 class RedisTest : public Redis
 {
     public:
-        virtual int get_connection_timeout() {return _connection_timeout;}
-        virtual int get_connection_interval() {return _connection_interval;}
-        virtual int get_command_timeout() {return _command_timeout;}
-        virtual int get_command_interval() {return _command_interval;}
-        virtual int get_connection_attempts() {return _connection_attempts;}
-        virtual int get_command_attempts() {return _command_attempts;}
-        virtual int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
-        virtual int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
-        virtual int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
-        virtual int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
+        int get_connection_timeout() {return _connection_timeout;}
+        int get_connection_interval() {return _connection_interval;}
+        int get_command_timeout() {return _command_timeout;}
+        int get_command_interval() {return _command_interval;}
+        int get_connection_attempts() {return _connection_attempts;}
+        int get_command_attempts() {return _command_attempts;}
+        int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
+        int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
+        int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
+        int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
 };
 
 class RedisClusterTest : public RedisCluster
 {
     public:
-        virtual int get_connection_timeout() {return _connection_timeout;}
-        virtual int get_connection_interval() {return _connection_interval;}
-        virtual int get_command_timeout() {return _command_timeout;}
-        virtual int get_command_interval() {return _command_interval;}
-        virtual int get_connection_attempts() {return _connection_attempts;}
-        virtual int get_command_attempts() {return _command_attempts;}
-        virtual int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
-        virtual int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
-        virtual int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
-        virtual int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
+        int get_connection_timeout() {return _connection_timeout;}
+        int get_connection_interval() {return _connection_interval;}
+        int get_command_timeout() {return _command_timeout;}
+        int get_command_interval() {return _command_interval;}
+        int get_connection_attempts() {return _connection_attempts;}
+        int get_command_attempts() {return _command_attempts;}
+        int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
+        int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
+        int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
+        int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
 };
+
+// For simplicity, define constants for environment variables outside
+// of the objects because of inheritance limitations
+const char* CONN_TIMEOUT_ENV_VAR = "SR_CONN_TIMEOUT";
+const char* CONN_INTERVAL_ENV_VAR = "SR_CONN_INTERVAL";
+const char* CMD_TIMEOUT_ENV_VAR = "SR_CMD_TIMEOUT";
+const char* CMD_INTERVAL_ENV_VAR = "SR_CMD_INTERVAL";
 
 // Helper method to invoke the constructor when we expect an
 // error to be thrown
@@ -93,10 +100,10 @@ void invoke_constructor()
 // cross-test contamination
 void unset_all_env_vars()
 {
-        unsetenv("SR_CONN_TIMEOUT");
-        unsetenv("SR_CONN_INTERVAL");
-        unsetenv("SR_CMD_TIMEOUT");
-        unsetenv("SR_CMD_INTERVAL");
+        unsetenv(CONN_TIMEOUT_ENV_VAR);
+        unsetenv(CONN_INTERVAL_ENV_VAR);
+        unsetenv(CMD_TIMEOUT_ENV_VAR);
+        unsetenv(CMD_INTERVAL_ENV_VAR);
 }
 
 // Helper function to check that all default values being used
@@ -121,7 +128,6 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     GIVEN("A Redis derived object created with all environment variables unset")
     {
         unset_all_env_vars();
-
         if (use_cluster()) {
             RedisClusterTest redis_server;
             THEN("Default member variable values are used")
@@ -140,10 +146,10 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     GIVEN("A Redis derived object with empty environment variables set")
     {
         unset_all_env_vars();
-        setenv("SR_CONN_TIMEOUT", "", true);
-        setenv("SR_CONN_INTERVAL", "", true);
-        setenv("SR_CMD_TIMEOUT", "", true);
-        setenv("SR_CMD_INTERVAL", "", true);
+        setenv(CONN_TIMEOUT_ENV_VAR, "", true);
+        setenv(CONN_INTERVAL_ENV_VAR, "", true);
+        setenv(CMD_TIMEOUT_ENV_VAR, "", true);
+        setenv(CMD_INTERVAL_ENV_VAR, "", true);
 
         if (use_cluster()) {
             RedisClusterTest redis_server;
@@ -170,10 +176,10 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         int expected_cmd_attempts = 9;
 
         unset_all_env_vars();
-        setenv("SR_CONN_TIMEOUT", std::to_string(conn_timeout).c_str(), true);
-        setenv("SR_CONN_INTERVAL", std::to_string(conn_interval).c_str(), true);
-        setenv("SR_CMD_TIMEOUT", std::to_string(cmd_timeout).c_str(), true);
-        setenv("SR_CMD_INTERVAL", std::to_string(cmd_interval).c_str(), true);
+        setenv(CONN_TIMEOUT_ENV_VAR, std::to_string(conn_timeout).c_str(), true);
+        setenv(CONN_INTERVAL_ENV_VAR, std::to_string(conn_interval).c_str(), true);
+        setenv(CMD_TIMEOUT_ENV_VAR, std::to_string(cmd_timeout).c_str(), true);
+        setenv(CMD_INTERVAL_ENV_VAR, std::to_string(cmd_interval).c_str(), true);
 
         if (use_cluster()) {
             RedisClusterTest redis_server;
@@ -214,38 +220,38 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
             }
         }
     }
-    GIVEN("A negative value of SR_CONN_TIMEOUT")
+    GIVEN("A negative value of " + std::string(CONN_TIMEOUT_ENV_VAR))
     {
         unset_all_env_vars();
-        setenv("SR_CONN_TIMEOUT", "-1", true);
+        setenv(CONN_TIMEOUT_ENV_VAR, "-1", true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
         }
     }
-    GIVEN("A negative value of SR_CONN_INTERVAL")
+    GIVEN("A negative value of " + std::string(CONN_INTERVAL_ENV_VAR))
     {
         unset_all_env_vars();
-        setenv("SR_CONN_INTERVAL", "-2", true);
+        setenv(CONN_INTERVAL_ENV_VAR, "-2", true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
         }
     }
-    GIVEN("A negative value of SR_CMD_TIMEOUT")
+    GIVEN("A negative value of " +  std::string(CMD_TIMEOUT_ENV_VAR))
     {
         unset_all_env_vars();
-        setenv("SR_CMD_TIMEOUT", "-3", true);
+        setenv(CMD_TIMEOUT_ENV_VAR, "-3", true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
         }
     }
 
-    GIVEN("A negative value of SR_CMD_INTERVAL")
+    GIVEN("A negative value of " + std::string(CMD_INTERVAL_ENV_VAR))
     {
         unset_all_env_vars();
-        setenv("SR_CMD_INTERVAL", "-4", true);
+        setenv(CMD_INTERVAL_ENV_VAR, "-4", true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
@@ -254,7 +260,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     GIVEN("An environment variable that includes non-digits")
     {
         unset_all_env_vars();
-        setenv("SR_CMD_INTERVAL", "425xkdfa4kd", true);
+        setenv(CMD_INTERVAL_ENV_VAR, "425xkdfa4kd", true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
@@ -264,29 +270,31 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     {
         std::string env_var_str = std::to_string(INT_MAX) + "0";
         unset_all_env_vars();
-        setenv("SR_CMD_INTERVAL", env_var_str.c_str(), true);
+        setenv(CMD_INTERVAL_ENV_VAR, env_var_str.c_str(), true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
         }
     }
-    GIVEN("An environment variable value of SR_CONN_TIMEOUT "\
+    GIVEN("An environment variable value of " +
+          std::string(CONN_TIMEOUT_ENV_VAR) +
           "that is too large for conversion to number of attempts")
     {
         std::string env_var_str = std::to_string(INT_MAX/1000+1);
         unset_all_env_vars();
-        setenv("SR_CONN_TIMEOUT", env_var_str.c_str(), true);
+        setenv(CONN_TIMEOUT_ENV_VAR, env_var_str.c_str(), true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);
         }
     }
-    GIVEN("An environment variable value of SR_CMD_TIMEOUT "\
+    GIVEN("An environment variable value of " +
+          std::string(CMD_TIMEOUT_ENV_VAR) +
           "that is too large for conversion to number of attempts")
     {
         std::string env_var_str = std::to_string(INT_MAX/1000+1);
         unset_all_env_vars();
-        setenv("SR_CMD_TIMEOUT", env_var_str.c_str(), true);
+        setenv(CMD_TIMEOUT_ENV_VAR, env_var_str.c_str(), true);
         THEN("Constructor throws an exception")
         {
             CHECK_THROWS_AS(invoke_constructor(), Exception);

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -44,7 +44,9 @@ using namespace SmartRedis;
     (i.e. virtual base classes) of Redis and RedisCluster, and a
     change like that does not seem warranted for testing purposes
     only.  If virtual base classes are implemented, RedisTest and
-    RedisClusterTest can be merged.
+    RedisClusterTest can be merged.  Direct inheritance from
+    RedisServer is not done because of the large number of
+    pure virtual functions that would need to be defined.
 */
 
 class RedisTest : public Redis

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -226,7 +226,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CONN_TIMEOUT_ENV_VAR, "-1", true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
     GIVEN("A negative value of " + std::string(CONN_INTERVAL_ENV_VAR))
@@ -235,7 +235,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CONN_INTERVAL_ENV_VAR, "-2", true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
     GIVEN("A negative value of " +  std::string(CMD_TIMEOUT_ENV_VAR))
@@ -244,7 +244,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CMD_TIMEOUT_ENV_VAR, "-3", true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
 
@@ -254,7 +254,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CMD_INTERVAL_ENV_VAR, "-4", true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
     GIVEN("An environment variable that includes non-digits")
@@ -263,7 +263,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CMD_INTERVAL_ENV_VAR, "425xkdfa4kd", true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
     GIVEN("An environment variable that is larger than integer storage size")
@@ -273,31 +273,31 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CMD_INTERVAL_ENV_VAR, env_var_str.c_str(), true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
     GIVEN("An environment variable value of " +
           std::string(CONN_TIMEOUT_ENV_VAR) +
-          "that is too large for conversion to number of attempts")
+          " that is too large for conversion to number of attempts")
     {
         std::string env_var_str = std::to_string(INT_MAX/1000+1);
         unset_all_env_vars();
         setenv(CONN_TIMEOUT_ENV_VAR, env_var_str.c_str(), true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
     GIVEN("An environment variable value of " +
           std::string(CMD_TIMEOUT_ENV_VAR) +
-          "that is too large for conversion to number of attempts")
+          " that is too large for conversion to number of attempts")
     {
         std::string env_var_str = std::to_string(INT_MAX/1000+1);
         unset_all_env_vars();
         setenv(CMD_TIMEOUT_ENV_VAR, env_var_str.c_str(), true);
         THEN("Constructor throws an exception")
         {
-            CHECK_THROWS_AS(invoke_constructor(), Exception);
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
 }


### PR DESCRIPTION
The following environment variables have been added to control client runtime behavior:

- ``SR_CONN_TIMEOUT`` : controls the amount of time before a connection attempt is terminated (seconds)
-  ``SR_CONN_INTERVAL`` : controls the time between connection attempts during client init (milliseconds)
-  ``SR_CMD_TIMEOUT`` : controls the amount of time before a command execution is terminated (seconds)
-  ``SR_CMD_INTERVAL`` : controls the amount of time between a command execution attempts (milliseconds)

Unit tests have been added to test the environment variables and associated error checks.  Documentation will be added when behavior of the environment variables is approved.

