### PR TITLE
Prevent Make Clean From Clobbering Catch2

### DIFF
--- a/build-scripts/build-catch.sh
+++ b/build-scripts/build-catch.sh
@@ -6,10 +6,7 @@ if [[ -f ./catch/single_include/catch2/catch.hpp ]]; then
 else
     echo "Installing Catch"
     if [[ ! -d "./catch" ]]; then
-        git clone https://github.com/catchorg/Catch2.git catch
-        cd catch
-        git checkout tags/v2.13.6
-        cd ..
+        git clone https://github.com/catchorg/Catch2.git catch --branch v2.13.6 --depth=1
     else
         echo "Catch downloaded"
     fi

--- a/build-scripts/build-catch.sh
+++ b/build-scripts/build-catch.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 # Install Catch
-if [[ -f ./catch/catch.hpp ]]; then
+if [[ -f ./catch/single_include/catch2/catch.hpp ]]; then
     echo "Catch has already been download and installed"
 else
     echo "Installing Catch"
     if [[ ! -d "./catch" ]]; then
-        wget https://github.com/catchorg/Catch2/releases/download/v2.13.6/catch.hpp -P catch
+        git clone https://github.com/catchorg/Catch2.git catch
+        cd catch
+        git checkout tags/v2.13.6
+        cd ..
     else
         echo "Catch downloaded"
     fi

--- a/tests/cpp/unit-tests/main.cpp
+++ b/tests/cpp/unit-tests/main.cpp
@@ -27,5 +27,5 @@
  */
 
 #define CATCH_CONFIG_MAIN
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "srexception.h"

--- a/tests/cpp/unit-tests/test_addressanycommand.cpp
+++ b/tests/cpp/unit-tests/test_addressanycommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "addressanycommand.h"
 #include "redisserver.h"
 

--- a/tests/cpp/unit-tests/test_addressatcommand.cpp
+++ b/tests/cpp/unit-tests/test_addressatcommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "addressatcommand.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_client.cpp
+++ b/tests/cpp/unit-tests/test_client.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "client.h"
 #include "dataset.h"
 #include "../client_test_utils.h"

--- a/tests/cpp/unit-tests/test_client_ensemble.cpp
+++ b/tests/cpp/unit-tests/test_client_ensemble.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "client.h"
 #include "dataset.h"
 #include "../client_test_utils.h"

--- a/tests/cpp/unit-tests/test_clusterinfocommand.cpp
+++ b/tests/cpp/unit-tests/test_clusterinfocommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "clusterinfocommand.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_commandlist.cpp
+++ b/tests/cpp/unit-tests/test_commandlist.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "commandlist.h"
 #include "singlekeycommand.h"
 #include "multikeycommand.h"

--- a/tests/cpp/unit-tests/test_commandreply.cpp
+++ b/tests/cpp/unit-tests/test_commandreply.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "commandreply.h"
 #include "srexception.h"
 

--- a/tests/cpp/unit-tests/test_compoundcommand.cpp
+++ b/tests/cpp/unit-tests/test_compoundcommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "compoundcommand.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_dataset.cpp
+++ b/tests/cpp/unit-tests/test_dataset.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "dataset.h"
 #include "srexception.h"
 #include <cxxabi.h>

--- a/tests/cpp/unit-tests/test_dbinfocommand.cpp
+++ b/tests/cpp/unit-tests/test_dbinfocommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "dbinfocommand.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_dbnode.cpp
+++ b/tests/cpp/unit-tests/test_dbnode.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "dbnode.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_metadata.cpp
+++ b/tests/cpp/unit-tests/test_metadata.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "metadata.h"
 #include "srexception.h"
 

--- a/tests/cpp/unit-tests/test_multikeycommand.cpp
+++ b/tests/cpp/unit-tests/test_multikeycommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "multikeycommand.h"
 
 

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -28,7 +28,7 @@
 
 #include "limits.h"
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "../client_test_utils.h"
 
 #include "redisserver.h"

--- a/tests/cpp/unit-tests/test_singlekeycommand.cpp
+++ b/tests/cpp/unit-tests/test_singlekeycommand.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "singlekeycommand.h"
 #include "srexception.h"
 

--- a/tests/cpp/unit-tests/test_ssdb.cpp
+++ b/tests/cpp/unit-tests/test_ssdb.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "redis.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_stringfield.cpp
+++ b/tests/cpp/unit-tests/test_stringfield.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "stringfield.h"
 
 SCENARIO("Test StringField", "[StringField]")

--- a/tests/cpp/unit-tests/test_tensor.cpp
+++ b/tests/cpp/unit-tests/test_tensor.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "tensor.h"
 
 using namespace SmartRedis;

--- a/tests/cpp/unit-tests/test_tensorbase.cpp
+++ b/tests/cpp/unit-tests/test_tensorbase.cpp
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../../third-party/catch/catch.hpp"
+#include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "tensorbase.h"
 #include "tensorpack.h"
 #include "srexception.h"


### PR DESCRIPTION
Super quick and dirty solution to keep Catch2 header file from being removed on `make clean`. Instead of downloading the single header file, we clone the repo and use the header file provided there.

This also prepares us for the next major release where catch plans to move away from the single header file model. We will simply need to bump the tag and build.