### PR TITLE
Squash more documentation build warnings

### DIFF
--- a/include/c_client.h
+++ b/include/c_client.h
@@ -629,7 +629,7 @@ SRError tensor_exists(void* c_client,
                       bool* exists);
 
 /*!
-*   \brief Check if a model or script \exists in the database
+*   \brief Check if a model or script exists in the database
 *   \details The model or script key used to check for existence
 *            may be formed by applying a prefix to the supplied
 *            name. See set_data_source()

--- a/include/client.h
+++ b/include/client.h
@@ -55,7 +55,9 @@ namespace SmartRedis {
 
 class Client;
 
-/** The database response to a command */
+/*!
+*  \brief The database response to a command
+*/
 typedef redisReply ReplyElem;
 
 ///@file

--- a/include/client.h
+++ b/include/client.h
@@ -55,6 +55,7 @@ namespace SmartRedis {
 
 class Client;
 
+/** The database response to a command */
 typedef redisReply ReplyElem;
 
 ///@file

--- a/include/clusterinfocommand.h
+++ b/include/clusterinfocommand.h
@@ -31,6 +31,9 @@
 
 #include "addressatcommand.h"
 
+/*!
+*  \brief A map of reply data from a database response
+*/
 using parsed_reply_map = std::unordered_map<std::string, std::string>;
 
 ///@file

--- a/include/command.h
+++ b/include/command.h
@@ -228,12 +228,12 @@ class Command
         std::string to_string();
 
         /*!
-        *   \typedef An iterator type for iterating over all Command fields
+        *   \brief An iterator type for iterating over all Command fields
         */
         typedef std::vector<std::string_view>::iterator iterator;
 
         /*!
-        *   \typedef An iterator type for iterating over all Command fields
+        *   \brief An iterator type for iterating over all Command fields
         */
         typedef std::vector<std::string_view>::const_iterator const_iterator;
 

--- a/include/commandlist.h
+++ b/include/commandlist.h
@@ -90,13 +90,13 @@ class CommandList
         T* add_command();
 
         /*!
-        *   \typedef An iterator type for iterating
+        *   \brief An iterator type for iterating
         *            over all Commands
         */
         typedef std::vector<Command*>::iterator iterator;
 
         /*!
-        *   \typedef A const iterator type for iterating
+        *   \brief A const iterator type for iterating
         *            over all Commands
         */
         typedef std::vector<Command*>::const_iterator const_iterator;

--- a/include/commandreply.h
+++ b/include/commandreply.h
@@ -40,7 +40,7 @@ namespace SmartRedis {
 class CommandReply;
 
 /*!
-*   \typedef Redis++ command reply type
+*   \brief Redis++ command reply type
 */
 typedef std::unique_ptr<redisReply, sw::redis::ReplyDeleter>
         RedisReplyUPtr;

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -288,12 +288,12 @@ class DataSet
     protected:
 
         /*!
-        *   \typedef Iterator for Tensor in the dataset
+        *   \brief Iterator for Tensor in the dataset
         */
         typedef TensorPack::tensorbase_iterator tensor_iterator;
 
         /*!
-        *   \typedef Const iterator for Tensor in the dataset
+        *   \brief Const iterator for Tensor in the dataset
         */
         typedef TensorPack::const_tensorbase_iterator const_tensor_iterator;
 

--- a/include/dbinfocommand.h
+++ b/include/dbinfocommand.h
@@ -30,6 +30,10 @@
 #define SMARTREDIS_DBINFOCOMMAND_H
 
 #include "addressatcommand.h"
+
+/*!
+*  \brief A nested map of reply data from a database response
+*/
 using parsed_reply_nested_map = std::unordered_map<std::string,
                                 std::unordered_map<std::string, std::string>>;
 

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -540,11 +540,11 @@ class PyClient
         */
         void config_set(std::string config_param, std::string value, std::string address);
 
-        /*
+        /*!
         *   \brief Performs a synchronous save of the database shard producing a point in
         *          time snapshot of all the data inside the Redis instance  in the form of
         *          an RDB file.
-        *   \param address The address of the database node (host:port)
+        *   \param addresses The addressees of database nodes (host:port)
         *   \throw RuntimeException if the address is not addressable by this
         *          client or if command fails to execute
         */

--- a/include/srassert.h
+++ b/include/srassert.h
@@ -50,7 +50,7 @@ inline bool throw_runtime_exception(const std::string &txt, const char *file, in
 }
 
 /*!
-*   \def SR_ASSERT Assert that a \a condition is true or throw a RuntimeException
+*   \brief Assert that a condition is true or throw a RuntimeException
 */
 #define SR_ASSERT(condition) \
     ((condition) || throw_runtime_exception(std::string("Assertion failed!") + #condition, __FILE__, __LINE__))
@@ -71,7 +71,7 @@ inline bool throw_param_exception(const std::string &txt, const char *file, int 
 }
 
 /*!
-*   \def SR_CHECK_PARAMS Validate a parameter list (via a boolean \a condition) or throw a RuntimeException
+*   \brief Validate a parameter list (via a boolean condition) or throw a RuntimeException
 */
 #define SR_CHECK_PARAMS(condition) \
     ((condition) || throw_param_exception(std::string("Assertion failed!") + #condition, __FILE__, __LINE__))

--- a/include/srexception.h
+++ b/include/srexception.h
@@ -203,8 +203,7 @@ class BadAllocException: public Exception
 };
 
 /*!
-*   \def SRBadAllocException Instantiate a BadAllocException with message
-*                            \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a BadAllocException with message
 */
 #define SRBadAllocException(txt) BadAllocException(txt, __FILE__, __LINE__)
 
@@ -227,8 +226,7 @@ class DatabaseException: public Exception
 };
 
 /*!
-*   \def SRDatabaseException Instantiate a DatabaseException with message
-*                            \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a DatabaseException with message
 */
 #define SRDatabaseException(txt) DatabaseException(txt, __FILE__, __LINE__)
 
@@ -251,9 +249,8 @@ class RuntimeException: public Exception
 };
 
 /*!
-*   \def SRRuntimeException Instantiate a RuntimeException with message
-*                           \a txt for file \a __FILE__, line \a __LINE__
-*/
+*   \brief Instantiate a RuntimeException with message
+\*/
 #define SRRuntimeException(txt) RuntimeException(txt, __FILE__, __LINE__)
 
 
@@ -275,8 +272,7 @@ class ParameterException: public Exception
 };
 
 /*!
-*   \def SRParameterException Instantiate a ParameterException with message
-*                             \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a ParameterException with message
 */
 #define SRParameterException(txt) ParameterException(txt, __FILE__, __LINE__)
 
@@ -299,8 +295,7 @@ class TimeoutException: public Exception
 };
 
 /*!
-*   \def SRTimeoutException Instantiate a TimeoutException with message
-*                           \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a TimeoutException with message
 */
 #define SRTimeoutException(txt) TimeoutException(txt, __FILE__, __LINE__)
 
@@ -323,8 +318,7 @@ class InternalException: public Exception
 };
 
 /*!
-*   \def SRInternalException Instantiate a InternalException with message
-*                            \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a InternalException with message
 */
 #define SRInternalException(txt) InternalException(txt, __FILE__, __LINE__)
 
@@ -347,8 +341,7 @@ class KeyException: public Exception
 };
 
 /*!
-*   \def SRKeyException Instantiate a KeyException with message
-*                       \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a KeyException with message
 */
 #define SRKeyException(txt) KeyException(txt, __FILE__, __LINE__)
 
@@ -370,8 +363,7 @@ class TypeException: public Exception
 };
 
 /*!
-*   \def SRTypeException Instantiate a TypeException with message
-*                        \a txt for file \a __FILE__, line \a __LINE__
+*   \brief Instantiate a TypeException with message
 */
 #define SRTypeException(txt) TypeException(txt, __FILE__, __LINE__)
 

--- a/include/tensorpack.h
+++ b/include/tensorpack.h
@@ -117,14 +117,14 @@ class TensorPack
         void add_tensor(TensorBase* tensor);
 
         /*!
-        *   \typedef An iterator type for iterating
+        *   \brief An iterator type for iterating
         *            over all TensorBase items
         */
         typedef std::forward_list<TensorBase*>::iterator
                 tensorbase_iterator;
 
         /*!
-        *   \typedef A const iterator type for iterating
+        *   \brief A const iterator type for iterating
         *            over all TensorBase items
         */
         typedef std::forward_list<TensorBase*>::const_iterator

--- a/src/fortran/client/put_tensor_methods_common.inc
+++ b/src/fortran/client/put_tensor_methods_common.inc
@@ -26,6 +26,11 @@
 
   !** Beginning of code common to all put_tensor subroutines
 
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  MODULE PUT_TENSOR_METHODS_COMMON
+#endif
+
   class(client_type),                    intent(in) :: self !< Fortran SLIC client
   character(len=*),                      intent(in) :: key  !< The unique key used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -51,5 +56,10 @@
 
   c_dims(:) = dims(:)
   c_dims_ptr = c_loc(c_dims)
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  END
+#endif
 
   !** End of code common to all put_tensor subroutines

--- a/src/fortran/client/put_tensor_methods_common.inc
+++ b/src/fortran/client/put_tensor_methods_common.inc
@@ -26,11 +26,6 @@
 
   !** Beginning of code common to all put_tensor subroutines
 
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  MODULE PUT_TENSOR_METHODS_COMMON
-#endif
-
   class(client_type),                    intent(in) :: self !< Fortran SLIC client
   character(len=*),                      intent(in) :: key  !< The unique key used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -56,10 +51,5 @@
 
   c_dims(:) = dims(:)
   c_dims_ptr = c_loc(c_dims)
-
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  END
-#endif
 
   !** End of code common to all put_tensor subroutines

--- a/src/fortran/client/unpack_tensor_methods_common.inc
+++ b/src/fortran/client/unpack_tensor_methods_common.inc
@@ -24,6 +24,13 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+  !** Beginning of code common to all unpack_tensor subroutines
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  MODULE UNPACK_TENSOR_METHODS_COMMON
+#endif
+
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: key   !< The key to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -44,3 +51,10 @@
   c_n_dims = size(dims)
   c_dims_ptr = c_loc(c_dims)
   mem_layout = c_fortran_contiguous
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  END
+#endif
+
+  !** End of code common to all unpack_tensor subroutines

--- a/src/fortran/client/unpack_tensor_methods_common.inc
+++ b/src/fortran/client/unpack_tensor_methods_common.inc
@@ -26,11 +26,6 @@
 
   !** Beginning of code common to all unpack_tensor subroutines
 
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  MODULE UNPACK_TENSOR_METHODS_COMMON
-#endif
-
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: key   !< The key to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -51,10 +46,5 @@
   c_n_dims = size(dims)
   c_dims_ptr = c_loc(c_dims)
   mem_layout = c_fortran_contiguous
-
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  END
-#endif
 
   !** End of code common to all unpack_tensor subroutines

--- a/src/fortran/dataset/add_meta_scalar_common.inc
+++ b/src/fortran/dataset/add_meta_scalar_common.inc
@@ -26,11 +26,6 @@
 
   !** Beginning of code common to all add_meta_scalar subroutines
 
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  MODULE ADD_META_SCALAR_COMMON
-#endif
-
   character(kind=c_char, len=len_trim(name))  :: c_name
   integer(kind=enum_kind) :: c_data_type, expected_data_type
   integer(kind=c_size_t) :: name_length
@@ -41,10 +36,5 @@
   meta_ptr = c_loc(meta)
 
   code = add_meta_scalar_c(self%dataset_ptr, c_name, name_length, meta_ptr, meta_type)
-
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  END
-#endif
 
   !** End of code common to all add_meta_scalar subroutines

--- a/src/fortran/dataset/add_meta_scalar_common.inc
+++ b/src/fortran/dataset/add_meta_scalar_common.inc
@@ -24,6 +24,13 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+  !** Beginning of code common to all add_meta_scalar subroutines
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  MODULE ADD_META_SCALAR_COMMON
+#endif
+
   character(kind=c_char, len=len_trim(name))  :: c_name
   integer(kind=enum_kind) :: c_data_type, expected_data_type
   integer(kind=c_size_t) :: name_length
@@ -34,3 +41,10 @@
   meta_ptr = c_loc(meta)
 
   code = add_meta_scalar_c(self%dataset_ptr, c_name, name_length, meta_ptr, meta_type)
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  END
+#endif
+
+  !** End of code common to all add_meta_scalar subroutines

--- a/src/fortran/dataset/add_tensor_methods_common.inc
+++ b/src/fortran/dataset/add_tensor_methods_common.inc
@@ -24,7 +24,12 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-  !** Beginning of code common to all put_tensor subroutines
+  !** Beginning of code common to all add_tensor subroutines
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  MODULE ADD_TENSOR_COMMON
+#endif
 
   class(dataset_type),   intent(in)  :: self !< Fortran SLIC dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
@@ -51,4 +56,9 @@
   c_dims(:) = dims(:)
   c_dims_ptr = c_loc(c_dims)
 
-  !** End of code common to all put_tensor subroutines
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  END
+#endif
+
+  !** End of code common to all add_tensor subroutines

--- a/src/fortran/dataset/add_tensor_methods_common.inc
+++ b/src/fortran/dataset/add_tensor_methods_common.inc
@@ -26,11 +26,6 @@
 
   !** Beginning of code common to all add_tensor subroutines
 
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  MODULE ADD_TENSOR_COMMON
-#endif
-
   class(dataset_type),   intent(in)  :: self !< Fortran SLIC dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -55,10 +50,5 @@
 
   c_dims(:) = dims(:)
   c_dims_ptr = c_loc(c_dims)
-
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  END
-#endif
 
   !** End of code common to all add_tensor subroutines

--- a/src/fortran/dataset/get_meta_scalars_common.inc
+++ b/src/fortran/dataset/get_meta_scalars_common.inc
@@ -26,12 +26,6 @@
 
   !** Beginning of code common to all get_meta_scalar subroutines
 
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  MODULE GET_META_SCALAR_COMMON
-#endif
-
-
   character(kind=c_char, len=len_trim(name))  :: c_name
   integer(kind=enum_kind) :: c_data_type
   integer(kind=c_size_t) :: name_length, meta_length
@@ -41,10 +35,5 @@
   name_length = len_trim(name)
   code = get_meta_scalars_c(self%dataset_ptr, c_name, name_length, meta_length, c_data_type, result_ptr)
   call c_f_pointer(result_ptr, meta, [meta_length])
-
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  END
-#endif
 
   !** End of code common to all get_meta_scalar subroutines

--- a/src/fortran/dataset/get_meta_scalars_common.inc
+++ b/src/fortran/dataset/get_meta_scalars_common.inc
@@ -24,6 +24,14 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+  !** Beginning of code common to all get_meta_scalar subroutines
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  MODULE GET_META_SCALAR_COMMON
+#endif
+
+
   character(kind=c_char, len=len_trim(name))  :: c_name
   integer(kind=enum_kind) :: c_data_type
   integer(kind=c_size_t) :: name_length, meta_length
@@ -33,3 +41,10 @@
   name_length = len_trim(name)
   code = get_meta_scalars_c(self%dataset_ptr, c_name, name_length, meta_length, c_data_type, result_ptr)
   call c_f_pointer(result_ptr, meta, [meta_length])
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  END
+#endif
+
+  !** End of code common to all get_meta_scalar subroutines

--- a/src/fortran/dataset/unpack_dataset_tensor_methods_common.inc
+++ b/src/fortran/dataset/unpack_dataset_tensor_methods_common.inc
@@ -26,12 +26,6 @@
 
   !** Beginning of code common to all unpack_dataset_tensor subroutines
 
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  MODULE UNPACK_DATASET_TENSOR_COMMON
-#endif
-
-
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -52,10 +46,5 @@
   c_n_dims = size(dims)
   c_dims_ptr = c_loc(c_dims)
   mem_layout = c_fortran_contiguous
-
-#ifdef DOXYGEN
-  ! Lie to Doxygen to get it to process these parameters
-  END
-#endif
 
   !** End of code common to all unpack_dataset_tensor subroutines

--- a/src/fortran/dataset/unpack_dataset_tensor_methods_common.inc
+++ b/src/fortran/dataset/unpack_dataset_tensor_methods_common.inc
@@ -24,6 +24,14 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+  !** Beginning of code common to all unpack_dataset_tensor subroutines
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  MODULE UNPACK_DATASET_TENSOR_COMMON
+#endif
+
+
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -44,3 +52,10 @@
   c_n_dims = size(dims)
   c_dims_ptr = c_loc(c_dims)
   mem_layout = c_fortran_contiguous
+
+#ifdef DOXYGEN
+  ! Lie to Doxygen to get it to process these parameters
+  END
+#endif
+
+  !** End of code common to all unpack_dataset_tensor subroutines


### PR DESCRIPTION
This PR squashes almost all of the build warnings generated when building docs for SmartRedis.

The only warnings left are from the cases where FORTRAN common methods are included from a secondary file. This fails because Doxygen is not a true compiler and does not actually parse the inclusion correctly. Rather, it does everything file-by-file. To fix this, we would have to make major structural changes to the way we do common methods in FORTRAN, and that would be extremely high risk this close to a release.