### PR TITLE
Clean up usage of name and key in source code

### DIFF
--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -177,8 +177,8 @@ class PyClient
         *   \throw RuntimeException for all client errors
         */
         void set_script_from_file(const std::string& name,
-                                const std::string& device,
-                                const std::string& script_file);
+                                  const std::string& device,
+                                  const std::string& script_file);
 
         /*!
         *   \brief Set a script from std::string_view buffer in the
@@ -210,7 +210,7 @@ class PyClient
         *   \param name The name associated with the script
         *   \param function The name of the function in the script
         *                   to run
-        *   \param inputs The names of inputs tensors to use
+        *   \param inputs The names of input tensors to use
         *                 in the script
         *   \param outputs The names of output tensors that
         *                 will be used to save script results
@@ -289,7 +289,7 @@ class PyClient
         *   \brief Run a model in the database using the
         *          specificed input and output tensors
         *   \param name The name associated with the model
-        *   \param inputs The names of inputs tensors to use
+        *   \param inputs The names of input tensors to use
         *                 in the model
         *   \param outputs The names of output tensors that
         *                 will be used to save model results
@@ -352,8 +352,7 @@ class PyClient
         *   \param key The key that will be checked in the database
         *   \param poll_frequency_ms The frequency of checks for the
         *                            key in milliseconds
-        *   \param num_tries The total number of times to check for
-        *                    the specified number of keys.
+        *   \param num_tries The total number of times to check for the key.
         *   \returns Returns true if the key is found within the
         *            specified number of tries, otherwise false.
         */
@@ -370,8 +369,8 @@ class PyClient
         *   \param poll_frequency_ms The frequency of checks for the
         *                            name in milliseconds
         *   \param num_tries The total number of times to check for
-        *                    the specified number of names.
-        *   \returns Returns true if the name is found within the
+        *                    the tensor.
+        *   \returns Returns true if the tensor is found within the
         *            specified number of tries, otherwise false.
         */
         bool poll_tensor(const std::string& name,
@@ -390,8 +389,8 @@ class PyClient
         *   \param poll_frequency_ms The frequency of checks for the
         *                            name in milliseconds
         *   \param num_tries The total number of times to check for
-        *                    the specified number of names.
-        *   \returns Returns true if the name is found within the
+        *                    the dataset.
+        *   \returns Returns true if the dataset is found within the
         *            specified number of tries, otherwise false.
         */
         bool poll_dataset(const std::string& name,
@@ -407,8 +406,8 @@ class PyClient
         *   \param poll_frequency_ms The frequency of checks for the
         *                            name in milliseconds
         *   \param num_tries The total number of times to check for
-        *                    the specified number of names.
-        *   \returns Returns true if the name is found within the
+        *                    the model or script.
+        *   \returns Returns true if the model or script is found within the
         *            specified number of tries, otherwise false.
         */
         bool poll_model(const std::string& name,

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -70,13 +70,13 @@ class PyClient
 
         /*!
         *   \brief Put a tensor into the database
-        *   \param key The key to associate with this tensor
+        *   \param name The name to associate with this tensor
         *              in the database
         *   \param type The data type of the tensor
         *   \param data Numpy array with Pybind*
         *   \throw RuntimeException for all client errors
         */
-        void put_tensor(std::string& key,
+        void put_tensor(std::string& name,
                         std::string& type,
                         py::array data);
 
@@ -92,35 +92,35 @@ class PyClient
         *            data.  Instead it is recommended that the user
         *            use PyClient.unpack_tensor() for large tensor
         *            data and to limit memory use by the PyClient.
-        *   \param key The name used to reference the tensor
+        *   \param name The name used to reference the tensor
         *   \throw RuntimeException for all client errors
         */
-        py::array get_tensor(const std::string& key);
+        py::array get_tensor(const std::string& name);
 
         /*!
         *   \brief delete a tensor stored in the database
-        *   \param key The key of tensor to delete
+        *   \param name The name of tensor to delete
         *   \throw RuntimeException for all client errors
         */
-        void delete_tensor(const std::string& key);
+        void delete_tensor(const std::string& name);
 
         /*!
         *   \brief rename a tensor stored in the database
-        *   \param key The key of tensor to rename
-        *   \param new_key the new name of the tensor
+        *   \param old_name The original name of tensor to rename
+        *   \param new_name the new name of the tensor
         *   \throw RuntimeException for all client errors
         */
-        void rename_tensor(const std::string& key,
-                           const std::string& new_key);
+        void rename_tensor(const std::string& old_name,
+                           const std::string& new_name);
 
         /*!
-        *   \brief copy a tensor to a new key
-        *   \param key The key of tensor to copy
-        *   \param dest_key the key to store tensor copy at
+        *   \brief copy a tensor to a new name
+        *   \param src_name The name of tensor to copy
+        *   \param dest_name the name to store tensor copy at
         *   \throw RuntimeException for all client errors
         */
-        void copy_tensor(const std::string& key,
-                         const std::string& dest_key);
+        void copy_tensor(const std::string& src_name,
+                         const std::string& dest_name);
 
 
         /*!
@@ -143,78 +143,80 @@ class PyClient
 
         /*!
         *   \brief delete a dataset stored in the database
-        *   \param key The key of dataset to delete
+        *   \param name The name of dataset to delete
         *   \throw RuntimeException for all client errors
         */
-        void delete_dataset(const std::string& key);
+        void delete_dataset(const std::string& name);
 
         /*!
         *   \brief rename a dataset stored in the database
-        *   \param key The key of dataset to rename
-        *   \param new_key the new name of the dataset
+        *   \param old_name The original name of dataset to rename
+        *   \param new_name the new name for the dataset
         *   \throw RuntimeException for all client errors
         */
-        void rename_dataset(const std::string& key, const std::string& new_key);
+        void rename_dataset(const std::string& old_name,
+                            const std::string& new_name);
 
         /*!
-        *   \brief copy a dataset to a new key
-        *   \param key The key of datalset to copy
-        *   \param dest_key the key to store dataset copy at
+        *   \brief copy a dataset to a new name
+        *   \param src_name The name of dataset to copy
+        *   \param dest_name the name to store dataset copy at
         *   \throw RuntimeException for all client errors
         */
-        void copy_dataset(const std::string& key, const std::string& dest_key);
+        void copy_dataset(const std::string& src_name,
+                          const std::string& dest_name);
 
 
         /*!
         *   \brief Set a script from file in the
         *          database for future execution
-        *   \param key The key to associate with the script
+        *   \param name The name to associate with the script
         *   \param device The name of the device for execution
         *                 (e.g. CPU or GPU)
         *   \param script_file The source file for the script
         *   \throw RuntimeException for all client errors
         */
-        void set_script_from_file(const std::string& key,
+        void set_script_from_file(const std::string& name,
                                 const std::string& device,
                                 const std::string& script_file);
 
         /*!
         *   \brief Set a script from std::string_view buffer in the
         *          database for future execution
-        *   \param key The key to associate with the script
+        *   \param name The name to associate with the script
         *   \param device The name of the device for execution
         *                 (e.g. CPU or GPU)
         *   \param script The script source in a std::string_view
         *   \throw RuntimeException for all client errors
         */
-        void set_script(const std::string& key,
+        void set_script(const std::string& name,
                         const std::string& device,
                         const std::string_view& script);
 
         /*!
         *   \brief Retrieve the script from the database
-        *   \param key The key associated with the script
+        *   \param name The name associated with the script
         *   \returns A std::string_view containing the script.
         *            The memory associated with the script
         *            is managed by the PyClient and is valid
         *            until the destruction of the PyClient.
         *   \throw RuntimeException for all client errors
         */
-        std::string_view get_script(const std::string& key);
+        std::string_view get_script(const std::string& name);
 
         /*!
         *   \brief Run a script function in the database using the
         *          specificed input and output tensors
-        *   \param key The key associated with the script
+        *   \param name The name associated with the script
         *   \param function The name of the function in the script
         *                   to run
-        *   \param inputs The keys of inputs tensors to use
+        *   \param inputs The names of inputs tensors to use
         *                 in the script
-        *   \param outputs The keys of output tensors that
+        *   \param outputs The names of output tensors that
         *                 will be used to save script results
         *   \throw RuntimeException for all client errors
         */
-        void run_script(const std::string& key,
+        void run_script(const std::string& name,
                         const std::string& function,
                         std::vector<std::string>& inputs,
                         std::vector<std::string>& outputs);
@@ -222,7 +224,7 @@ class PyClient
         /*!
         *   \brief Set a model from std::string_view buffer in the
         *          database for future execution
-        *   \param key The key to associate with the model
+        *   \param name The name to associate with the model
         *   \param model The model as a continuous buffer string_view
         *   \param backend The name of the backend
         *                  (TF, TFLITE, TORCH, ONNX)
@@ -239,7 +241,7 @@ class PyClient
         *                 (TF models only)
         *   \throw RuntimeException for all client errors
         */
-        void set_model(const std::string& key,
+        void set_model(const std::string& name,
                         const std::string_view& model,
                         const std::string& backend,
                         const std::string& device,
@@ -254,7 +256,7 @@ class PyClient
         /*!
         *   \brief Set a model from file in the
         *          database for future execution
-        *   \param key The key to associate with the model
+        *   \param name The name to associate with the model
         *   \param model_file The source file for the model
         *   \param backend The name of the backend
         *                  (TF, TFLITE, TORCH, ONNX)
@@ -271,7 +273,7 @@ class PyClient
         *                 (TF models only)
         *   \throw RuntimeException for all client errors
         */
-        void set_model_from_file(const std::string& key,
+        void set_model_from_file(const std::string& name,
                                 const std::string& model_file,
                                 const std::string& backend,
                                 const std::string& device,
@@ -286,24 +288,24 @@ class PyClient
         /*!
         *   \brief Run a model in the database using the
         *          specificed input and output tensors
-        *   \param key The key associated with the model
-        *   \param inputs The keys of inputs tensors to use
+        *   \param name The name associated with the model
+        *   \param inputs The names of inputs tensors to use
         *                 in the model
-        *   \param outputs The keys of output tensors that
+        *   \param outputs The names of output tensors that
         *                 will be used to save model results
         *   \throw RuntimeException for all client errors
         */
-        void run_model(const std::string& key,
+        void run_model(const std::string& name,
                         std::vector<std::string> inputs,
                         std::vector<std::string> outputs);
 
         /*!
         *   \brief Retrieve the model from the database
-        *   \param key The key associated with the model
+        *   \param name The name associated with the model
         *   \returns A py:bytes object containing the model
         *   \throw RuntimeException for all client errors
         */
-        py::bytes get_model(const std::string& key);
+        py::bytes get_model(const std::string& name);
 
         /*!
         *   \brief Check if the key exists in the database
@@ -364,12 +366,12 @@ class PyClient
         *          specified frequency for a specified number
         *          of times. The name will be automatically prefixed
         *          base on prefixing behavior.
-        *   \param name The key that will be checked in the database
+        *   \param name The name that will be checked in the database
         *   \param poll_frequency_ms The frequency of checks for the
-        *                            key in milliseconds
+        *                            name in milliseconds
         *   \param num_tries The total number of times to check for
-        *                    the specified number of keys.
-        *   \returns Returns true if the key is found within the
+        *                    the specified number of names.
+        *   \returns Returns true if the name is found within the
         *            specified number of tries, otherwise false.
         */
         bool poll_tensor(const std::string& name,
@@ -381,15 +383,15 @@ class PyClient
         *          specified frequency for a specified number
         *          of times. The name will be automatically prefixed
         *          base on prefixing behavior.
-        *   \param name The key that will be checked in the database
+        *   \param name The name that will be checked in the database
         *               Depending on the current prefixing behavior,
         *               the name could be automatically prefixed
-        *               to form the corresponding key.
+        *               to form the corresponding name.
         *   \param poll_frequency_ms The frequency of checks for the
-        *                            key in milliseconds
+        *                            name in milliseconds
         *   \param num_tries The total number of times to check for
-        *                    the specified number of keys.
-        *   \returns Returns true if the key is found within the
+        *                    the specified number of names.
+        *   \returns Returns true if the name is found within the
         *            specified number of tries, otherwise false.
         */
         bool poll_dataset(const std::string& name,
@@ -401,12 +403,12 @@ class PyClient
         *          specified frequency for a specified number
         *          of times. The name will be automatically prefixed
         *          base on prefixing behavior.
-        *   \param name The key that will be checked in the database
+        *   \param name The name that will be checked in the database
         *   \param poll_frequency_ms The frequency of checks for the
-        *                            key in milliseconds
+        *                            name in milliseconds
         *   \param num_tries The total number of times to check for
-        *                    the specified number of keys.
-        *   \returns Returns true if the key is found within the
+        *                    the specified number of names.
+        *   \returns Returns true if the name is found within the
         *            specified number of tries, otherwise false.
         */
         bool poll_model(const std::string& name,

--- a/src/c/c_client.cpp
+++ b/src/c/c_client.cpp
@@ -157,18 +157,18 @@ SRError get_dataset(void* c_client, const char* name,
 
 // Rename a dataset in the database.
 extern "C"
-SRError rename_dataset(void* c_client, const char* name,
-                       const size_t name_length, const char* new_name,
+SRError rename_dataset(void* c_client, const char* old_name,
+                       const size_t old_name_length, const char* new_name,
                        const size_t new_name_length)
 {
   SRError result = SRNoError;
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && name != NULL && new_name != NULL);
+    SR_CHECK_PARAMS(c_client != NULL && old_name != NULL && new_name != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string name_str(name, name_length);
+    std::string name_str(old_name, old_name_length);
     std::string new_name_str(new_name, new_name_length);
 
     s->rename_dataset(name_str, new_name_str);
@@ -245,8 +245,8 @@ SRError delete_dataset(void* c_client, const char* name, const size_t name_lengt
 // Put a tensor of a specified type into the database
 extern "C"
 SRError put_tensor(void* c_client,
-                  const char* key,
-                  const size_t key_length,
+                  const char* name,
+                  const size_t name_length,
                   void* data,
                   const size_t* dims,
                   const size_t n_dims,
@@ -257,16 +257,16 @@ SRError put_tensor(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL &&
                     data != NULL && dims != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
 
     std::vector<size_t> dims_vec;
     dims_vec.assign(dims, dims + n_dims);
 
-    s->put_tensor(key_str, data, dims_vec, type, mem_layout);
+    s->put_tensor(name_str, data, dims_vec, type, mem_layout);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -283,8 +283,8 @@ SRError put_tensor(void* c_client,
 // Get a tensor of a specified type from the database
 extern "C"
 SRError get_tensor(void* c_client,
-                  const char* key,
-                  const size_t key_length,
+                  const char* name,
+                  const size_t name_length,
                   void** result,
                   size_t** dims,
                   size_t* n_dims,
@@ -295,13 +295,13 @@ SRError get_tensor(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && result != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && result != NULL &&
                     dims != NULL && n_dims != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
 
-    s->get_tensor(key_str, *result, *dims, *n_dims, *type, mem_layout);
+    s->get_tensor(name_str, *result, *dims, *n_dims, *type, mem_layout);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -319,8 +319,8 @@ SRError get_tensor(void* c_client,
 // and put the values into the user provided memory space.
 extern "C"
 SRError unpack_tensor(void* c_client,
-                     const char* key,
-                     const size_t key_length,
+                     const char* name,
+                     const size_t name_length,
                      void* result,
                      const size_t* dims,
                      const size_t n_dims,
@@ -331,16 +331,16 @@ SRError unpack_tensor(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && result != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && result != NULL &&
                     dims != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
 
     std::vector<size_t> dims_vec;
     dims_vec.assign(dims, dims + n_dims);
 
-    s->unpack_tensor(key_str, result, dims_vec, type, mem_layout);
+    s->unpack_tensor(name_str, result, dims_vec, type, mem_layout);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -354,23 +354,23 @@ SRError unpack_tensor(void* c_client,
   return outcome;
 }
 
-// Rename a tensor from key to new_key
+// Rename a tensor from old_name to new_name
 extern "C"
-SRError rename_tensor(void* c_client, const char* key,
-                     const size_t key_length, const char* new_key,
-                     const size_t new_key_length)
+SRError rename_tensor(void* c_client,
+                      const char* old_name, const size_t old_name_length,
+                      const char* new_name, const size_t new_name_length)
 {
   SRError result = SRNoError;
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && new_key != NULL);
+    SR_CHECK_PARAMS(c_client != NULL && old_name != NULL && new_name != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
-    std::string new_key_str(new_key, new_key_length);
+    std::string old_name_str(old_name, old_name_length);
+    std::string new_name_str(new_name, new_name_length);
 
-    s->rename_tensor(key_str, new_key_str);
+    s->rename_tensor(old_name_str, new_name_str);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -386,19 +386,19 @@ SRError rename_tensor(void* c_client, const char* key,
 
 // Delete a tensor from the database.
 extern "C"
-SRError delete_tensor(void* c_client, const char* key,
-                      const size_t key_length)
+SRError delete_tensor(void* c_client, const char* name,
+                      const size_t name_length)
 {
   SRError result = SRNoError;
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL);
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
 
-    s->delete_tensor(key_str);
+    s->delete_tensor(name_str);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -462,7 +462,7 @@ bool CompareCaseInsensitive(const char* a,const char* b) {
 // Set a model stored in a binary file.
 extern "C"
 SRError set_model_from_file(void* c_client,
-                           const char* key, const size_t key_length,
+                           const char* name, const size_t name_length,
                            const char* model_file, const size_t model_file_length,
                            const char* backend, const size_t backend_length,
                            const char* device, const size_t device_length,
@@ -478,7 +478,7 @@ SRError set_model_from_file(void* c_client,
   {
     // Sanity check params. Tag is strictly optional, and inputs/outputs are
     // mandatory IFF backend is TensorFlow (TF or TFLITE)
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && model_file != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && model_file != NULL &&
                     backend != NULL && device != NULL);
     bool isTensorFlow = CompareCaseInsensitive(backend, "TF") || CompareCaseInsensitive(backend, "TFLITE");
     if (isTensorFlow) {
@@ -511,7 +511,7 @@ SRError set_model_from_file(void* c_client,
     }
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
     std::string model_file_str(model_file, model_file_length);
     std::string backend_str(backend, backend_length);
     std::string device_str(device, device_length);
@@ -536,7 +536,7 @@ SRError set_model_from_file(void* c_client,
       }
     }
 
-    s->set_model_from_file(key_str, model_file_str, backend_str, device_str,
+    s->set_model_from_file(name_str, model_file_str, backend_str, device_str,
                            batch_size, min_batch_size, tag_str, input_vec,
                            output_vec);
   }
@@ -555,7 +555,7 @@ SRError set_model_from_file(void* c_client,
 // Set a model stored in a buffer c-string.
 extern "C"
 SRError set_model(void* c_client,
-                 const char* key, const size_t key_length,
+                 const char* name, const size_t name_length,
                  const char* model, const size_t model_length,
                  const char* backend, const size_t backend_length,
                  const char* device, const size_t device_length,
@@ -571,7 +571,7 @@ SRError set_model(void* c_client,
   {
     // Sanity check params. Tag is strictly optional, and inputs/outputs are
     // mandatory IFF backend is TensorFlow (TF or TFLITE)
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && model != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && model != NULL &&
                     backend != NULL && device != NULL);
     bool isTensorFlow = CompareCaseInsensitive(backend, "TF") || CompareCaseInsensitive(backend, "TFLITE");
     if (isTensorFlow) {
@@ -604,7 +604,7 @@ SRError set_model(void* c_client,
     }
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
     std::string model_str(model, model_length);
     std::string backend_str(backend, backend_length);
     std::string device_str(device, device_length);
@@ -629,7 +629,7 @@ SRError set_model(void* c_client,
       }
     }
 
-    s->set_model(key_str, model_str, backend_str, device_str,
+    s->set_model(name_str, model_str, backend_str, device_str,
                 batch_size, min_batch_size, tag_str, input_vec,
                 output_vec);
   }
@@ -648,8 +648,8 @@ SRError set_model(void* c_client,
 // Retrieve the model and model length from the database
 extern "C"
 SRError get_model(void* c_client,
-                  const char* key,
-                  const size_t key_length,
+                  const char* name,
+                  const size_t name_length,
                   size_t* model_length,
                   const char** model)
 {
@@ -657,12 +657,12 @@ SRError get_model(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && model_length != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && model_length != NULL &&
                     model != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
-    std::string_view model_str_view(s->get_model(key_str));
+    std::string name_str(name, name_length);
+    std::string_view model_str_view(s->get_model(name_str));
 
     *model_length = model_str_view.size();
     *model = model_str_view.data();
@@ -682,8 +682,8 @@ SRError get_model(void* c_client,
 // Put a script in the database that is stored in a file.
 extern "C"
 SRError set_script_from_file(void* c_client,
-                            const char* key,
-                            const size_t key_length,
+                            const char* name,
+                            const size_t name_length,
                             const char* device,
                             const size_t device_length,
                             const char* script_file,
@@ -693,15 +693,15 @@ SRError set_script_from_file(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && device != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && device != NULL &&
                     script_file != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
     std::string device_str(device, device_length);
     std::string script_file_str(script_file, script_file_length);
 
-    s->set_script_from_file(key_str, device_str, script_file_str);
+    s->set_script_from_file(name_str, device_str, script_file_str);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -718,8 +718,8 @@ SRError set_script_from_file(void* c_client,
 // Put a script in the database that is stored in a string.
 extern "C"
 SRError set_script(void* c_client,
-                  const char* key,
-                  const size_t key_length,
+                  const char* name,
+                  const size_t name_length,
                   const char* device,
                   const size_t device_length,
                   const char* script,
@@ -729,16 +729,16 @@ SRError set_script(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && device != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && device != NULL &&
                     script != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
 
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
     std::string device_str(device, device_length);
     std::string script_str(script, script_length);
 
-    s->set_script(key_str, device_str, script_str);
+    s->set_script(name_str, device_str, script_str);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -755,8 +755,8 @@ SRError set_script(void* c_client,
 // Retrieve the script stored in the database
 extern "C"
 SRError get_script(void* c_client,
-                  const char* key,
-                  const size_t key_length,
+                  const char* name,
+                  const size_t name_length,
                   const char** script,
                   size_t* script_length)
 {
@@ -764,12 +764,12 @@ SRError get_script(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && script != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && script != NULL &&
                     script_length != NULL);
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    std::string key_str(key, key_length);
-    std::string_view script_str_view(s->get_script(key_str));
+    std::string name_str(name, name_length);
+    std::string_view script_str_view(s->get_script(name_str));
 
     (*script) = script_str_view.data();
     (*script_length) = script_str_view.size();
@@ -789,8 +789,8 @@ SRError get_script(void* c_client,
 // Run  a script function in the database
 extern "C"
 SRError run_script(void* c_client,
-                  const char* key,
-                  const size_t key_length,
+                  const char* name,
+                  const size_t name_length,
                   const char* function,
                   const size_t function_length,
                   const char** inputs,
@@ -804,7 +804,7 @@ SRError run_script(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL && function != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL && function != NULL &&
                     inputs != NULL && input_lengths != NULL &&
                     outputs != NULL && output_lengths != NULL);
 
@@ -822,7 +822,7 @@ SRError run_script(void* c_client,
       }
     }
 
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
     std::string function_str(function, function_length);
 
     std::vector<std::string> input_vec;
@@ -840,7 +840,7 @@ SRError run_script(void* c_client,
     }
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    s->run_script(key_str, function_str, input_vec, output_vec);
+    s->run_script(name_str, function_str, input_vec, output_vec);
   }
   catch (const Exception& e) {
     SRSetLastError(e);
@@ -857,8 +857,8 @@ SRError run_script(void* c_client,
 // Run a model in the database
 extern "C"
 SRError run_model(void* c_client,
-                 const char* key,
-                 const size_t key_length,
+                 const char* name,
+                 const size_t name_length,
                  const char** inputs,
                  const size_t* input_lengths,
                  const size_t n_inputs,
@@ -870,7 +870,7 @@ SRError run_model(void* c_client,
   try
   {
     // Sanity check params
-    SR_CHECK_PARAMS(c_client != NULL && key != NULL &&
+    SR_CHECK_PARAMS(c_client != NULL && name != NULL &&
                     inputs != NULL && input_lengths != NULL &&
                     outputs != NULL && output_lengths != NULL);
 
@@ -888,7 +888,7 @@ SRError run_model(void* c_client,
       }
     }
 
-    std::string key_str(key, key_length);
+    std::string name_str(name, name_length);
 
     std::vector<std::string> input_vec;
     if (n_inputs != 1 || input_lengths[0] != 0) {
@@ -905,7 +905,7 @@ SRError run_model(void* c_client,
     }
 
     Client* s = reinterpret_cast<Client*>(c_client);
-    s->run_model(key_str, input_vec, output_vec);
+    s->run_model(name_str, input_vec, output_vec);
   }
   catch (const Exception& e) {
     SRSetLastError(e);

--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -92,7 +92,7 @@ type, public :: client_type
   procedure :: rename_tensor
   !> Delete a tensor from the database
   procedure :: delete_tensor
-  !> Copy a tensor within the database to a new key
+  !> Copy a tensor within the database to a new name
   procedure :: copy_tensor
   !> Set a model from a file
   procedure :: set_model_from_file
@@ -116,7 +116,7 @@ type, public :: client_type
   procedure :: get_dataset
   !> Rename the dataset within the database
   procedure :: rename_dataset
-  !> Copy a dataset stored in the database into another key
+  !> Copy a dataset stored in the database into another name
   procedure :: copy_dataset
   !> Delete the dataset from the database
   procedure :: delete_dataset
@@ -271,7 +271,7 @@ end function dataset_exists
 !> Repeatedly poll the database until the tensor exists or the number of tries is exceeded
 function poll_tensor(self, tensor_name, poll_frequency_ms, num_tries, exists) result(code)
   class(client_type),   intent(in)  :: self              !< The client
-  character(len=*),     intent(in)  :: tensor_name       !< Key in the database to poll
+  character(len=*),     intent(in)  :: tensor_name       !< name in the database to poll
   integer,              intent(in)  :: poll_frequency_ms !< Frequency at which to poll the database (ms)
   integer,              intent(in)  :: num_tries         !< Number of times to poll the database before failing
   logical(kind=c_bool), intent(out) :: exists            !< Receives whether the tensor exists
@@ -294,7 +294,7 @@ end function poll_tensor
 function poll_dataset(self, dataset_name, poll_frequency_ms, num_tries, exists)
   integer(kind=enum_kind)           :: poll_dataset
   class(client_type),   intent(in)  :: self              !< The client
-  character(len=*),     intent(in)  :: dataset_name      !< Key in the database to poll
+  character(len=*),     intent(in)  :: dataset_name      !< Name in the database to poll
   integer,              intent(in)  :: poll_frequency_ms !< Frequency at which to poll the database (ms)
   integer,              intent(in)  :: num_tries         !< Number of times to poll the database before failing
   logical(kind=c_bool), intent(out) :: exists            !< Receives whether the tensor exists
@@ -315,7 +315,7 @@ end function poll_dataset
 !> Repeatedly poll the database until the model exists or the number of tries is exceeded
 function poll_model(self, model_name, poll_frequency_ms, num_tries, exists) result(code)
   class(client_type),   intent(in)  :: self              !< The client
-  character(len=*),     intent(in)  :: model_name        !< Key in the database to poll
+  character(len=*),     intent(in)  :: model_name        !< Name in the database to poll
   integer,              intent(in)  :: poll_frequency_ms !< Frequency at which to poll the database (ms)
   integer,              intent(in)  :: num_tries         !< Number of times to poll the database before failing
   logical(kind=c_bool), intent(out) :: exists            !< Receives whether the model exists
@@ -357,181 +357,181 @@ function poll_key(self, key, poll_frequency_ms, num_tries, exists) result(code)
 end function poll_key
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
-function put_tensor_i8(self, key, data, dims) result(code)
+function put_tensor_i8(self, name, data, dims) result(code)
   integer(kind=c_int8_t), dimension(..), target, intent(in) :: data !< Data to be sent
   include 'client/put_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int8
-  code = put_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, &
+  code = put_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, &
     c_n_dims, data_type, c_fortran_contiguous)
 end function put_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
-function put_tensor_i16(self, key, data, dims) result(code)
+function put_tensor_i16(self, name, data, dims) result(code)
   integer(kind=c_int16_t), dimension(..), target, intent(in) :: data !< Data to be sent
   include 'client/put_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int16
-  code = put_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = put_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, c_fortran_contiguous)
 end function put_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
-function put_tensor_i32(self, key, data, dims) result(code)
+function put_tensor_i32(self, name, data, dims) result(code)
   integer(kind=c_int32_t), dimension(..), target, intent(in) :: data !< Data to be sent
   include 'client/put_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int32
-  code = put_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = put_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, c_fortran_contiguous)
 end function put_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
-function put_tensor_i64(self, key, data, dims) result(code)
+function put_tensor_i64(self, name, data, dims) result(code)
   integer(kind=c_int64_t), dimension(..), target, intent(in) :: data !< Data to be sent
   include 'client/put_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int64
-  code = put_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = put_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, c_fortran_contiguous)
 end function put_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
-function put_tensor_float(self, key, data, dims) result(code)
+function put_tensor_float(self, name, data, dims) result(code)
   real(kind=c_float), dimension(..), target, intent(in) :: data !< Data to be sent
   include 'client/put_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_flt
-  code = put_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = put_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, c_fortran_contiguous)
 end function put_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
-function put_tensor_double(self, key, data, dims) result(code)
+function put_tensor_double(self, name, data, dims) result(code)
   real(kind=c_double), dimension(..), target, intent(in) :: data !< Data to be sent
   include 'client/put_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_dbl
-  code = put_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = put_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, c_fortran_contiguous)
 end function put_tensor_double
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
-function unpack_tensor_i8(self, key, result, dims) result(code)
+function unpack_tensor_i8(self, name, result, dims) result(code)
   integer(kind=c_int8_t), dimension(..), target, intent(out) :: result !< Data to be sent
   include 'client/unpack_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int8
-  code = unpack_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = unpack_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, mem_layout)
 end function unpack_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
-function unpack_tensor_i16(self, key, result, dims) result(code)
+function unpack_tensor_i16(self, name, result, dims) result(code)
   integer(kind=c_int16_t), dimension(..), target, intent(out) :: result !< Data to be sent
   include 'client/unpack_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int16
-  code = unpack_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = unpack_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, mem_layout)
 end function unpack_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
-function unpack_tensor_i32(self, key, result, dims) result(code)
+function unpack_tensor_i32(self, name, result, dims) result(code)
   integer(kind=c_int32_t), dimension(..), target, intent(out) :: result !< Data to be sent
   include 'client/unpack_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int32
-  code = unpack_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, c_n_dims, &
+  code = unpack_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, c_n_dims, &
     data_type, mem_layout)
 end function unpack_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
-function unpack_tensor_i64(self, key, result, dims) result(code)
+function unpack_tensor_i64(self, name, result, dims) result(code)
   integer(kind=c_int64_t), dimension(..), target, intent(out) :: result !< Data to be sent
   include 'client/unpack_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_int64
-  code = unpack_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, &
+  code = unpack_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, &
     c_n_dims, data_type, mem_layout)
 end function unpack_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
-function unpack_tensor_float(self, key, result, dims) result(code)
+function unpack_tensor_float(self, name, result, dims) result(code)
   real(kind=c_float), dimension(..), target, intent(out) :: result !< Data to be sent
   include 'client/unpack_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_flt
-  code = unpack_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, &
+  code = unpack_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, &
     c_n_dims, data_type, mem_layout)
 end function unpack_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
-function unpack_tensor_double(self, key, result, dims) result(code)
+function unpack_tensor_double(self, name, result, dims) result(code)
   real(kind=c_double), dimension(..), target, intent(out) :: result !< Data to be sent
   include 'client/unpack_tensor_methods_common.inc'
 
   ! Define the type and call the C-interface
   data_type = tensor_dbl
-  code = unpack_tensor_c(self%client_ptr, c_key, key_length, data_ptr, c_dims_ptr, &
+  code = unpack_tensor_c(self%client_ptr, c_name, name_length, data_ptr, c_dims_ptr, &
     c_n_dims, data_type, mem_layout)
 end function unpack_tensor_double
 
-!> Move a tensor to a new key
-function rename_tensor(self, key, new_key) result(code)
-  class(client_type), intent(in) :: self    !< The initialized Fortran SmartRedis client
-  character(len=*),   intent(in) :: key     !< The current key for the tensor
-                                            !! excluding null terminating character
-  character(len=*),   intent(in) :: new_key !< The new tensor key
+!> Move a tensor to a new name
+function rename_tensor(self, old_name, new_name) result(code)
+  class(client_type), intent(in) :: self     !< The initialized Fortran SmartRedis client
+  character(len=*),   intent(in) :: old_name !< The current name for the tensor
+                                             !! excluding null terminating character
+  character(len=*),   intent(in) :: new_name !< The new tensor name
   integer(kind=enum_kind)        :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
-  character(kind=c_char, len=len_trim(new_key)) :: c_new_key
-  integer(kind=c_size_t) :: key_length, new_key_length
+  character(kind=c_char, len=len_trim(old_name)) :: c_old_name
+  character(kind=c_char, len=len_trim(new_name)) :: c_new_name
+  integer(kind=c_size_t) :: old_name_length, new_name_length
 
-  c_key = trim(key)
-  c_new_key = trim(new_key)
+  c_old_name = trim(old_name)
+  c_new_name = trim(new_name)
 
-  key_length = len_trim(key)
-  new_key_length = len_trim(new_key)
+  old_name_length = len_trim(old_name)
+  new_name_length = len_trim(new_name)
 
-  code = rename_tensor_c(self%client_ptr, c_key, key_length, c_new_key, new_key_length)
+  code = rename_tensor_c(self%client_ptr, c_old_name, old_name_length, c_new_name, new_name_length)
 end function rename_tensor
 
 !> Delete a tensor
-function delete_tensor(self, key) result(code)
+function delete_tensor(self, name) result(code)
   class(client_type), intent(in) :: self !< The initialized Fortran SmartRedis client
-  character(len=*),   intent(in) :: key  !< The key associated with the tensor
+  character(len=*),   intent(in) :: name !< The name associated with the tensor
   integer(kind=enum_kind)        :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
-  integer(kind=c_size_t) :: key_length
+  character(kind=c_char, len=len_trim(name)) :: c_name
+  integer(kind=c_size_t) :: name_length
 
-  c_key = trim(key)
-  key_length = len_trim(key)
+  c_name = trim(name)
+  name_length = len_trim(name)
 
-  code = delete_tensor_c(self%client_ptr, c_key, key_length)
+  code = delete_tensor_c(self%client_ptr, c_name, name_length)
 end function delete_tensor
 
-!> Copy a tensor to the destination key
+!> Copy a tensor to the destination name
 function copy_tensor(self, src_name, dest_name) result(code)
   class(client_type), intent(in) :: self      !< The initialized Fortran SmartRedis client
-  character(len=*),   intent(in) :: src_name  !< The key associated with the tensor
+  character(len=*),   intent(in) :: src_name  !< The name associated with the tensor
                                               !! excluding null terminating character
-  character(len=*),   intent(in) :: dest_name !< The new tensor key
+  character(len=*),   intent(in) :: dest_name !< The new tensor name
   integer(kind=enum_kind)        :: code
 
   ! Local variables
@@ -549,23 +549,23 @@ function copy_tensor(self, src_name, dest_name) result(code)
 end function copy_tensor
 
 !> Retrieve the model from the database
-function get_model(self, key, model) result(code)
+function get_model(self, name, model) result(code)
   class(client_type),               intent(in  ) :: self  !< An initialized SmartRedis client
-  character(len=*),                 intent(in  ) :: key   !< The key associated with the model
+  character(len=*),                 intent(in  ) :: name  !< The name associated with the model
   character(len=*),                 intent( out) :: model !< The model as a continuous buffer
   integer(kind=enum_kind)                        :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
-  integer(kind=c_size_t) :: key_length, model_length
+  character(kind=c_char, len=len_trim(name)) :: c_name
+  integer(kind=c_size_t) :: name_length, model_length
   character(kind=c_char), dimension(:), pointer :: f_str_ptr
   type(c_ptr) :: c_str_ptr
   integer :: i
 
-  c_key = trim(key)
-  key_length = len_trim(key)
+  c_name = trim(name)
+  name_length = len_trim(name)
 
-  code = get_model_c(self%client_ptr, key, key_length, c_str_ptr, model_length, c_str_ptr)
+  code = get_model_c(self%client_ptr, name, name_length, c_str_ptr, model_length, c_str_ptr)
 
   call c_f_pointer(c_str_ptr, f_str_ptr, [ model_length ])
 
@@ -575,10 +575,10 @@ function get_model(self, key, model) result(code)
 end function get_model
 
 !> Load the machine learning model from a file and set the configuration
-function set_model_from_file(self, key, model_file, backend, device, batch_size, min_batch_size, tag, &
+function set_model_from_file(self, name, model_file, backend, device, batch_size, min_batch_size, tag, &
     inputs, outputs) result(code)
   class(client_type),                       intent(in) :: self           !< An initialized SmartRedis client
-  character(len=*),                         intent(in) :: key            !< The key to use to place the model
+  character(len=*),                         intent(in) :: name           !< The name to use to place the model
   character(len=*),                         intent(in) :: model_file     !< The file storing the model
   character(len=*),                         intent(in) :: backend        !< The name of the backend (TF, TFLITE, TORCH, ONNX)
   character(len=*),                         intent(in) :: device         !< The name of the device (CPU, GPU, GPU:0, GPU:1...)
@@ -592,7 +592,7 @@ function set_model_from_file(self, key, model_file, backend, device, batch_size,
   integer(kind=enum_kind)                              :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
+  character(kind=c_char, len=len_trim(name)) :: c_name
   character(kind=c_char, len=len_trim(model_file)) :: c_model_file
   character(kind=c_char, len=len_trim(backend)) :: c_backend
   character(kind=c_char, len=len_trim(device)) :: c_device
@@ -602,7 +602,7 @@ function set_model_from_file(self, key, model_file, backend, device, batch_size,
   character(kind=c_char,len=1), target, dimension(1) :: dummy_inputs, dummy_outputs
 
   integer(c_size_t), dimension(:), allocatable, target :: input_lengths, output_lengths
-  integer(kind=c_size_t) :: key_length, model_file_length, backend_length, device_length, tag_length, n_inputs, &
+  integer(kind=c_size_t) :: name_length, model_file_length, backend_length, device_length, tag_length, n_inputs, &
                             n_outputs
   integer(kind=c_int)    :: c_batch_size, c_min_batch_size
   type(c_ptr)            :: inputs_ptr, input_lengths_ptr, outputs_ptr, output_lengths_ptr
@@ -627,12 +627,12 @@ function set_model_from_file(self, key, model_file, backend, device, batch_size,
   endif
 
   ! Cast to c_char kind stringts
-  c_key = trim(key)
+  c_name = trim(name)
   c_model_file = trim(model_file)
   c_backend = trim(backend)
   c_device = trim(device)
 
-  key_length = len_trim(key)
+  name_length = len_trim(name)
   model_file_length = len_trim(model_file)
   backend_length = len_trim(backend)
   device_length = len_trim(device)
@@ -655,7 +655,7 @@ function set_model_from_file(self, key, model_file, backend, device, batch_size,
                                   output_lengths_ptr, n_outputs)
   endif
 
-  code = set_model_from_file_c(self%client_ptr, c_key, key_length, c_model_file, model_file_length, &
+  code = set_model_from_file_c(self%client_ptr, c_name, name_length, c_model_file, model_file_length, &
                              c_backend, backend_length, c_device, device_length, c_batch_size, c_min_batch_size, &
                              c_tag, tag_length, inputs_ptr, input_lengths_ptr, n_inputs, outputs_ptr, &
                              output_lengths_ptr, n_outputs)
@@ -669,10 +669,10 @@ function set_model_from_file(self, key, model_file, backend, device, batch_size,
 end function set_model_from_file
 
 !> Establish a model to run
-function set_model(self, key, model, backend, device, batch_size, min_batch_size, tag, &
+function set_model(self, name, model, backend, device, batch_size, min_batch_size, tag, &
     inputs, outputs) result(code)
   class(client_type),             intent(in) :: self           !< An initialized SmartRedis client
-  character(len=*),               intent(in) :: key            !< The key to use to place the model
+  character(len=*),               intent(in) :: name           !< The name to use to place the model
   character(len=*),               intent(in) :: model          !< The binary representation of the model
   character(len=*),               intent(in) :: backend        !< The name of the backend (TF, TFLITE, TORCH, ONNX)
   character(len=*),               intent(in) :: device         !< The name of the device (CPU, GPU, GPU:0, GPU:1...)
@@ -684,7 +684,7 @@ function set_model(self, key, model, backend, device, batch_size, min_batch_size
   integer(kind=enum_kind)                    :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
+  character(kind=c_char, len=len_trim(name)) :: c_name
   character(kind=c_char, len=len_trim(model)) :: c_model
   character(kind=c_char, len=len_trim(backend)) :: c_backend
   character(kind=c_char, len=len_trim(device)) :: c_device
@@ -693,7 +693,7 @@ function set_model(self, key, model, backend, device, batch_size, min_batch_size
   character(kind=c_char, len=:), allocatable, target :: c_inputs(:), c_outputs(:)
 
   integer(c_size_t), dimension(:), allocatable, target :: input_lengths, output_lengths
-  integer(kind=c_size_t) :: key_length, model_length, backend_length, device_length, tag_length, n_inputs, &
+  integer(kind=c_size_t) :: name_length, model_length, backend_length, device_length, tag_length, n_inputs, &
                             n_outputs
   integer(kind=c_int)    :: c_batch_size, c_min_batch_size
   type(c_ptr)            :: inputs_ptr, input_lengths_ptr, outputs_ptr, output_lengths_ptr
@@ -702,13 +702,13 @@ function set_model(self, key, model, backend, device, batch_size, min_batch_size
   integer :: i
   integer :: max_length, length
 
-  c_key = trim(key)
+  c_name = trim(name)
   c_model = trim(model)
   c_backend = trim(backend)
   c_device = trim(device)
   c_tag = trim(tag)
 
-  key_length = len_trim(key)
+  name_length = len_trim(name)
   model_length = len_trim(model)
   backend_length = len_trim(backend)
   device_length = len_trim(device)
@@ -724,7 +724,7 @@ function set_model(self, key, model, backend, device, batch_size, min_batch_size
   c_batch_size = batch_size
   c_min_batch_size = min_batch_size
 
-  code = set_model_c(self%client_ptr, c_key, key_length, c_model, model_length, c_backend, backend_length, &
+  code = set_model_c(self%client_ptr, c_name, name_length, c_model, model_length, c_backend, backend_length, &
                  c_device, device_length, batch_size, min_batch_size, c_tag, tag_length, &
                  inputs_ptr, input_lengths_ptr, n_inputs, outputs_ptr, output_lengths_ptr, n_outputs)
 
@@ -737,34 +737,34 @@ function set_model(self, key, model, backend, device, batch_size, min_batch_size
 end function set_model
 
 !> Execute a model
-function run_model(self, key, inputs, outputs) result(code)
+function run_model(self, name, inputs, outputs) result(code)
   class(client_type),             intent(in) :: self    !< An initialized SmartRedis client
-  character(len=*),               intent(in) :: key     !< The key to use to place the model
+  character(len=*),               intent(in) :: name    !< The name to use to place the model
   character(len=*), dimension(:), intent(in) :: inputs  !< One or more names of model input nodes (TF models)
   character(len=*), dimension(:), intent(in) :: outputs !< One or more names of model output nodes (TF models)
   integer(kind=enum_kind)                    :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
+  character(kind=c_char, len=len_trim(name)) :: c_name
   character(kind=c_char, len=:), allocatable, target :: c_inputs(:), c_outputs(:)
 
   integer(c_size_t), dimension(:), allocatable, target :: input_lengths, output_lengths
-  integer(kind=c_size_t) :: n_inputs, n_outputs, key_length
+  integer(kind=c_size_t) :: n_inputs, n_outputs, name_length
   type(c_ptr) :: inputs_ptr, input_lengths_ptr, outputs_ptr, output_lengths_ptr
   type(c_ptr), dimension(:), allocatable :: ptrs_to_inputs, ptrs_to_outputs
 
   integer :: i
   integer :: max_length, length
 
-  c_key = trim(key)
-  key_length = len_trim(key)
+  c_name = trim(name)
+  name_length = len_trim(name)
 
   call convert_char_array_to_c(inputs, c_inputs, ptrs_to_inputs, inputs_ptr, input_lengths, input_lengths_ptr, &
                                 n_inputs)
   call convert_char_array_to_c(outputs, c_outputs, ptrs_to_outputs, outputs_ptr, output_lengths, &
                                 output_lengths_ptr, n_outputs)
 
-  code = run_model_c(self%client_ptr, c_key, key_length, inputs_ptr, input_lengths_ptr, n_inputs, outputs_ptr, &
+  code = run_model_c(self%client_ptr, c_name, name_length, inputs_ptr, input_lengths_ptr, n_inputs, outputs_ptr, &
                           output_lengths_ptr, n_outputs)
 
   deallocate(c_inputs)
@@ -776,23 +776,23 @@ function run_model(self, key, inputs, outputs) result(code)
 end function run_model
 
 !> Retrieve the script from the database
-function get_script(self, key, script) result(code)
+function get_script(self, name, script) result(code)
   class(client_type), intent(in  ) :: self   !< An initialized SmartRedis client
-  character(len=*),   intent(in  ) :: key    !< The key to use to place the script
+  character(len=*),   intent(in  ) :: name   !< The name to use to place the script
   character(len=*),   intent( out) :: script !< The script as a continuous buffer
   integer(kind=enum_kind)          :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
-  integer(kind=c_size_t) :: key_length, script_length
+  character(kind=c_char, len=len_trim(name)) :: c_name
+  integer(kind=c_size_t) :: name_length, script_length
   character(kind=c_char), dimension(:), pointer :: f_str_ptr
   type(c_ptr) :: c_str_ptr
   integer :: i
 
-  c_key = trim(key)
-  key_length = len_trim(key)
+  c_name = trim(name)
+  name_length = len_trim(name)
 
-  code = get_script_c(self%client_ptr, key, key_length, c_str_ptr, script_length)
+  code = get_script_c(self%client_ptr, name, name_length, c_str_ptr, script_length)
 
   call c_f_pointer(c_str_ptr, f_str_ptr, [ script_length ])
 
@@ -801,86 +801,86 @@ function get_script(self, key, script) result(code)
   enddo
 end function get_script
 
-function set_script_from_file(self, key, device, script_file) result(code)
+function set_script_from_file(self, name, device, script_file) result(code)
   class(client_type), intent(in) :: self        !< An initialized SmartRedis client
-  character(len=*),   intent(in) :: key         !< The key to use to place the script
+  character(len=*),   intent(in) :: name        !< The name to use to place the script
   character(len=*),   intent(in) :: device      !< The name of the device (CPU, GPU, GPU:0, GPU:1...)
   character(len=*),   intent(in) :: script_file !< The file storing the script
   integer(kind=enum_kind)        :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key))         :: c_key
+  character(kind=c_char, len=len_trim(name))        :: c_name
   character(kind=c_char, len=len_trim(device))      :: c_device
   character(kind=c_char, len=len_trim(script_file)) :: c_script_file
 
-  integer(kind=c_size_t) :: key_length
+  integer(kind=c_size_t) :: name_length
   integer(kind=c_size_t) :: script_file_length
   integer(kind=c_size_t) :: device_length
 
-  c_key = trim(key)
+  c_name = trim(name)
   c_script_file = trim(script_file)
   c_device = trim(device)
 
-  key_length = len_trim(key)
+  name_length = len_trim(name)
   script_file_length = len_trim(script_file)
   device_length = len_trim(device)
 
-  code = set_script_from_file_c(self%client_ptr, c_key, key_length, c_device, device_length, &
+  code = set_script_from_file_c(self%client_ptr, c_name, name_length, c_device, device_length, &
                               c_script_file, script_file_length)
 end function set_script_from_file
 
-function set_script(self, key, device, script) result(code)
+function set_script(self, name, device, script) result(code)
   class(client_type), intent(in) :: self   !< An initialized SmartRedis client
-  character(len=*),   intent(in) :: key    !< The key to use to place the script
+  character(len=*),   intent(in) :: name   !< The name to use to place the script
   character(len=*),   intent(in) :: device !< The name of the device (CPU, GPU, GPU:0, GPU:1...)
   character(len=*),   intent(in) :: script !< The file storing the script
   integer(kind=enum_kind)        :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
+  character(kind=c_char, len=len_trim(name)) :: c_name
   character(kind=c_char, len=len_trim(device)) :: c_device
   character(kind=c_char, len=len_trim(script)) :: c_script
 
-  integer(kind=c_size_t) :: key_length
+  integer(kind=c_size_t) :: name_length
   integer(kind=c_size_t) :: script_length
   integer(kind=c_size_t) :: device_length
 
-  c_key    = trim(key)
+  c_name    = trim(name)
   c_script = trim(script)
   c_device = trim(device)
 
-  key_length = len_trim(key)
+  name_length = len_trim(name)
   script_length = len_trim(script)
   device_length = len_trim(device)
 
-  code = set_script_c(self%client_ptr, c_key, key_length, c_device, device_length, c_script, script_length)
+  code = set_script_c(self%client_ptr, c_name, name_length, c_device, device_length, c_script, script_length)
 end function set_script
 
-function run_script(self, key, func, inputs, outputs) result(code)
+function run_script(self, name, func, inputs, outputs) result(code)
   class(client_type),             intent(in) :: self           !< An initialized SmartRedis client
-  character(len=*),               intent(in) :: key            !< The key to use to place the script
+  character(len=*),               intent(in) :: name           !< The name to use to place the script
   character(len=*),               intent(in) :: func           !< The name of the function in the script to call
   character(len=*), dimension(:), intent(in) :: inputs         !< One or more names of script input nodes (TF scripts)
   character(len=*), dimension(:), intent(in) :: outputs        !< One or more names of script output nodes (TF scripts)
   integer(kind=enum_kind)                    :: code
 
   ! Local variables
-  character(kind=c_char, len=len_trim(key)) :: c_key
+  character(kind=c_char, len=len_trim(name)) :: c_name
   character(kind=c_char, len=len_trim(func)) :: c_func
   character(kind=c_char, len=:), allocatable, target :: c_inputs(:), c_outputs(:)
 
   integer(c_size_t), dimension(:), allocatable, target :: input_lengths, output_lengths
-  integer(kind=c_size_t) :: n_inputs, n_outputs, key_length, func_length
+  integer(kind=c_size_t) :: n_inputs, n_outputs, name_length, func_length
   type(c_ptr) :: inputs_ptr, input_lengths_ptr, outputs_ptr, output_lengths_ptr
   type(c_ptr), dimension(:), allocatable :: ptrs_to_inputs, ptrs_to_outputs
 
   integer :: i
   integer :: max_length, length
 
-  c_key  = trim(key)
+  c_name  = trim(name)
   c_func = trim(func)
 
-  key_length = len_trim(key)
+  name_length = len_trim(name)
   func_length = len_trim(func)
 
   call convert_char_array_to_c(inputs, c_inputs, ptrs_to_inputs, inputs_ptr, input_lengths, input_lengths_ptr, &
@@ -888,7 +888,7 @@ function run_script(self, key, func, inputs, outputs) result(code)
   call convert_char_array_to_c(outputs, c_outputs, ptrs_to_outputs, outputs_ptr, output_lengths, &
                                 output_lengths_ptr, n_outputs)
 
-  code = run_script_c(self%client_ptr, c_key, key_length, c_func, func_length, inputs_ptr, input_lengths_ptr, &
+  code = run_script_c(self%client_ptr, c_name, name_length, c_func, func_length, inputs_ptr, input_lengths_ptr, &
                             n_inputs, outputs_ptr, output_lengths_ptr, n_outputs)
 
   deallocate(c_inputs)
@@ -910,8 +910,8 @@ end function put_dataset
 
 !> Retrieve a dataset from the database
 function get_dataset(self, name, dataset) result(code)
-  class(client_type), intent(in )  :: self !< An initialized SmartRedis client
-  character(len=*),   intent(in )  :: name !< Name of the dataset to get
+  class(client_type), intent(in )  :: self    !< An initialized SmartRedis client
+  character(len=*),   intent(in )  :: name    !< Name of the dataset to get
   type(dataset_type), intent( out) :: dataset !< receives the dataset
   integer(kind=enum_kind)          :: code
 
@@ -946,7 +946,7 @@ end function rename_dataset
 
 !> Copy a dataset within the database to a new name
 function copy_dataset(self, name, new_name) result(code)
-  class(client_type), intent(in) :: self   !< An initialized SmartRedis client
+  class(client_type), intent(in) :: self     !< An initialized SmartRedis client
   character(len=*),   intent(in) :: name     !< Source name of the dataset
   character(len=*),   intent(in) :: new_name !< Name of the new dataset
   integer(kind=enum_kind)        :: code
@@ -967,7 +967,7 @@ end function copy_dataset
 !> Delete a dataset stored within a database
 function delete_dataset(self, name) result(code)
   class(client_type), intent(in) :: self !< An initialized SmartRedis client
-  character(len=*),   intent(in) :: name   !< Name of the dataset to delete
+  character(len=*),   intent(in) :: name !< Name of the dataset to delete
   integer(kind=enum_kind)        :: code
 
   ! Local variables
@@ -979,10 +979,10 @@ function delete_dataset(self, name) result(code)
   code = delete_dataset_c(self%client_ptr, c_name, name_length)
 end function delete_dataset
 
-!> Set the data source (i.e. key prefix for get functions)
+!> Set the data source (i.e. name prefix for get functions)
 function set_data_source(self, source_id) result(code)
   class(client_type), intent(in) :: self      !< An initialized SmartRedis client
-  character(len=*),   intent(in) :: source_id !< The key prefix
+  character(len=*),   intent(in) :: source_id !< The name prefix
   integer(kind=enum_kind)        :: code
 
   ! Local variables
@@ -994,10 +994,10 @@ function set_data_source(self, source_id) result(code)
   code = set_data_source_c(self%client_ptr, c_source_id, source_id_length)
 end function set_data_source
 
-!> Set whether names of model and script entities should be prefixed (e.g. in an ensemble) to form database keys.
+!> Set whether names of model and script entities should be prefixed (e.g. in an ensemble) to form database names.
 !! Prefixes will only be used if they were previously set through the environment variables SSKEYOUT and SSKEYIN.
 !! Keys of entities created before client function is called will not be affected. By default, the client does not
-!! prefix model and script keys.
+!! prefix model and script names.
 function use_model_ensemble_prefix(self, use_prefix) result(code)
   class(client_type),   intent(in) :: self       !< An initialized SmartRedis client
   logical,              intent(in) :: use_prefix !< The prefix setting

--- a/src/fortran/client/put_tensor_methods_common.inc
+++ b/src/fortran/client/put_tensor_methods_common.inc
@@ -27,15 +27,15 @@
   !** Beginning of code common to all put_tensor subroutines
 
   class(client_type),                    intent(in) :: self !< Fortran SLIC client
-  character(len=*),                      intent(in) :: key  !< The unique key used to store in the database
+  character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
   integer(kind=enum_kind)                           :: code
 
   ! Local variables
   integer(kind=c_size_t)                      :: c_n_dims ! Number of dimensions
   type(c_ptr) :: data_ptr, c_dims_ptr
-  character(kind=c_char, len=len_trim(key)) :: c_key !< Transformed fortran 'key' to a c-string
-  integer(kind=c_size_t) :: key_length
+  character(kind=c_char, len=len_trim(name)) :: c_name !< Transformed fortran 'name' to a c-string
+  integer(kind=c_size_t) :: name_length
   integer(kind=c_size_t), target :: c_dims(size(dims))
   integer(kind=enum_kind) :: data_type
 
@@ -45,9 +45,9 @@
   ! Create the pointer to the data array
   data_ptr = c_loc(data)
 
-  ! Process the key and calculate its length
-  c_key = trim(key)
-  key_length = len_trim(key)
+  ! Process the name and calculate its length
+  c_name = trim(name)
+  name_length = len_trim(name)
 
   c_dims(:) = dims(:)
   c_dims_ptr = c_loc(c_dims)

--- a/src/fortran/client/unpack_tensor_methods_common.inc
+++ b/src/fortran/client/unpack_tensor_methods_common.inc
@@ -25,20 +25,20 @@
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
-  character(len=*),                     intent(in) :: key   !< The key to use to place the tensor
+  character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
   integer(kind=enum_kind)                          :: code
 
   ! Local variables
   integer(kind=c_size_t) :: ndim ! Number of dimensions
   type(c_ptr) :: data_ptr, c_dims_ptr
-  character(kind=c_char, len=len_trim(key)) :: c_key !< Transformed fortran 'key' to a c-string
-  integer(kind=c_size_t) :: key_length, c_n_dims
+  character(kind=c_char, len=len_trim(name)) :: c_name !< Transformed fortran 'name' to a c-string
+  integer(kind=c_size_t) :: name_length, c_n_dims
   integer(kind=c_size_t), target :: c_dims(size(dims))
   integer(kind=enum_kind) :: data_type, mem_layout
 
-  c_key = trim(key)
-  key_length = len_trim(key)
+  c_name = trim(name)
+  name_length = len_trim(name)
   data_ptr = c_loc(result)
   c_dims(:) = dims(:)
   c_n_dims = size(dims)

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -65,7 +65,7 @@ PyClient::~PyClient()
     }
 }
 
-void PyClient::put_tensor(std::string& key,
+void PyClient::put_tensor(std::string& name,
                           std::string& type,
                           py::array data)
 {
@@ -81,7 +81,7 @@ void PyClient::put_tensor(std::string& key,
     SRTensorType ttype = TENSOR_TYPE_MAP.at(type);
 
     try {
-        _client->put_tensor(key, ptr, dims, ttype, SRMemLayoutContiguous);
+        _client->put_tensor(name, ptr, dims, ttype, SRMemLayoutContiguous);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -98,11 +98,11 @@ void PyClient::put_tensor(std::string& key,
     }
 }
 
-py::array PyClient::get_tensor(const std::string& key)
+py::array PyClient::get_tensor(const std::string& name)
 {
     TensorBase* tensor = NULL;
     try {
-        tensor = _client->_get_tensorbase_obj(key);
+        tensor = _client->_get_tensorbase_obj(name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -171,9 +171,9 @@ py::array PyClient::get_tensor(const std::string& key)
     }
 }
 
-void PyClient::delete_tensor(const std::string& key) {
+void PyClient::delete_tensor(const std::string& name) {
     try {
-        _client->delete_tensor(key);
+        _client->delete_tensor(name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -190,10 +190,10 @@ void PyClient::delete_tensor(const std::string& key) {
     }
 }
 
-void PyClient::copy_tensor(const std::string& key,
-                           const std::string& dest_key) {
+void PyClient::copy_tensor(const std::string& src_name,
+                           const std::string& dest_name) {
     try {
-        _client->copy_tensor(key, dest_key);
+        _client->copy_tensor(src_name, dest_name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -210,10 +210,10 @@ void PyClient::copy_tensor(const std::string& key,
     }
 }
 
-void PyClient::rename_tensor(const std::string& key,
-                             const std::string& new_key) {
+void PyClient::rename_tensor(const std::string& old_name,
+                             const std::string& new_name) {
     try {
-        _client->rename_tensor(key, new_key);
+        _client->rename_tensor(old_name, new_name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -277,9 +277,9 @@ PyDataset* PyClient::get_dataset(const std::string& name)
     return dataset;
 }
 
-void PyClient::delete_dataset(const std::string& key) {
+void PyClient::delete_dataset(const std::string& name) {
     try {
-        _client->delete_dataset(key);
+        _client->delete_dataset(name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -296,10 +296,10 @@ void PyClient::delete_dataset(const std::string& key) {
     }
 }
 
-void PyClient::copy_dataset(const std::string& key,
-                           const std::string& dest_key) {
+void PyClient::copy_dataset(const std::string& src_name,
+                           const std::string& dest_name) {
     try {
-        _client->copy_dataset(key, dest_key);
+        _client->copy_dataset(src_name, dest_name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -316,10 +316,10 @@ void PyClient::copy_dataset(const std::string& key,
     }
 }
 
-void PyClient::rename_dataset(const std::string& key,
-                             const std::string& new_key) {
+void PyClient::rename_dataset(const std::string& old_name,
+                             const std::string& new_name) {
     try {
-        _client->rename_dataset(key, new_key);
+        _client->rename_dataset(old_name, new_name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -336,12 +336,12 @@ void PyClient::rename_dataset(const std::string& key,
     }
 }
 
-void PyClient::set_script_from_file(const std::string& key,
+void PyClient::set_script_from_file(const std::string& name,
                                     const std::string& device,
                                     const std::string& script_file)
 {
     try {
-        _client->set_script_from_file(key, device, script_file);
+        _client->set_script_from_file(name, device, script_file);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -358,12 +358,12 @@ void PyClient::set_script_from_file(const std::string& key,
     }
 }
 
-void PyClient::set_script(const std::string& key,
+void PyClient::set_script(const std::string& name,
                           const std::string& device,
                           const std::string_view& script)
 {
     try {
-        _client->set_script(key, device, script);
+        _client->set_script(name, device, script);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -380,11 +380,11 @@ void PyClient::set_script(const std::string& key,
     }
 }
 
-std::string_view PyClient::get_script(const std::string& key)
+std::string_view PyClient::get_script(const std::string& name)
 {
     std::string_view script;
     try {
-        script = _client->get_script(key);
+        script = _client->get_script(name);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -402,13 +402,13 @@ std::string_view PyClient::get_script(const std::string& key)
     return script;
 }
 
-void PyClient::run_script(const std::string& key,
+void PyClient::run_script(const std::string& name,
                 const std::string& function,
                 std::vector<std::string>& inputs,
                 std::vector<std::string>& outputs)
 {
     try {
-      _client->run_script(key, function, inputs, outputs);
+      _client->run_script(name, function, inputs, outputs);
     }
     catch (Exception& e) {
         // exception is already prepared for caller
@@ -425,10 +425,10 @@ void PyClient::run_script(const std::string& key,
     }
 }
 
-py::bytes PyClient::get_model(const std::string& key)
+py::bytes PyClient::get_model(const std::string& name)
 {
     try {
-        std::string model(_client->get_model(key));
+        std::string model(_client->get_model(name));
         return py::bytes(model);
     }
     catch (Exception& e) {
@@ -446,7 +446,7 @@ py::bytes PyClient::get_model(const std::string& key)
     }
 }
 
-void PyClient::set_model(const std::string& key,
+void PyClient::set_model(const std::string& name,
                  const std::string_view& model,
                  const std::string& backend,
                  const std::string& device,
@@ -457,7 +457,7 @@ void PyClient::set_model(const std::string& key,
                  const std::vector<std::string>& outputs)
 {
     try {
-        _client->set_model(key, model, backend, device,
+        _client->set_model(name, model, backend, device,
                            batch_size, min_batch_size, tag,
                            inputs, outputs);
     }
@@ -476,7 +476,7 @@ void PyClient::set_model(const std::string& key,
     }
 }
 
-void PyClient::set_model_from_file(const std::string& key,
+void PyClient::set_model_from_file(const std::string& name,
                                    const std::string& model_file,
                                    const std::string& backend,
                                    const std::string& device,
@@ -487,7 +487,7 @@ void PyClient::set_model_from_file(const std::string& key,
                                    const std::vector<std::string>& outputs)
 {
     try {
-        _client->set_model_from_file(key, model_file, backend, device,
+        _client->set_model_from_file(name, model_file, backend, device,
                                            batch_size, min_batch_size, tag,
                                            inputs, outputs);
     }
@@ -506,12 +506,12 @@ void PyClient::set_model_from_file(const std::string& key,
     }
 }
 
-void PyClient::run_model(const std::string& key,
+void PyClient::run_model(const std::string& name,
                          std::vector<std::string> inputs,
                          std::vector<std::string> outputs)
 {
     try {
-        _client->run_model(key, inputs, outputs);
+        _client->run_model(name, inputs, outputs);
     }
     catch (Exception& e) {
         // exception is already prepared for caller


### PR DESCRIPTION
Make the source code cleanly differentiate between names (the raw name for a tensor, dataset, script, or model) and keys (the potentially prefixed version of the name that is used to reference it in the database).