### PR TITLE
Dataset acknowledgement key refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.10)
 
 option(BUILD_PYTHON "Build the python module" ON)
 
-set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_BUILD_TYPE RELEASE)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install)
 add_link_options(-lpthread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.10)
 
 option(BUILD_PYTHON "Build the python module" ON)
 
-set(CMAKE_BUILD_TYPE RELEASE)
+set(CMAKE_BUILD_TYPE DEBUG)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install)
 add_link_options(-lpthread)

--- a/include/client.h
+++ b/include/client.h
@@ -798,6 +798,8 @@ class Client
         */
         TensorBase* _get_tensorbase_obj(const std::string& name);
 
+        inline static const std::string _DATASET_ACK_FIELD = ".COMPLETE";
+
         friend class PyClient;
 
     private:
@@ -848,57 +850,84 @@ class Client
         bool _use_model_prefix;
 
         /*!
-        * \brief Build full formatted key of a tensor, based on current prefix settings.
+        * \brief Build full formatted key of a tensor, based on
+        *        current prefix settings.
         * \param key Tensor key
-        * \param on_db Indicates whether the key refers to an entity which is already in the database.
+        * \param on_db Indicates whether the key refers to an entity
+        *              which is already in the database.
         */
-        inline std::string _build_tensor_key(const std::string& key, bool on_db);
+        inline std::string _build_tensor_key(const std::string& key,
+                                             const bool on_db);
 
         /*!
-        * \brief Build full formatted key of a model or a script, based on current prefix settings.
+        * \brief Build full formatted key of a model or a script,
+        *        based on current prefix settings.
         * \param key Model or script key
-        * \param on_db Indicates whether the key refers to an entity which is already in the database.
+        * \param on_db Indicates whether the key refers to an entity
+        *              which is already in the database.
         */
-        inline std::string _build_model_key(const std::string& key, bool on_db);
+        inline std::string _build_model_key(const std::string& key,
+                                            const bool on_db);
 
         /*!
         *  \brief Build full formatted key of a dataset, based
         *         on current prefix settings.
         *  \param dataset_name Name of dataset
-        *  \param on_db Indicates whether the key refers to an entity which is already in the database.
+        *  \param on_db Indicates whether the key refers to an entity
+        *               which is already in the database.
         *  \returns Formatted key.
         */
-        inline std::string _build_dataset_key(const std::string& dataset_name, bool on_db);
+        inline std::string _build_dataset_key(const std::string& dataset_name,
+                                              const bool on_db);
 
         /*!
-        *  \brief Create the key for putting or getting a DataSet tensor in the database
+        *  \brief Create the key for putting or getting a DataSet tensor
+        *         in the database
         *  \param dataset_name The name of the dataset
         *  \param tensor_name The name of the tensor
-        *  \param on_db Indicates whether the key refers to an entity which is already in the database.
+        *  \param on_db Indicates whether the key refers to an entity
+        *               which is already in the database.
         *  \returns A string of the key for the tensor
         */
         inline std::string _build_dataset_tensor_key(const std::string& dataset_name,
                                                      const std::string& tensor_name,
-                                                     bool on_db);
+                                                     const bool on_db);
 
         /*!
-        *  \brief Create the key for putting or getting DataSet metadata in the database
+        *  \brief Create keys for putting or getting a DataSet tensors
+        *         in the database
         *  \param dataset_name The name of the dataset
-        *  \param on_db Indicates whether the key refers to an entity which is already in the database.
+        *  \param tensor_name The name of the tensor
+        *  \param on_db Indicates whether the key refers to an entity which
+        *               is already in the database.
+        *  \returns A std::vector<std::string> of the keys for the tensors
+        */
+        inline std::vector<std::string>
+        _build_dataset_tensor_keys(const std::string& dataset_name,
+                                   const std::vector<std::string>& tensor_names,
+                                   const bool on_db);
+
+        /*!
+        *  \brief Create the key for putting or getting DataSet metadata
+        *         in the database
+        *  \param dataset_name The name of the dataset
+        *  \param on_db Indicates whether the key refers to an entity which
+        *               is already in the database.
         *  \returns A string of the key for the metadata
         */
         inline std::string _build_dataset_meta_key(const std::string& dataset_name,
-                                                   bool on_db);
+                                                   const bool on_db);
 
         /*!
-        *  \brief Create the key to place an indicator in the database that the dataset has been
-        *         successfully stored.
+        *  \brief Create the key to place an indicator in the database
+        *         that the dataset has been successfully stored.
         *  \param dataset_name The name of the dataset
-        *  \param on_db Indicates whether the key refers to an entity which is already in the database.
+        *  \param on_db Indicates whether the key refers to an entity which
+        *               is already in the database.
         *  \returns A string of the key for the ack key
         */
         inline std::string _build_dataset_ack_key(const std::string& dataset_name,
-                                                  bool on_db);
+                                                  const bool on_db);
 
         /*!
         *   \brief Append the Command associated with

--- a/include/client.h
+++ b/include/client.h
@@ -798,6 +798,10 @@ class Client
         */
         TensorBase* _get_tensorbase_obj(const std::string& name);
 
+        /*!
+        *   \brief The name of the hash field used to confirm that the
+        *          DataSet placement operation was successfully completed.
+        */
         inline static const std::string _DATASET_ACK_FIELD = ".COMPLETE";
 
         friend class PyClient;
@@ -897,8 +901,8 @@ class Client
         *  \brief Create keys for putting or getting a DataSet tensors
         *         in the database
         *  \param dataset_name The name of the dataset
-        *  \param tensor_name The name of the tensor
-        *  \param on_db Indicates whether the key refers to an entity which
+        *  \param tensor_name A std::vector of tensor names
+        *  \param on_db Indicates whether the keys refer to an entity which
         *               is already in the database.
         *  \returns A std::vector<std::string> of the keys for the tensors
         */

--- a/include/redis.h
+++ b/include/redis.h
@@ -148,6 +148,15 @@ class Redis : public RedisServer
         virtual bool key_exists(const std::string& key);
 
         /*!
+        *   \brief Check if a hash field exists
+        *   \param key The key containing the field
+        *   \param field The field in the key to check
+        *   \returns True if the hash field exists, otherwise False
+        */
+        virtual bool hash_field_exists(const std::string& key,
+                                       const std::string& field);
+
+        /*!
         *   \brief Check if a model or script key exists in the database
         *   \param key The key to check
         *   \returns True if the key exists, otherwise False

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -159,6 +159,15 @@ class RedisCluster : public RedisServer
         virtual bool key_exists(const std::string& key);
 
         /*!
+        *   \brief Check if a hash field exists
+        *   \param key The key containing the field
+        *   \param field The field in the key to check
+        *   \returns True if the hash field exists, otherwise False
+        */
+        virtual bool hash_field_exists(const std::string& key,
+                                       const std::string& field);
+
+        /*!
         *   \brief Check if a model or script key exists in the database
         *   \param key The key to check
         *   \returns True if the key exists, otherwise False

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -140,6 +140,15 @@ class RedisServer {
         virtual bool key_exists(const std::string& key) = 0;
 
         /*!
+        *   \brief Check if a hash field exists
+        *   \param key The key containing the field
+        *   \param field The field in the key to check
+        *   \returns True if the hash field exists, otherwise False
+        */
+        virtual bool hash_field_exists(const std::string& key,
+                                       const std::string& field) = 0;
+
+        /*!
          *  \brief Check if a model or script exists in the database
          *  \param key The script or model key
          *  \return True if the model or script exists

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -63,7 +63,7 @@ Client::~Client()
     _redis_server = NULL;
 }
 
-// Establish a dataset
+// Put a DataSet object into the database
 void Client::put_dataset(DataSet& dataset)
 {
     CommandList cmds;
@@ -73,7 +73,7 @@ void Client::put_dataset(DataSet& dataset)
     _run(cmds);
 }
 
-// Retrieve the current dataset
+// Retrieve a DataSet object from the database
 DataSet Client::get_dataset(const std::string& name)
 {
     // Get the metadata message and construct DataSet
@@ -88,6 +88,7 @@ DataSet Client::get_dataset(const std::string& name)
 
     std::vector<std::string> tensor_names = dataset.get_tensor_names();
 
+    // Retrieve DataSet tensors and fill the DataSet object
     for(size_t i = 0; i < tensor_names.size(); i++) {
         std::string tensor_key =
             _build_dataset_tensor_key(name, tensor_names[i], true);
@@ -115,7 +116,7 @@ void Client::rename_dataset(const std::string& name,
 void Client::copy_dataset(const std::string& src_name,
                           const std::string& dest_name)
 {
-    // Extract metadata
+    // Get the metadata message and construct DataSet
     CommandReply reply = _get_dataset_metadata(src_name);
     if (reply.n_elements() == 0) {
         throw SRRuntimeException("The requested DataSet " +
@@ -124,16 +125,12 @@ void Client::copy_dataset(const std::string& src_name,
     DataSet dataset(src_name);
     _unpack_dataset_metadata(dataset, reply);
 
-    // Clone tensor keys
+    // Build tensor keys for cloning
     std::vector<std::string> tensor_names = dataset.get_tensor_names();
-    std::vector<std::string> tensor_src_names;
-    std::vector<std::string> tensor_dest_names;
-    for (size_t i = 0; i < tensor_names.size(); i++) {
-        std::string key = _build_dataset_tensor_key(src_name, tensor_names[i],true);
-        tensor_src_names.push_back(key);
-        key = _build_dataset_tensor_key(dest_name, tensor_names[i],false);
-        tensor_dest_names.push_back(key);
-    }
+    std::vector<std::string> tensor_src_names =
+        _build_dataset_tensor_keys(src_name, tensor_names, true);
+    std::vector<std::string> tensor_dest_names =
+         _build_dataset_tensor_keys(dest_name, tensor_names, false);
 
     // Clone tensors
     _redis_server->copy_tensors(tensor_src_names, tensor_dest_names);
@@ -162,30 +159,25 @@ void Client::delete_dataset(const std::string& name)
     _unpack_dataset_metadata(dataset, reply);
 
     // Build the delete command
-    CompoundCommand cmd;
+    MultiKeyCommand cmd;
+
+    // Delete the metadata (which contains the ack key)
     cmd.add_field("DEL");
     cmd.add_field(_build_dataset_meta_key(dataset.name, true), true);
 
     // Add in all the tensors to be deleted
     std::vector<std::string> tensor_names = dataset.get_tensor_names();
-    for (size_t i = 0; i < tensor_names.size(); i++) {
-        std::string tensor_key(_build_dataset_tensor_key(dataset.name,
-                                            tensor_names[i], true));
-        cmd.add_field(tensor_key, true);
-    }
+    std::vector<std::string> tensor_keys =
+        _build_dataset_tensor_keys(dataset.name, tensor_names, true);
+    cmd.add_fields(tensor_keys, true);
 
     // Run the command
     reply = _run(cmd);
-    if (reply.has_error())
-        return; // Bail on error
 
-    // Acknowledge the response
-    CompoundCommand cmd_ack_key;
-    std::string dataset_ack_key(_build_dataset_ack_key(name, false));
-    cmd_ack_key.add_field("DEL");
-    cmd_ack_key.add_field(dataset_ack_key, true);
-
-    reply = _run(cmd_ack_key);
+    if (reply.has_error()) {
+        throw SRRuntimeException("An error was encountered when executing "\
+                                 "DataSet " + name + " deletion.");
+    }
 }
 
 // Put a tensor into the database
@@ -624,8 +616,8 @@ bool Client::tensor_exists(const std::string& name)
 bool Client::dataset_exists(const std::string& name)
 {
     // Same implementation as for tensors; the next line is NOT a type
-    std::string g_key = _build_dataset_ack_key(name, true);
-    return this->_redis_server->key_exists(g_key);
+    std::string key = _build_dataset_ack_key(name, true);
+    return _redis_server->hash_field_exists(key, _DATASET_ACK_FIELD);
 }
 
 // Check if the model (or the script) exists in the database
@@ -954,7 +946,8 @@ inline CommandReply Client::_get_dataset_metadata(const std::string& name)
 }
 
 // Build full formatted key of a tensor, based on current prefix settings.
-inline std::string Client::_build_tensor_key(const std::string& key, bool on_db)
+inline std::string Client::_build_tensor_key(const std::string& key,
+                                             const bool on_db)
 {
     std::string prefix;
     if (_use_tensor_prefix)
@@ -963,8 +956,10 @@ inline std::string Client::_build_tensor_key(const std::string& key, bool on_db)
     return prefix + key;
 }
 
-// Build full formatted key of a model or a script, based on current prefix settings.
-inline std::string Client::_build_model_key(const std::string& key, bool on_db)
+// Build full formatted key of a model or a script,
+// based on current prefix settings.
+inline std::string Client::_build_model_key(const std::string& key,
+                                            const bool on_db)
 {
     std::string prefix;
     if (_use_model_prefix)
@@ -974,7 +969,8 @@ inline std::string Client::_build_model_key(const std::string& key, bool on_db)
 }
 
 // Build full formatted key of a dataset, based on current prefix settings.
-inline std::string Client::_build_dataset_key(const std::string& dataset_name, bool on_db)
+inline std::string Client::_build_dataset_key(const std::string& dataset_name,
+                                              const bool on_db)
 {
     std::string prefix;
     if (_use_tensor_prefix)
@@ -984,30 +980,48 @@ inline std::string Client::_build_dataset_key(const std::string& dataset_name, b
 }
 
 // Create the key for putting or getting a DataSet tensor in the database
-inline std::string Client::_build_dataset_tensor_key(const std::string& dataset_name,
-                                                     const std::string& tensor_name,
-                                                     bool on_db)
+inline std::string
+Client::_build_dataset_tensor_key(const std::string& dataset_name,
+                                  const std::string& tensor_name,
+                                  const bool on_db)
 {
     return _build_dataset_key(dataset_name, on_db) + "." + tensor_name;
 }
 
+// Create the keys for putting or getting a DataSet tensors in the database
+inline std::vector<std::string>
+Client::_build_dataset_tensor_keys(const std::string& dataset_name,
+                                   const std::vector<std::string>& tensor_names,
+                                   const bool on_db)
+{
+    std::vector<std::string> dataset_tensor_keys;
+    for (size_t i = 0; i < tensor_names.size(); i++) {
+        dataset_tensor_keys.push_back(
+            _build_dataset_tensor_key(dataset_name, tensor_names[i], on_db));
+    }
+
+    return dataset_tensor_keys;
+}
+
 // Create the key for putting or getting DataSet metadata in the database
-inline std::string Client::_build_dataset_meta_key(const std::string& dataset_name,
-                                                   bool on_db)
+inline std::string
+Client::_build_dataset_meta_key(const std::string& dataset_name,
+                                const bool on_db)
 {
     return _build_dataset_key(dataset_name, on_db) + ".meta";
 }
 
-// Create the key to place an indicator in the database that the dataset has been
-// successfully stored.
-inline std::string Client::_build_dataset_ack_key(const std::string& dataset_name,
-                                                  bool on_db)
+// Create the key to place an indicator in the database that the
+// dataset has been successfully stored.
+inline std::string
+Client::_build_dataset_ack_key(const std::string& dataset_name,
+                               const bool on_db)
 {
-    return _build_tensor_key(dataset_name, on_db);
+    return _build_dataset_meta_key(dataset_name, on_db);
 }
 
-// Append the Command associated with placing DataSet metadata in the database
-// to a CommandList
+// Append the Command associated with placing DataSet metadata in
+// the database to a CommandList
 void Client::_append_dataset_metadata_commands(CommandList& cmd_list,
                                                DataSet& dataset)
 {
@@ -1028,7 +1042,7 @@ void Client::_append_dataset_metadata_commands(CommandList& cmd_list,
 
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
     if (cmd == NULL) {
-        throw SRRuntimeException("Failed to create singlekeycommande");
+        throw SRRuntimeException("Failed to create SingleKeyCommand.");
     }
     cmd->add_field("HMSET");
     cmd->add_field (meta_key, true);
@@ -1062,12 +1076,11 @@ void Client::_append_dataset_tensor_commands(CommandList& cmd_list,
 // (all put commands processed) to the CommandList
 void Client::_append_dataset_ack_command(CommandList& cmd_list, DataSet& dataset)
 {
-    std::string dataset_ack_key = _build_dataset_ack_key(dataset.name, false);
-
-    // SingleKeyCommand* cmd = new SingleKeyCommand();
+    std::string key = _build_dataset_ack_key(dataset.name, false);
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
-    cmd->add_field("SET");
-    cmd->add_field(dataset_ack_key, true);
+    cmd->add_field("HSET");
+    cmd->add_field(key, true);
+    cmd->add_field(_DATASET_ACK_FIELD);
     cmd->add_field("1");
 }
 
@@ -1083,9 +1096,11 @@ void Client::_unpack_dataset_metadata(DataSet& dataset, CommandReply& reply)
     // Process each pair of response fields
     for (size_t i = 0; i < reply.n_elements(); i += 2) {
         std::string field_name(reply[i].str(), reply[i].str_len());
-        dataset._add_serialized_field(field_name,
-                                      reply[i + 1].str(),
-                                      reply[i + 1].str_len());
+        if (field_name != _DATASET_ACK_FIELD) {
+            dataset._add_serialized_field(field_name,
+                                          reply[i + 1].str(),
+                                          reply[i + 1].str_len());
+        }
     }
 }
 

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -612,10 +612,9 @@ bool Client::tensor_exists(const std::string& name)
     return _redis_server->key_exists(get_key);
 }
 
-// Check if the datyaset exists in the database
+// Check if the dataset exists in the database
 bool Client::dataset_exists(const std::string& name)
 {
-    // Same implementation as for tensors; the next line is NOT a type
     std::string key = _build_dataset_ack_key(name, true);
     return _redis_server->hash_field_exists(key, _DATASET_ACK_FIELD);
 }

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -117,6 +117,25 @@ bool Redis::key_exists(const std::string& key)
     return (bool)reply.integer();
 }
 
+// Check if a hash field exists in the database
+bool Redis::hash_field_exists(const std::string& key,
+                              const std::string& field)
+{
+    // Build the command
+    SingleKeyCommand cmd;
+    cmd.add_field("HEXISTS");
+    cmd.add_field(key, true);
+    cmd.add_field(field);
+
+    // Run it
+    CommandReply reply = run(cmd);
+    if (reply.has_error() > 0)
+        throw SRRuntimeException("Error encountered while checking "\
+                                 "for existence of hash field " +
+                                 field + " at key " + key);
+    return (bool)reply.integer();
+}
+
 // Check if address is valid
 bool Redis::is_addressable(const std::string& address,
                            const uint64_t& port)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(client_test_dataset_copy_constructor
 )
 
 add_executable(client_test_dataset_move_constructor
-  client_test_dataset_copy_constructor.cpp
+  client_test_dataset_move_constructor.cpp
 )
 target_link_libraries(client_test_dataset_move_constructor
   ${SR_LIB}
@@ -93,7 +93,7 @@ target_link_libraries(client_test_dataset_copy_assignment
 )
 
 add_executable(client_test_dataset_move_assignment
-  client_test_dataset_copy_assignment.cpp
+  client_test_dataset_move_assignment.cpp
 )
 target_link_libraries(client_test_dataset_move_assignment
   ${SR_LIB}

--- a/tests/cpp/client_test_copy_dataset.cpp
+++ b/tests/cpp/client_test_copy_dataset.cpp
@@ -52,7 +52,7 @@ void put_and_copy_dataset(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet source_dataset(dataset_name);
 
     //Add metadata to the DataSet
@@ -74,7 +74,9 @@ void put_and_copy_dataset(
     std::string dest_dataset_name = "copy_" + dataset_name;
     client.copy_dataset(dataset_name, dest_dataset_name);
 
-    if(!client.tensor_exists(dest_dataset_name))
+    std::string ack_key = "{" + dest_dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw RuntimeException("The DataSet confirmation key is not set.");
 
     //Retrieving a dataset

--- a/tests/cpp/client_test_copy_dataset.cpp
+++ b/tests/cpp/client_test_copy_dataset.cpp
@@ -74,10 +74,17 @@ void put_and_copy_dataset(
     std::string dest_dataset_name = "copy_" + dataset_name;
     client.copy_dataset(dataset_name, dest_dataset_name);
 
+    // Check that the ack key was placed for the copied dataset
     std::string ack_key = "{" + dest_dataset_name + "}" + ".meta";
     std::string ack_field = client.ack_field();
     if(!client.hash_field_exists(ack_key, ack_field))
         throw RuntimeException("The DataSet confirmation key is not set.");
+
+    // Check the copied dataset exists
+    if(!client.dataset_exists(dest_dataset_name))
+        throw RuntimeException("dataset_exists() returns false for the "\
+                               "copied dataset after ack key confirmed "\
+                               "in the database.");
 
     //Retrieving a dataset
     SmartRedis::DataSet DestDataSet = client.get_dataset(dest_dataset_name);

--- a/tests/cpp/client_test_dataset.cpp
+++ b/tests/cpp/client_test_dataset.cpp
@@ -79,6 +79,12 @@ void put_get_dataset(
     // Put the DataSet into the database
     client.put_dataset(sent_dataset);
 
+    // Check that the ack key was placed for the copied dataset
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
+        throw RuntimeException("The DataSet confirmation key is not set.");
+
     // Make sure it exists
     if (!client.dataset_exists(dataset_name))
       throw std::runtime_error("Client.dataset_exists() returns false "\
@@ -88,8 +94,8 @@ void put_get_dataset(
                                "after dataset placed into database.");
 
     // Test that the acknowledgement field exists after placement
-    std::string ack_key = "{" + dataset_name + "}" + ".meta";
-    std::string ack_field = client.ack_field();
+    ack_key = "{" + dataset_name + "}" + ".meta";
+    ack_field = client.ack_field();
     if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The dataset ack field was not set.");
 

--- a/tests/cpp/client_test_dataset.cpp
+++ b/tests/cpp/client_test_dataset.cpp
@@ -52,7 +52,7 @@ void put_get_dataset(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet sent_dataset(dataset_name);
 
     //Add metadata to the DataSet
@@ -70,26 +70,28 @@ void put_get_dataset(
     // Make sure a nonexistant dataset doesn't exist
     std::string nonexistant("nonexistant");
     if (client.dataset_exists(nonexistant))
-      throw std::runtime_error("DataSet existence of a non-existant"\
-                               "dataset failed.");
+      throw std::runtime_error("client.dataset_exists() returns true for "\
+                               "for a nonexistant dataset.");
     if (client.poll_dataset(nonexistant, 50, 5))
-      throw std::runtime_error("DataSet existence of a non-existant "\
-                                 "dataset failed.");
+      throw std::runtime_error("client.poll_dataset() returns true for "\
+                               "for a nonexistant dataset.");
 
     // Put the DataSet into the database
     client.put_dataset(sent_dataset);
 
     // Make sure it exists
     if (!client.dataset_exists(dataset_name))
-      throw std::runtime_error("DataSet existence of an existant"\
-                               "dataset failed.");
+      throw std::runtime_error("Client.dataset_exists() returns false "\
+                               "after dataset placed into database.");
     if (!client.poll_dataset(dataset_name, 50, 5))
-      throw std::runtime_error("DataSet existence of an existant"\
-                                 "dataset failed.");
+      throw std::runtime_error("Client.poll_dataset() returns false "\
+                               "after dataset placed into database.");
 
-    if (!client.tensor_exists(dataset_name))
-        throw std::runtime_error("The DataSet "\
-                                 "confirmation key is not set.");
+    // Test that the acknowledgement field exists after placement
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
+        throw std::runtime_error("The dataset ack field was not set.");
 
     SmartRedis::DataSet retrieved_dataset = client.get_dataset(dataset_name);
 

--- a/tests/cpp/client_test_dataset_copy_assignment.cpp
+++ b/tests/cpp/client_test_dataset_copy_assignment.cpp
@@ -52,7 +52,7 @@ void copy_assignment(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSets
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet* dataset = new SmartRedis::DataSet(dataset_name);
 
     //Add tensors to the DataSet
@@ -139,7 +139,9 @@ void copy_assignment(
 
     client.put_dataset(*dataset);
 
-    if(!client.tensor_exists(dataset_name))
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The first DataSet confirmation "\
                                  "key is not set.");
 
@@ -163,7 +165,7 @@ void copy_assignment(
     client.put_dataset(copied_dataset);
     SmartRedis::DataSet full_dataset = client.get_dataset(dataset_name);
 
-    if(!client.tensor_exists(dataset_name))
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The copy assigned DataSet "\
                                  "confirmation key is not set.");
 

--- a/tests/cpp/client_test_dataset_copy_constructor.cpp
+++ b/tests/cpp/client_test_dataset_copy_constructor.cpp
@@ -52,7 +52,7 @@ void copy_constructor(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet* dataset = new SmartRedis::DataSet(dataset_name);
 
     //Add tensors to the DataSet
@@ -141,7 +141,9 @@ void copy_constructor(
 
     client.put_dataset(*dataset);
 
-    if(!client.tensor_exists(dataset_name))
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The first DataSet confirmation "\
                                  "key is not set.");
 
@@ -165,7 +167,7 @@ void copy_constructor(
 
     client.put_dataset(copied_dataset);
 
-    if(!client.tensor_exists(dataset_name))
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The copy-constructed DataSet "\
                                  "confirmation key is not set.");
 

--- a/tests/cpp/client_test_dataset_move_assignment.cpp
+++ b/tests/cpp/client_test_dataset_move_assignment.cpp
@@ -52,7 +52,7 @@ void put_get_3D_array(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSets
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet* dataset = new SmartRedis::DataSet(dataset_name);
 
     //Add tensors to the DataSet
@@ -61,11 +61,11 @@ void put_get_3D_array(
     std::string t_name_3 = "tensor_3";
 
     dataset->add_tensor(t_name_1, t_send_1,
-                        dims, type, SmartRedis::MemoryLayout::nested);
+                        dims, type, SRMemLayoutNested);
     dataset->add_tensor(t_name_2, t_send_2,
-                        dims, type, SmartRedis::MemoryLayout::nested);
+                        dims, type, SRMemLayoutNested);
     dataset->add_tensor(t_name_3, t_send_3,
-                        dims, type, SmartRedis::MemoryLayout::nested);
+                        dims, type, SRMemLayoutNested);
 
     //Add metadata fields to the DataSet.  _meta_1 and _meta_2
     //Add only a portion of the metadata values so that we can test
@@ -146,7 +146,9 @@ void put_get_3D_array(
     delete dataset;
     client.put_dataset(moved_dataset);
 
-    if(!client.tensor_exists(dataset_name))
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The moved assigned DataSet "\
                                  "confirmation key is not set.");
 

--- a/tests/cpp/client_test_dataset_move_constructor.cpp
+++ b/tests/cpp/client_test_dataset_move_constructor.cpp
@@ -52,7 +52,7 @@ void move_constructor(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSets
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet* dataset = new SmartRedis::DataSet(dataset_name);
 
     //Add tensors to the DataSet
@@ -61,11 +61,11 @@ void move_constructor(
     std::string t_name_3 = "tensor_3";
 
     dataset->add_tensor(t_name_1, t_send_1,
-                        dims, type, SmartRedis::MemoryLayout::nested);
+                        dims, type, SRMemLayoutNested);
     dataset->add_tensor(t_name_2, t_send_2,
-                        dims, type, SmartRedis::MemoryLayout::nested);
+                        dims, type, SRMemLayoutNested);
     dataset->add_tensor(t_name_3, t_send_3,
-                        dims, type, SmartRedis::MemoryLayout::nested);
+                        dims, type, SRMemLayoutNested);
 
     //Add metadata fields to the DataSet.  _meta_1 and _meta_2
     //Add only a portion of the metadata values so that we can test
@@ -146,9 +146,11 @@ void move_constructor(
     delete dataset;
     client.put_dataset(moved_dataset);
 
-    if(!client.tensor_exists(dataset_name))
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The moved constructed DataSet "\
-                                 "confirmation key is not set.");
+                                 "ack field is not set.");
 
     SmartRedis::DataSet full_dataset = client.get_dataset(dataset_name);
 

--- a/tests/cpp/client_test_dataset_multiple_get_tensor.cpp
+++ b/tests/cpp/client_test_dataset_multiple_get_tensor.cpp
@@ -52,7 +52,7 @@ void get_multiple_tensors(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet sent_dataset(dataset_name);
 
     //Add metadata to the DataSet
@@ -70,9 +70,11 @@ void get_multiple_tensors(
     //Put the DataSet into the database
     client.put_dataset(sent_dataset);
 
-    if(!client.tensor_exists(dataset_name))
-        throw std::runtime_error("The DataSet "\
-                                 "confirmation key is not set.");
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
+        throw std::runtime_error("The dataset ack field does not exist "\
+                                 "after placement in the database.");
 
     SmartRedis::DataSet retrieved_dataset = client.get_dataset(dataset_name);
 

--- a/tests/cpp/client_test_dataset_no_meta.cpp
+++ b/tests/cpp/client_test_dataset_no_meta.cpp
@@ -52,7 +52,7 @@ void put_get_dataset(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient  client(use_cluster());
     SmartRedis::DataSet sent_dataset(dataset_name);
 
     //Add tensors to the DataSet
@@ -67,9 +67,11 @@ void put_get_dataset(
     //Put the DataSet into the database
     client.put_dataset(sent_dataset);
 
-    if(!client.tensor_exists(dataset_name))
-        throw std::runtime_error("The DataSet "\
-                                 "confirmation key is not set.");
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
+        throw std::runtime_error("The dataset ack field does not exist "\
+                                 "after placement in the database.");
 
     SmartRedis::DataSet retrieved_dataset = client.get_dataset(dataset_name);
 

--- a/tests/cpp/client_test_dataset_no_tensors.cpp
+++ b/tests/cpp/client_test_dataset_no_tensors.cpp
@@ -34,7 +34,7 @@
 void put_dataset_no_tensors(std::string dataset_name)
 {
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet sent_dataset(dataset_name);
 
     //Add metadata to the DataSet
@@ -43,9 +43,11 @@ void put_dataset_no_tensors(std::string dataset_name)
     //Put the DataSet into the database
     client.put_dataset(sent_dataset);
 
-    if(!client.tensor_exists(dataset_name))
-        throw std::runtime_error("The DataSet "\
-                                 "confirmation key is not set.");
+    // Test that the acknowledgement field exists after placement
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
+        throw std::runtime_error("The dataset ack field was not set.");
 
     SmartRedis::DataSet retrieved_dataset = client.get_dataset(dataset_name);
 

--- a/tests/cpp/client_test_delete_dataset.cpp
+++ b/tests/cpp/client_test_delete_dataset.cpp
@@ -52,7 +52,7 @@ void dataset_delete(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSets
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet* dataset = new SmartRedis::DataSet(dataset_name);
 
     //Add tensors to the DataSet
@@ -115,9 +115,11 @@ void dataset_delete(
         throw std::runtime_error("The DataSet tensor " + key +
                                  " was not deleted.");
 
-    if(client.tensor_exists(dataset_name))
-        throw std::runtime_error("The DataSet confirmation "\
-                                 "key was not deleted.");
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(client.hash_field_exists(ack_key, ack_field))
+        throw std::runtime_error("The dataset ack field still exists "\
+                                 "after deletion");
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/cpp/client_test_ensemble.cpp
+++ b/tests/cpp/client_test_ensemble.cpp
@@ -114,7 +114,7 @@ void produce(
   dataset.add_tensor(in_key_ds, mnist_array, {1,1,28,28}, SRTensorTypeFloat, SRMemLayoutNested);
   client.put_dataset(dataset);
 
-  if(!client.tensor_exists(dataset_name))
+  if(!client.dataset_exists(dataset_name))
     throw std::runtime_error("The dataset key does not exist in the database.");
 
   std::string dataset_in_key = "{" + dataset_name + "}." + in_key_ds;

--- a/tests/cpp/client_test_rename_dataset.cpp
+++ b/tests/cpp/client_test_rename_dataset.cpp
@@ -52,7 +52,7 @@ void rename_dataset(
     fill_array(t_send_3, dims[0], dims[1], dims[2]);
 
     //Create Client and DataSet
-    SmartRedis::Client client(use_cluster());
+    DATASET_TEST_UTILS::DatasetTestClient client(use_cluster());
     SmartRedis::DataSet sent_dataset(dataset_name);
 
     //Add metadata to the DataSet
@@ -96,11 +96,15 @@ void rename_dataset(
         throw std::runtime_error("The DataSet metadata "\
                                  "was not deleted.");
 
-    if(client.tensor_exists(dataset_name))
+    std::string ack_key = "{" + dataset_name + "}" + ".meta";
+    std::string ack_field = client.ack_field();
+    if(client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The DataSet confirmation "\
                                  "key was not deleted.");
 
-    if(!client.tensor_exists(new_dataset_name))
+    ack_key = "{" + new_dataset_name + "}" + ".meta";
+    ack_field = client.ack_field();
+    if(!client.hash_field_exists(ack_key, ack_field))
         throw std::runtime_error("The renamed DataSet "\
                                  "confirmation key is not set.");
 

--- a/tests/cpp/dataset_test_utils.h
+++ b/tests/cpp/dataset_test_utils.h
@@ -34,6 +34,26 @@
 
 namespace DATASET_TEST_UTILS {
 
+/*
+   The following Client derivative enables checking for
+   a hash field to verify DataSet behavior.  If hash
+   field functionality is introduced to Client, this
+   class can be removed.
+*/
+class DatasetTestClient : public SmartRedis::Client
+{
+    public:
+        DatasetTestClient(bool cluster) : Client(cluster) {};
+
+        bool hash_field_exists(const std::string& key,
+                               const std::string& field) {
+            return _redis_server->hash_field_exists(key, field);
+        }
+        std::string ack_field() {
+            return _DATASET_ACK_FIELD;
+        }
+};
+
 const static double dbl_meta_1 = std::numeric_limits<double>::max();
 const static double dbl_meta_2 = std::numeric_limits<double>::min();
 const static double dbl_meta_3 = M_PI;

--- a/tests/cpp/unit-tests/test_client_ensemble.cpp
+++ b/tests/cpp/unit-tests/test_client_ensemble.cpp
@@ -174,7 +174,7 @@ SCENARIO("Testing Client ensemble using a producer/consumer paradigm")
             dataset.add_tensor(in_key_ds, mnist_array, {1,1,28,28},
                                SRTensorTypeFloat, SRMemLayoutNested);
             producer_client.put_dataset(dataset);
-            CHECK(producer_client.tensor_exists(dataset_name) == true);
+            CHECK(producer_client.dataset_exists(dataset_name) == true);
             producer_client.run_script(script_name, "pre_process",
                              {dataset_in_key}, {script_out_key_ds});
             producer_client.run_model(model_name, {script_out_key_ds},


### PR DESCRIPTION
Previously the ``Client`` class stored an acknowledgement key at the key ``dataset_name``.  However, tensor and metadata keys for the dataset were stored at ``{dataset_name}.tensor_name`` and ``{dataset_name}.meta``.  This is OK for non-ensemble use cases, but in an ensemble, the keys take the form:

Ack key: ``ensemble_name.dataset_name``
Tensor keys: ``ensemble_name.{dataset_name}.tensor_name``
Metadata key: ``ensemble_name.{dataset_name}.meta``.

This means that for ensembles the ack key will hash to a different slot than the tensors and metadata.  This prevents pipelining dataset ``HSET`` and ``AI.TENSORSET`` operations into a single roundtrip communication.    

This PR changes the acknowledgement key to be a hash field in the ``.meta`` key.  In this way, the ack key is easily included and pipelined in the dataset ``HSET`` and ``AI.TENSORSET`` operations. 