### PR TITLE
Streamline run() and connect() commands

### DIFF
--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -445,14 +445,29 @@ inline CommandReply Redis::_run(const Command& cmd)
             // Exception is already prepared, just propagate it
             throw;
         }
-        catch (sw::redis::Error &e) {
+        catch (sw::redis::IoError &e) {
             // For an error from Redis, retry unless we're out of chances
             if (i == _command_attempts) {
                 throw SRDatabaseException(
-                    std::string("Redis error when executing commend: ") +
+                    std::string("Redis IO error when executing commend: ") +
                     e.what());
             }
             // else, Fall through for a retry
+        }
+        catch (sw::redis::ClosedError &e) {
+            // For an error from Redis, retry unless we're out of chances
+            if (i == _command_attempts) {
+                throw SRDatabaseException(
+                    std::string("Redis Closed error when executing commend: ") +
+                    e.what());
+            }
+            // else, Fall through for a retry
+        }
+        catch (sw::redis::Error &e) {
+            // For other errors from Redis, report them immediately
+            throw SRRuntimeException(
+                std::string("Redis error when executing commend: ") +
+                e.what());
         }
         catch (std::exception& e) {
             // Should never hit this, so bail immediately if we do

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -429,44 +429,50 @@ CommandReply Redis::get_model_script_ai_info(const std::string& address,
 
 inline CommandReply Redis::_run(const Command& cmd)
 {
-    CommandReply reply;
-    bool executed = false;
     for (int i = 1; i <= _command_attempts; i++) {
         try {
-            reply = _redis->command(cmd.cbegin(), cmd.cend());
+            // Run the command
+            CommandReply reply = _redis->command(cmd.cbegin(), cmd.cend());
             if (reply.has_error() == 0)
                 return reply;
-            executed = true;
-            break;
+
+            // On an error response, print the response and bail
+            reply.print_reply_error();
+            throw SRRuntimeException(
+                "Redis failed to execute command: " + cmd.first_field());
         }
-        catch (sw::redis::IoError &e) {
-            // Fall through for a retry
+        catch (SmartRedis::Exception& e) {
+            // Exception is already prepared, just propagate it
+            throw;
         }
-        catch (sw::redis::ClosedError &e) {
-            // Fall through for a retry
+        catch (sw::redis::Error &e) {
+            // For an error from Redis, retry unless we're out of chances
+            if (i == _command_attempts) {
+                throw SRDatabaseException(
+                    std::string("Redis error when executing commend: ") +
+                    e.what());
+            }
+            // else, Fall through for a retry
         }
         catch (std::exception& e) {
-            throw SRRuntimeException(e.what());
+            // Should never hit this, so bail immediately if we do
+            throw SRInternalException(
+                std::string("Unexpected exception executing command: ") +
+                e.what());
         }
         catch (...) {
-            throw SRInternalException("Non-standard exception "\
-                                      "encountered during command " +
-                                      cmd.first_field() + " execution. ");
+            // Should never hit this, so bail immediately if we do
+            throw SRInternalException(
+                "Non-standard exception encountered executing command " +
+                cmd.first_field());
         }
 
+        // If we get here, the execution attempt failed.
+        // Sleep before the next attempt
         std::this_thread::sleep_for(std::chrono::milliseconds(_command_interval));
     }
 
-    // If we get here, we've either run out of retry attempts or gotten
-    // a failure back from the database
-    if (executed) {
-        if (reply.has_error() > 0)
-            reply.print_reply_error();
-        throw SRRuntimeException("Redis failed to execute command: " +
-                                 cmd.first_field());
-    }
-
-    // Since we didn't execute, we must have run out of retry attempts
+    // If we get here, we've run out of retry attempts
     throw SRTimeoutException("Unable to execute command" + cmd.first_field());
 }
 
@@ -482,57 +488,70 @@ inline void Redis::_add_to_address_map(std::string address_port)
 
 inline void Redis::_connect(std::string address_port)
 {
-    // Try to create the sw::redis::Redis object
-    try {
-        _redis = new sw::redis::Redis(address_port);
-    }
-    catch (sw::redis::Error& e) {
-        _redis = NULL;
-        throw SRDatabaseException(std::string("Unable to connect to "\
-                                  "backend Redis database: ") +
-                                  e.what());
-    }
-    catch (std::bad_alloc& e) {
-        throw SRBadAllocException("Redis connection");
-    }
-    catch (std::exception& e) {
-        _redis = NULL;
-        throw SRRuntimeException("Failed to create Redis object with error: " +
-                                 std::string(e.what()));
-    }
-    catch (...) {
-        _redis = NULL;
-        throw SRInternalException("A non-standard exception encountered "\
-                                  "during client connection.");
-    }
-
-    // Attempt to have the sw::redis::Redis object
-    // make a connection using the PING command
     for (int i = 1; i <= _connection_attempts; i++) {
         try {
+            // Try to create the sw::redis::Redis object
+            _redis = new sw::redis::Redis(address_port);
+
+            // Attempt to have the sw::redis::Redis object
+            // make a connection using the PING command
             if (_redis->ping().compare("PONG") == 0) {
                 return;
             }
-            else if (i == _connection_attempts) {
-                throw SRTimeoutException(std::string("Connection attempt "\
-                                         "failed after ") +
-                                         std::to_string(i) + "tries");
+        }
+        catch (std::bad_alloc& e) {
+            // On a memory error, bail immediately
+            if (_redis != NULL) {
+                delete _redis;
+                _redis = NULL;
+            }
+            throw SRBadAllocException("Redis connection");
+        }
+        catch (sw::redis::Error& e) {
+            // For an error from Redis, retry unless we're out of chances
+            if (_redis != NULL) {
+                delete _redis;
+                _redis = NULL;
+            }
+            if (i == _connection_attempts) {
+                throw SRDatabaseException(
+                    std::string("Unable to connect to backend database: ") +
+                                e.what());
             }
         }
         catch (std::exception& e) {
-            if (i == _connection_attempts) {
-                throw SRRuntimeException(e.what());
+            // Should never hit this, so bail immediately if we do
+            if (_redis != NULL) {
+                delete _redis;
+                _redis = NULL;
             }
+            throw SRInternalException(
+                std::string("Unexpected exception while connecting: ") +
+                e.what());
         }
         catch (...) {
-            if (i == _connection_attempts) {
-                throw SRRuntimeException("A non-standard exception encountered"\
-                                         " during client connection.");
+            // Should never hit this, so bail immediately if we do
+            if (_redis != NULL) {
+                delete _redis;
+                _redis = NULL;
             }
+            throw SRInternalException(
+                "A non-standard exception encountered "\
+                "during client connection.");
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(_connection_interval));
+
+        // Delay before the retry
+        if (_redis != NULL) {
+            delete _redis;
+            _redis = NULL;
+        }
+        if (i < _connection_attempts) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(_connection_interval));
+        }
     }
 
-    // Should never get here
-    throw SRInternalException("End of _connect reached unexpectedly");
+    // If we get here, we've run out of retry attempts
+    throw SRTimeoutException(std::string("Connection attempt failed after ") +
+                             std::to_string(_connection_attempts) + "tries");
 }

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -608,101 +608,102 @@ inline CommandReply RedisCluster::_run(const Command& cmd, std::string db_prefix
     std::string_view sv_prefix(db_prefix.data(), db_prefix.size());
 
     // Execute the commmand
-    CommandReply reply;
-    bool executed = false;
     for (int i = 1; i <= _command_attempts; i++) {
         try {
             sw::redis::Redis db = _redis_cluster->redis(sv_prefix, false);
-            reply = db.command(cmd.cbegin(), cmd.cend());
+            CommandReply reply = db.command(cmd.cbegin(), cmd.cend());
             if (reply.has_error() == 0) {
                 _last_prefix = db_prefix;
                 return reply;
             }
-            executed = true;
-            break;
+
+            // On an error response, print the response and bail
+            reply.print_reply_error();
+            throw SRRuntimeException(
+                "Redis failed to execute command: " + cmd.first_field());
         }
-        catch (sw::redis::IoError &e) {
-            // Fall through for a retry
+        catch (SmartRedis::Exception& e) {
+            // Exception is already prepared, just propagate it
+            throw;
         }
-        catch (sw::redis::ClosedError &e) {
-            // Fall through for a retry
+        catch (sw::redis::Error &e) {
+            // For an error from Redis, retry unless we're out of chances
+            if (i == _command_attempts) {
+                throw SRDatabaseException(
+                    std::string("Redis error when executing commend: ") +
+                    e.what());
+            }
+            // else, Fall through for a retry
         }
         catch (std::exception& e) {
-            throw SRRuntimeException(e.what());
+            // Should never hit this, so bail immediately if we do
+            throw SRInternalException(
+                std::string("Unexpected exception executing command: ") +
+                e.what());
         }
         catch (...) {
-            throw SRInternalException("A non-standard exception encountered "\
-                                      "during command " + cmd.first_field() +
-                                      " execution.");
+            // Should never hit this, so bail immediately if we do
+            throw SRInternalException(
+                "Non-standard exception encountered executing command " +
+                cmd.first_field());
         }
 
         // Sleep before the next attempt
         std::this_thread::sleep_for(std::chrono::milliseconds(_command_interval));
     }
 
-    // If we get here, we've either run out of retry attempts or gotten
-    // a failure back from the database
-    if (executed) {
-        if (reply.has_error() > 0)
-            reply.print_reply_error();
-        throw SRRuntimeException("Redis failed to execute command: " +
-                                 cmd.first_field());
-    }
-
-    // Since we didn't execute, we must have run out of retry attempts
+    // If we get here, we've run out of retry attempts
     throw SRTimeoutException("Unable to execute command " + cmd.first_field());
 }
 
 // Connect to the cluster at the address and port
 inline void RedisCluster::_connect(std::string address_port)
 {
-    const int n_trials = 10;
     for (int i = 1; i <= _connection_attempts; i++) {
         try {
+            // Attempt the connection
             _redis_cluster = new sw::redis::RedisCluster(address_port);
             return;
         }
-        catch (sw::redis::Error& e) {
-            _redis_cluster = NULL;
-            throw SRDatabaseException(std::string("Unable to connect to "\
-                                      "backend Redis database: ") +
-                                      e.what());
-        }
         catch (std::bad_alloc& e) {
+            // On a memory error, bail immediately
+            _redis_cluster = NULL;
             throw SRBadAllocException("RedisCluster connection");
         }
+        catch (sw::redis::Error& e) {
+            // For an error from Redis, retry unless we're out of chances
+            _redis_cluster = NULL;
+            if (i == _connection_attempts) {
+                throw SRDatabaseException(
+                    std::string("Unable to connect to backend database: ") +
+                    e.what());
+            }
+            // Else, fall through to retry
+        }
         catch (std::exception& e) {
-            if (_redis_cluster != NULL) {
-                delete _redis_cluster;
-                _redis_cluster = NULL;
-            }
-            if (i == n_trials) {
-                throw SRRuntimeException(e.what());
-            }
+            // Should never hit this, so bail immediately if we do
+            _redis_cluster = NULL;
+            throw SRInternalException(
+                std::string("Unexpected exception while connecting: ") +
+                e.what());
         }
         catch (...) {
-            if (_redis_cluster != NULL) {
-                delete _redis_cluster;
-                _redis_cluster = NULL;
-            }
-            if (i == n_trials) {
-                throw SRInternalException("A non-standard exception was "\
-                                          "encountered during client "\
-                                          "connection.");
-            }
+            // Should never hit this, so bail immediately if we do
+            _redis_cluster = NULL;
+            throw SRInternalException(
+                "A non-standard exception was encountered during client "\
+                "connection.");
         }
 
+        // If we get here, the connection attempt failed.
         // Sleep before the next attempt
-        if (_redis_cluster != NULL) {
-            delete _redis_cluster;
-            _redis_cluster = NULL;
-        }
+        _redis_cluster = NULL;
         std::this_thread::sleep_for(std::chrono::milliseconds(_connection_interval));
     }
 
     // If we get here, we failed to establish a connection
     throw SRTimeoutException(std::string("Connection attempt failed after ") +
-                                         std::to_string(_connection_attempts) + "tries");
+                             std::to_string(_connection_attempts) + "tries");
 }
 
 // Map the RedisCluster via the CLUSTER SLOTS command


### PR DESCRIPTION
Streamline `run` and `connect` commands for Redis and RedisCluster to make sure that retries happen when they should and appropriate messages are generated when operations fail.