### PR TITLE
Add AI.INFO command

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -600,6 +600,14 @@ class Client
         parsed_reply_map get_db_cluster_info(std::string address);
 
         /*!
+        *   \brief Returns the AI.INFO command reply from any database shard
+        *   \returns parsed_reply_map containing the AI.INFO information.
+        *   \throws SmartRedis::Exception or derivative error object if
+        *           command execution or reply parsing fails.
+        */
+        parsed_reply_map get_ai_info();
+
+        /*!
         *   \brief Returns the CLUSTER INFO command reply addressed to a single
         *          cluster node.
         *   \param address The address of the database node (host:port)

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -486,6 +486,14 @@ class PyClient
         std::vector<py::dict> get_db_cluster_info(std::vector<std::string> addresses);
 
         /*!
+        *   \brief Returns the AI.INFO command reply from any database shard
+        *   \returns A dictionary that maps AI.INFO field names to values
+        *   \throws SmartRedis::RuntimeException or derivative error object if
+        *           command execution or reply parsing fails.
+        */
+        py::dict get_ai_info();
+
+        /*!
         *   \brief Delete all the keys of the given database
         *   \param addresses The addresses of the database nodes. Each address is
         *                    formatted as address:port e.g. 127.0.0.1:6379

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -70,6 +70,7 @@ PYBIND11_MODULE(smartredisPy, m) {
         .def("use_model_ensemble_prefix", &PyClient::use_model_ensemble_prefix)
         .def("get_db_node_info", &PyClient::get_db_node_info)
         .def("get_db_cluster_info", &PyClient::get_db_cluster_info)
+        .def("get_ai_info", &PyClient::get_ai_info)
         .def("flush_db", &PyClient::flush_db)
         .def("config_set", &PyClient::config_set)
         .def("config_get", &PyClient::config_get)

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -713,6 +713,19 @@ class Client(PyClient):
         except RuntimeError as e:
             raise RedisReplyError(str(e), "get_db_cluster_info")
 
+    def get_ai_info(self):
+        """Returns AI.INFO command reply information from any
+        database node
+        :returns: Dictionary of AI.INFO reply fields
+        :rtype: dict
+        :raises RedisReplyError: if there is an error
+                in command execution or parsing the command reply.
+        """
+        try:
+            return super().get_ai_info()
+        except RuntimeError as e:
+            raise RedisReplyError(str(e), "get_ai_info()")
+
     def flush_db(self, addresses):
         """Removes all keys from a specified db node.
 

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -601,6 +601,24 @@ std::vector<py::dict> PyClient::get_db_cluster_info(std::vector<std::string> add
     return addresses_info;
 }
 
+py::dict PyClient::get_ai_info()
+{
+    py::dict result;
+    try {
+        parsed_reply_map result_map = _client->get_ai_info();
+        result = py::cast(result_map);
+    }
+    catch(const std::exception& e) {
+        throw SRRuntimeException(e.what());
+    }
+    catch(...) {
+        throw SRRuntimeException("A non-standard exception was encountered "\
+                                "during client get_db_cluster_info execution.");
+    }
+
+    return result;
+}
+
 // Delete all keys of all existing databases
 void PyClient::flush_db(std::vector<std::string> addresses)
 {

--- a/tests/cpp/unit-tests/test_client.cpp
+++ b/tests/cpp/unit-tests/test_client.cpp
@@ -515,6 +515,24 @@ SCENARIO("Testing INFO Functions on Client Object", "[Client]")
     }
 }
 
+SCENARIO("Testing AI.INFO Functions on Client Object", "[Client]")
+{
+    GIVEN("A Client object")
+    {
+        Client client(use_cluster());
+
+        WHEN("AI.INFO is called")
+        {
+            THEN("No errors are thrown and the returned object is not empty")
+            {
+                parsed_reply_map result;
+                CHECK_NOTHROW(result = client.get_ai_info());
+                CHECK(result.size() != 0);
+            }
+        }
+    }
+}
+
 SCENARIO("Testing FLUSHDB on empty Client Object", "[Client][FLUSHDB]")
 {
 

--- a/tests/python/test_nonkeyed_cmd.py
+++ b/tests/python/test_nonkeyed_cmd.py
@@ -61,6 +61,17 @@ def test_dbcluster_info_command(use_cluster):
         with pytest.raises(RedisReplyError):
             client.get_db_cluster_info(address)
 
+def test_dbcluster_info_command(use_cluster):
+    # get env var to set through client init
+    ssdb = os.environ["SSDB"]
+    address = [ssdb]
+    del os.environ["SSDB"]
+
+    client = Client(address=ssdb, cluster=use_cluster)
+
+    ai_info = client.get_ai_info()
+
+    assert len(ai_info) != 0
 
 def test_flushdb_command(use_cluster):
     # from within the testing framework, there is no way


### PR DESCRIPTION
The AI.INFO command is added to the C++ and Python clients.  The commands returns a dictionary containing the field and field values from the AI.INFO command.  For example, the python client will return ``{'RDB Encoding version': '1', 'Low Level API Version': '1', 'Torch version': 'NA', 'Version': '1.2.3'}``.