### PR TITLE
Add AI.INFO command to Python and C++ clients

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -600,12 +600,19 @@ class Client
         parsed_reply_map get_db_cluster_info(std::string address);
 
         /*!
-        *   \brief Returns the AI.INFO command reply from any database shard
+        *   \brief Returns the AI.INFO command reply from the database
+        *          shard at the provided address
+        *   \param address The address of the database node (host:port)
+        *   \param key The model or script name
+        *   \param reset_stat Boolean indicating if the counters associated
+        *                     with the model or script should be reset.
         *   \returns parsed_reply_map containing the AI.INFO information.
         *   \throws SmartRedis::Exception or derivative error object if
         *           command execution or reply parsing fails.
         */
-        parsed_reply_map get_ai_info();
+        parsed_reply_map get_ai_info(const std::string& address,
+                                     const std::string& key,
+                                     const bool reset_stat);
 
         /*!
         *   \brief Returns the CLUSTER INFO command reply addressed to a single

--- a/include/client.h
+++ b/include/client.h
@@ -600,6 +600,14 @@ class Client
         parsed_reply_map get_db_cluster_info(std::string address);
 
         /*!
+        *   \brief Returns the AI.INFO command reply from any database shard
+        *   \returns parsed_reply_map containing the AI.INFO information.
+        *   \throws SmartRedis::Exception or derivative error object if
+        *           command execution or reply parsing fails.
+        */
+        parsed_reply_map get_ai_info();
+
+        /*!
         *   \brief Returns the CLUSTER INFO command reply addressed to a single
         *          cluster node.
         *   \param address The address of the database node (host:port)

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -486,6 +486,14 @@ class PyClient
         std::vector<py::dict> get_db_cluster_info(std::vector<std::string> addresses);
 
         /*!
+        *   \brief Returns the AI.INFO command reply from any database shard
+        *   \returns A dictionary that maps AI.INFO field names to values
+        *   \throws SmartRedis::RuntimeException or derivative error object if
+        *           command execution or reply parsing fails.
+        */
+        py::dict get_ai_info();
+
+        /*!
         *   \brief Delete all the keys of the given database
         *   \param addresses The addresses of the database nodes. Each address is
         *                    formatted as address:port e.g. 127.0.0.1:6379

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -486,12 +486,23 @@ class PyClient
         std::vector<py::dict> get_db_cluster_info(std::vector<std::string> addresses);
 
         /*!
-        *   \brief Returns the AI.INFO command reply from any database shard
-        *   \returns A dictionary that maps AI.INFO field names to values
-        *   \throws SmartRedis::RuntimeException or derivative error object if
-        *           command execution or reply parsing fails.
+        *   \brief Returns the AI.INFO command reply from the database
+        *          shard at the provided address
+        *   \param addresses std::vector of addresses of the database
+        *                    nodes (host:port)
+        *   \param key The model or script key
+        *   \param reset_stat Boolean indicating if the counters associated
+        *                     with the model or script should be reset.
+        *   \returns A std::vector of dictionaries that map AI.INFO
+        *            field names to values for each of the provided
+        *            database addresses.
+        *   \throws SmartRedis::RuntimeException or derivative error object
+        *           if command execution or reply parsing fails.
         */
-        py::dict get_ai_info();
+        std::vector<py::dict>
+        get_ai_info(const std::vector<std::string>& addresses,
+                    const std::string& key,
+                    const bool reset_stat);
 
         /*!
         *   \brief Delete all the keys of the given database

--- a/include/redis.h
+++ b/include/redis.h
@@ -322,6 +322,20 @@ class Redis : public RedisServer
         */
         virtual CommandReply get_script(const std::string& key);
 
+        /*!
+        *   \brief Retrieve model/script runtime statistics
+        *   \param address The address of the database node (host:port)
+        *   \param key The key associated with the model or script
+        *   \param reset_stat Boolean indicating if the counters associated
+        *                     with the model or script should be reset.
+        *   \returns The CommandReply that contains the result
+        *            of the AI.INFO execution on the server
+        */
+        virtual CommandReply
+        get_model_script_ai_info(const std::string& address,
+                                 const std::string& key,
+                                 const bool reset_stat);
+
     private:
 
         /*!

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -337,6 +337,20 @@ class RedisCluster : public RedisServer
         */
         virtual CommandReply get_script(const std::string& key);
 
+        /*!
+        *   \brief Retrieve model/script runtime statistics
+        *   \param address The address of the database node (host:port)
+        *   \param key The key associated with the model or script
+        *   \param reset_stat Boolean indicating if the counters associated
+        *                     with the model or script should be reset.
+        *   \returns The CommandReply that contains the result
+        *            of the AI.INFO execution on the server
+        */
+        virtual CommandReply
+        get_model_script_ai_info(const std::string& address,
+                                 const std::string& key,
+                                 const bool reset_stat);
+
     protected:
 
         /*!

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -327,6 +327,20 @@ class RedisServer {
         */
         virtual CommandReply get_script(const std::string& key) = 0;
 
+        /*!
+        *   \brief Retrieve model/script runtime statistics
+        *   \param address The address of the database node (host:port)
+        *   \param key The key associated with the model or script
+        *   \param reset_stat Boolean indicating if the counters associated
+        *                     with the model or script should be reset.
+        *   \returns The CommandReply that contains the result
+        *            of the AI.INFO execution on the server
+        */
+        virtual CommandReply
+        get_model_script_ai_info(const std::string& address,
+                                 const std::string& key,
+                                 const bool reset_stat) = 0;
+
     protected:
 
         /*!

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -784,13 +784,14 @@ parsed_reply_map Client::get_db_cluster_info(std::string address)
                                                      reply.str_len()));
 }
 
-// Returns the AI.INFO command reply addressed to any database shard
-parsed_reply_map Client::get_ai_info()
+// Returns the AI.INFO command reply
+parsed_reply_map Client::get_ai_info(const std::string& address,
+                                     const std::string& key,
+                                     const bool reset_stat)
 {
-    // Run the AI.INFO command
-    AddressAnyCommand cmd;
-    cmd.add_field("AI.INFO", true);
-    CommandReply reply = _run(cmd);
+    // Run the command
+    CommandReply reply =
+        _redis_server->get_model_script_ai_info(address, key, reset_stat);
 
     if (reply.has_error())
         throw SRRuntimeException("AI.INFO command failed on server");
@@ -799,29 +800,23 @@ parsed_reply_map Client::get_ai_info()
         throw SRInternalException("The AI.INFO reply structure has an "\
                                   "unexpected format");
 
+    reply.print_reply_structure();
+
     // Parse reply
     parsed_reply_map reply_map;
-    std::string key;
-    std::string value;
-    for(size_t i = 0; i < reply.n_elements(); i += 2){
-
-        if(reply[i].redis_reply_type() == "REDIS_REPLY_STRING")
-            key = reply[i].str();
-        else if (reply[i].redis_reply_type() == "REDIS_REPLY_STATUS")
-            key = reply[i].status_str();
-        else
-            throw SRInternalException("The AI.INFO reply does not have "\
-                                      "the correct type.");
-
+    for (size_t i = 0; i < reply.n_elements(); i += 2) {
+        std::string map_key = reply[i].str();
+        std::string value;
         if(reply[i+1].redis_reply_type() == "REDIS_REPLY_STRING")
             value = reply[i+1].str();
-        else if (reply[i+1].redis_reply_type() == "REDIS_REPLY_STATUS")
-            value = reply[i+1].status_str();
+        else if (reply[i+1].redis_reply_type() == "REDIS_REPLY_INTEGER")
+            value = std::to_string(reply[i+1].integer());
+        else if (reply[i+1].redis_reply_type() == "REDIS_REPLY_DOUBLE")
+            value = std::to_string(reply[i+1].dbl());
         else
-            throw SRInternalException("The AI.INFO reply does not have "\
-                                      "the correct type.");
-
-        reply_map[key] = value;
+            throw SRInternalException("The AI.INFO field " + map_key +
+                                      " has an unexpected type.");
+        reply_map[map_key] = value;
     }
     return reply_map;
 }

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -808,10 +808,10 @@ parsed_reply_map Client::get_ai_info(const std::string& address,
         std::string map_key = reply[i].str();
         std::string value;
         if(reply[i+1].redis_reply_type() == "REDIS_REPLY_STRING")
-            value = reply[i+1].str();
-        else if (reply[i+1].redis_reply_type() == "REDIS_REPLY_INTEGER")
+            value = reply[i + 1].str();
+        else if (reply[i + 1].redis_reply_type() == "REDIS_REPLY_INTEGER")
             value = std::to_string(reply[i+1].integer());
-        else if (reply[i+1].redis_reply_type() == "REDIS_REPLY_DOUBLE")
+        else if (reply[i + 1].redis_reply_type() == "REDIS_REPLY_DOUBLE")
             value = std::to_string(reply[i+1].dbl());
         else
             throw SRInternalException("The AI.INFO field " + map_key +

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -396,6 +396,37 @@ CommandReply Redis::get_script(const std::string& key)
     return run(cmd);
 }
 
+// Retrieve the model and script AI.INFO
+CommandReply Redis::get_model_script_ai_info(const std::string& address,
+                                             const std::string& key,
+                                             const bool reset_stat)
+{
+    AddressAtCommand cmd;
+
+    // Parse the host and port
+    std::string host = cmd.parse_host(address);
+    uint64_t port = cmd.parse_port(address);
+
+    // Determine the prefix we need for the model or script
+    if (!is_addressable(host, port)) {
+        throw SRRuntimeException("The provided host and port do not match "\
+                                 "the host and port used to initialize the "\
+                                 "non-cluster client connection.");
+    }
+
+    //Build the Command
+    cmd.set_exec_address_port(host, port);
+    cmd.add_field("AI.INFO");
+    cmd.add_field(key);
+
+    // Optionally add RESETSTAT to the command
+    if (reset_stat) {
+        cmd.add_field("RESETSTAT");
+    }
+
+    return run(cmd);
+}
+
 inline CommandReply Redis::_run(const Command& cmd)
 {
     CommandReply reply;

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -70,6 +70,7 @@ PYBIND11_MODULE(smartredisPy, m) {
         .def("use_model_ensemble_prefix", &PyClient::use_model_ensemble_prefix)
         .def("get_db_node_info", &PyClient::get_db_node_info)
         .def("get_db_cluster_info", &PyClient::get_db_cluster_info)
+        .def("get_ai_info", &PyClient::get_ai_info)
         .def("flush_db", &PyClient::flush_db)
         .def("config_set", &PyClient::config_set)
         .def("config_get", &PyClient::config_get)

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -713,16 +713,25 @@ class Client(PyClient):
         except RuntimeError as e:
             raise RedisReplyError(str(e), "get_db_cluster_info")
 
-    def get_ai_info(self):
-        """Returns AI.INFO command reply information from any
-        database node
-        :returns: Dictionary of AI.INFO reply fields
-        :rtype: dict
+    def get_ai_info(self, address, key, reset_stat=False):
+        """Returns AI.INFO command reply information for the
+        script or model key at the provided addresses.
+        :param addresses: The addresses of the database nodes
+        :type address: list[str]
+        :param key: The key associated with the model or script
+        :type key: str
+        :param reset_stat: Boolean indicating if the statistics
+                           for the model or script should be
+                           reset.
+        :type reset_stat: bool
+        :returns: A list of dictionaries with each entry in the
+                  list corresponding to an address reply
+        :rtype: list[dict]
         :raises RedisReplyError: if there is an error
                 in command execution or parsing the command reply.
         """
         try:
-            return super().get_ai_info()
+            return super().get_ai_info(address, key, reset_stat)
         except RuntimeError as e:
             raise RedisReplyError(str(e), "get_ai_info()")
 

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -713,6 +713,19 @@ class Client(PyClient):
         except RuntimeError as e:
             raise RedisReplyError(str(e), "get_db_cluster_info")
 
+    def get_ai_info(self):
+        """Returns AI.INFO command reply information from any
+        database node
+        :returns: Dictionary of AI.INFO reply fields
+        :rtype: dict
+        :raises RedisReplyError: if there is an error
+                in command execution or parsing the command reply.
+        """
+        try:
+            return super().get_ai_info()
+        except RuntimeError as e:
+            raise RedisReplyError(str(e), "get_ai_info()")
+
     def flush_db(self, addresses):
         """Removes all keys from a specified db node.
 

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -601,22 +601,30 @@ std::vector<py::dict> PyClient::get_db_cluster_info(std::vector<std::string> add
     return addresses_info;
 }
 
-py::dict PyClient::get_ai_info()
-{
-    py::dict result;
-    try {
-        parsed_reply_map result_map = _client->get_ai_info();
-        result = py::cast(result_map);
-    }
-    catch(const std::exception& e) {
-        throw SRRuntimeException(e.what());
-    }
-    catch(...) {
-        throw SRRuntimeException("A non-standard exception was encountered "\
-                                "during client get_db_cluster_info execution.");
-    }
+// Execute AI.INFO command
+std::vector<py::dict>
+PyClient::get_ai_info(const std::vector<std::string>& addresses,
+                      const std::string& key,
+                      const bool reset_stat)
 
-    return result;
+{
+    std::vector<py::dict> ai_info;
+    for(size_t i = 0; i < addresses.size(); i++) {
+        try {
+            parsed_reply_map result =
+                _client->get_ai_info(addresses[i], key, reset_stat);
+            py::dict result_dict = py::cast(result);
+            ai_info.push_back(result_dict);
+        }
+        catch(const std::exception& e) {
+            throw SRRuntimeException(e.what());
+        }
+        catch(...) {
+            throw SRRuntimeException("A non-standard exception was encountered "\
+                                     "during client get_ai_info() execution.");
+        }
+    }
+    return ai_info;
 }
 
 // Delete all keys of all existing databases

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -608,23 +608,24 @@ PyClient::get_ai_info(const std::vector<std::string>& addresses,
                       const bool reset_stat)
 
 {
-    std::vector<py::dict> ai_info;
-    for(size_t i = 0; i < addresses.size(); i++) {
-        try {
-            parsed_reply_map result =
-                _client->get_ai_info(addresses[i], key, reset_stat);
-            py::dict result_dict = py::cast(result);
-            ai_info.push_back(result_dict);
+    try {
+        std::vector<py::dict> ai_info;
+        for(size_t i = 0; i < addresses.size(); i++) {
+                parsed_reply_map result =
+                    _client->get_ai_info(addresses[i], key, reset_stat);
+                py::dict result_dict = py::cast(result);
+                ai_info.push_back(result_dict);
+
         }
-        catch(const std::exception& e) {
-            throw SRRuntimeException(e.what());
-        }
-        catch(...) {
-            throw SRRuntimeException("A non-standard exception was encountered "\
-                                     "during client get_ai_info() execution.");
-        }
+        return ai_info;
     }
-    return ai_info;
+    catch(const std::exception& e) {
+        throw SRRuntimeException(e.what());
+    }
+    catch(...) {
+        throw SRRuntimeException("A non-standard exception was encountered "\
+                                    "during client get_ai_info() execution.");
+    }
 }
 
 // Delete all keys of all existing databases

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -601,6 +601,24 @@ std::vector<py::dict> PyClient::get_db_cluster_info(std::vector<std::string> add
     return addresses_info;
 }
 
+py::dict PyClient::get_ai_info()
+{
+    py::dict result;
+    try {
+        parsed_reply_map result_map = _client->get_ai_info();
+        result = py::cast(result_map);
+    }
+    catch(const std::exception& e) {
+        throw SRRuntimeException(e.what());
+    }
+    catch(...) {
+        throw SRRuntimeException("A non-standard exception was encountered "\
+                                "during client get_db_cluster_info execution.");
+    }
+
+    return result;
+}
+
 // Delete all keys of all existing databases
 void PyClient::flush_db(std::vector<std::string> addresses)
 {

--- a/tests/cpp/unit-tests/test_client.cpp
+++ b/tests/cpp/unit-tests/test_client.cpp
@@ -515,6 +515,24 @@ SCENARIO("Testing INFO Functions on Client Object", "[Client]")
     }
 }
 
+SCENARIO("Testing AI.INFO Functions on Client Object", "[Client]")
+{
+    GIVEN("A Client object")
+    {
+        Client client(use_cluster());
+
+        WHEN("AI.INFO is called")
+        {
+            THEN("No errors are thrown and the returned object is not empty")
+            {
+                parsed_reply_map result;
+                CHECK_NOTHROW(result = client.get_ai_info());
+                CHECK(result.size() != 0);
+            }
+        }
+    }
+}
+
 SCENARIO("Testing FLUSHDB on empty Client Object", "[Client][FLUSHDB]")
 {
 

--- a/tests/cpp/unit-tests/test_client.cpp
+++ b/tests/cpp/unit-tests/test_client.cpp
@@ -521,13 +521,43 @@ SCENARIO("Testing AI.INFO Functions on Client Object", "[Client]")
     {
         Client client(use_cluster());
 
-        WHEN("AI.INFO is called")
+        WHEN("AI.INFO called on database with an invalid address")
         {
-            THEN("No errors are thrown and the returned object is not empty")
+            THEN("An error is thrown")
             {
-                parsed_reply_map result;
-                CHECK_NOTHROW(result = client.get_ai_info());
-                CHECK(result.size() != 0);
+                std::string db_address = ":00";
+
+                CHECK_THROWS_AS(client.get_ai_info(db_address, "bad_key", false),
+                                RuntimeException);
+            }
+        }
+        AND_WHEN("AI.INFO is called on database with a valid address "\
+                 "but invalid key")
+        {
+            THEN("An error is thrown")
+            {
+                std::string db_address = parse_SSDB(std::getenv("SSDB"));
+
+                CHECK_THROWS_AS(client.get_ai_info(db_address, "bad_key", false),
+                                RuntimeException);
+            }
+        }
+        AND_WHEN("AI.INFO is called on database with a valid address "\
+                 "and valid key")
+        {
+            THEN("No errors are thrown and the returned list has non-zero size")
+            {
+                std::string db_address = parse_SSDB(std::getenv("SSDB"));
+                std::string model_key = "ai_info_model";
+                std::string model_file = "./../../mnist_data/mnist_cnn.pt";
+                std::string backend = "TORCH";
+                std::string device = "CPU";
+                parsed_reply_map reply;
+                CHECK_NOTHROW(client.set_model_from_file(model_key, model_file,
+                                                         backend, device));
+                CHECK_NOTHROW(reply = client.get_ai_info(db_address, model_key,
+                                                         false));
+                CHECK(reply.size() > 0);
             }
         }
     }

--- a/tests/python/test_nonkeyed_cmd.py
+++ b/tests/python/test_nonkeyed_cmd.py
@@ -61,6 +61,17 @@ def test_dbcluster_info_command(use_cluster):
         with pytest.raises(RedisReplyError):
             client.get_db_cluster_info(address)
 
+def test_dbcluster_info_command(use_cluster):
+    # get env var to set through client init
+    ssdb = os.environ["SSDB"]
+    address = [ssdb]
+    del os.environ["SSDB"]
+
+    client = Client(address=ssdb, cluster=use_cluster)
+
+    ai_info = client.get_ai_info()
+
+    assert len(ai_info) != 0
 
 def test_flushdb_command(use_cluster):
     # from within the testing framework, there is no way

--- a/tests/python/test_nonkeyed_cmd.py
+++ b/tests/python/test_nonkeyed_cmd.py
@@ -45,7 +45,7 @@ def test_dbnode_info_command(use_cluster):
     assert len(info) > 0
 
 
-def test_dbcluster_info_command(use_cluster):
+def test_dbcluster_info_command(mock_model, use_cluster):
     # get env var to set through client init
     ssdb = os.environ["SSDB"]
     address = [ssdb]
@@ -61,17 +61,31 @@ def test_dbcluster_info_command(use_cluster):
         with pytest.raises(RedisReplyError):
             client.get_db_cluster_info(address)
 
-def test_dbcluster_info_command(use_cluster):
     # get env var to set through client init
     ssdb = os.environ["SSDB"]
     address = [ssdb]
     del os.environ["SSDB"]
 
+    # Init client
     client = Client(address=ssdb, cluster=use_cluster)
 
-    ai_info = client.get_ai_info()
+    # Get a mock model
+    model = mock_model.create_torch_cnn()
 
+    # set the mock model
+    client.set_model("ai_info_cnn", model, "TORCH", "CPU")
+
+    # Check with valid address and model key
+    ai_info = client.get_ai_info(address, "ai_info_cnn")
     assert len(ai_info) != 0
+
+    # Check that invalid address throws error
+    with pytest.raises(RedisReplyError):
+        client.get_ai_info(["no_host:6379"], "ai_info_cnn")
+
+    # Check that invalid model name throws error
+    with pytest.raises(RedisReplyError):
+        client.get_ai_info(address, "bad_key")
 
 def test_flushdb_command(use_cluster):
     # from within the testing framework, there is no way


### PR DESCRIPTION
The AI.INFO command has been added to the Python and C++ clients.  The commands allow users to retrieve statistics on scripts and models (metadata and execution information).  The API functions follow the same format as other "information" commands:  users are required to give the address of the database nodes where the command is to be executed.  Like the other "information" commands, the Python client supports multiple addresses.  The results are returned in Python as a list of dictionaries.