### PR TITLE
Fix name conflict in dataset.h

### DIFF
--- a/include/dataset.h
+++ b/include/dataset.h
@@ -280,7 +280,7 @@ class DataSet
         /*!
         *  \brief The name of the DataSet
         */
-        std::string name;
+        std::string _name;
 
         friend class Client;
         friend class PyDataset;

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -278,9 +278,16 @@ class DataSet
         std::vector<std::string> get_tensor_names();
 
         /*!
-        *  \brief The name of the DataSet
+        *   \brief Retrieve the name of the DataSet
+        *   \returns The name of the DataSet
         */
-        std::string _name;
+        std::string get_name() { return _dsname; }
+
+        /*!
+        *   \brief Change the name for the DataSet
+        *   \param name The name for the DataSet
+        */
+        void set_name(std::string name) { _dsname = name; }
 
         friend class Client;
         friend class PyDataset;
@@ -380,6 +387,10 @@ class DataSet
 
     private:
 
+        /*!
+        *  \brief The name of the DataSet
+        */
+        std::string _dsname;
 
         /*!
         *   \brief A repository for all metadata associated with this DataSet

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -139,7 +139,7 @@ void Client::copy_dataset(const std::string& src_name,
     // Update the DataSet name to the destination name
     // so we can reuse the object for placing metadata
     // and ack commands
-    dataset.name = dest_name;
+    dataset._name = dest_name;
     CommandList put_meta_cmds;
     _append_dataset_metadata_commands(put_meta_cmds, dataset);
     _append_dataset_ack_command(put_meta_cmds, dataset);
@@ -164,12 +164,12 @@ void Client::delete_dataset(const std::string& name)
 
     // Delete the metadata (which contains the ack key)
     cmd.add_field("DEL");
-    cmd.add_field(_build_dataset_meta_key(dataset.name, true), true);
+    cmd.add_field(_build_dataset_meta_key(dataset._name, true), true);
 
     // Add in all the tensors to be deleted
     std::vector<std::string> tensor_names = dataset.get_tensor_names();
     std::vector<std::string> tensor_keys =
-        _build_dataset_tensor_keys(dataset.name, tensor_names, true);
+        _build_dataset_tensor_keys(dataset._name, tensor_names, true);
     cmd.add_fields(tensor_keys, true);
 
     // Run the command
@@ -1077,7 +1077,7 @@ Client::_build_dataset_ack_key(const std::string& dataset_name,
 void Client::_append_dataset_metadata_commands(CommandList& cmd_list,
                                                DataSet& dataset)
 {
-    std::string meta_key = _build_dataset_meta_key(dataset.name, false);
+    std::string meta_key = _build_dataset_meta_key(dataset._name, false);
 
     std::vector<std::pair<std::string, std::string>> mdf =
         dataset.get_metadata_serialization_map();
@@ -1113,7 +1113,7 @@ void Client::_append_dataset_tensor_commands(CommandList& cmd_list,
     for ( ; it != dataset.tensor_end(); it++) {
         TensorBase* tensor = *it;
         std::string tensor_key = _build_dataset_tensor_key(
-            dataset.name, tensor->name(), false);
+            dataset._name, tensor->name(), false);
         SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
         cmd->add_field("AI.TENSORSET");
         cmd->add_field(tensor_key, true);
@@ -1128,7 +1128,7 @@ void Client::_append_dataset_tensor_commands(CommandList& cmd_list,
 // (all put commands processed) to the CommandList
 void Client::_append_dataset_ack_command(CommandList& cmd_list, DataSet& dataset)
 {
-    std::string key = _build_dataset_ack_key(dataset.name, false);
+    std::string key = _build_dataset_ack_key(dataset._name, false);
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
     cmd->add_field("HSET");
     cmd->add_field(key, true);

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -139,7 +139,7 @@ void Client::copy_dataset(const std::string& src_name,
     // Update the DataSet name to the destination name
     // so we can reuse the object for placing metadata
     // and ack commands
-    dataset._name = dest_name;
+    dataset.set_name(dest_name);
     CommandList put_meta_cmds;
     _append_dataset_metadata_commands(put_meta_cmds, dataset);
     _append_dataset_ack_command(put_meta_cmds, dataset);
@@ -164,12 +164,12 @@ void Client::delete_dataset(const std::string& name)
 
     // Delete the metadata (which contains the ack key)
     cmd.add_field("DEL");
-    cmd.add_field(_build_dataset_meta_key(dataset._name, true), true);
+    cmd.add_field(_build_dataset_meta_key(dataset.get_name(), true), true);
 
     // Add in all the tensors to be deleted
     std::vector<std::string> tensor_names = dataset.get_tensor_names();
     std::vector<std::string> tensor_keys =
-        _build_dataset_tensor_keys(dataset._name, tensor_names, true);
+        _build_dataset_tensor_keys(dataset.get_name(), tensor_names, true);
     cmd.add_fields(tensor_keys, true);
 
     // Run the command
@@ -1077,7 +1077,7 @@ Client::_build_dataset_ack_key(const std::string& dataset_name,
 void Client::_append_dataset_metadata_commands(CommandList& cmd_list,
                                                DataSet& dataset)
 {
-    std::string meta_key = _build_dataset_meta_key(dataset._name, false);
+    std::string meta_key = _build_dataset_meta_key(dataset.get_name(), false);
 
     std::vector<std::pair<std::string, std::string>> mdf =
         dataset.get_metadata_serialization_map();
@@ -1113,7 +1113,7 @@ void Client::_append_dataset_tensor_commands(CommandList& cmd_list,
     for ( ; it != dataset.tensor_end(); it++) {
         TensorBase* tensor = *it;
         std::string tensor_key = _build_dataset_tensor_key(
-            dataset._name, tensor->name(), false);
+            dataset.get_name(), tensor->name(), false);
         SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
         cmd->add_field("AI.TENSORSET");
         cmd->add_field(tensor_key, true);
@@ -1128,7 +1128,7 @@ void Client::_append_dataset_tensor_commands(CommandList& cmd_list,
 // (all put commands processed) to the CommandList
 void Client::_append_dataset_ack_command(CommandList& cmd_list, DataSet& dataset)
 {
-    std::string key = _build_dataset_ack_key(dataset._name, false);
+    std::string key = _build_dataset_ack_key(dataset.get_name(), false);
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
     cmd->add_field("HSET");
     cmd->add_field(key, true);

--- a/src/cpp/dataset.cpp
+++ b/src/cpp/dataset.cpp
@@ -33,8 +33,8 @@
 using namespace SmartRedis;
 
 // DataSet constructor
-DataSet::DataSet(const std::string& _name)
- : name(_name)
+DataSet::DataSet(const std::string& name)
+ : _name(name)
 {
     // NOP
 }
@@ -245,7 +245,7 @@ inline void DataSet::_enforce_tensor_exists(const std::string& tensorname)
 {
     if (!_tensorpack.tensor_exists(tensorname)) {
         throw SRKeyException("The tensor \"" + std::string(tensorname) +
-                             "\" does not exist in dataset \"" + name + "\".");
+                             "\" does not exist in dataset \"" + _name + "\".");
     }
 }
 

--- a/src/cpp/dataset.cpp
+++ b/src/cpp/dataset.cpp
@@ -34,7 +34,7 @@ using namespace SmartRedis;
 
 // DataSet constructor
 DataSet::DataSet(const std::string& name)
- : _name(name)
+ : _dsname(name)
 {
     // NOP
 }
@@ -245,7 +245,8 @@ inline void DataSet::_enforce_tensor_exists(const std::string& tensorname)
 {
     if (!_tensorpack.tensor_exists(tensorname)) {
         throw SRKeyException("The tensor \"" + std::string(tensorname) +
-                             "\" does not exist in dataset \"" + _name + "\".");
+                             "\" does not exist in dataset \"" +
+                             _dsname + "\".");
     }
 }
 

--- a/src/python/src/pydataset.cpp
+++ b/src/python/src/pydataset.cpp
@@ -279,7 +279,7 @@ py::array PyDataset::get_meta_scalars(const std::string& name)
 std::string PyDataset::get_name()
 {
     try {
-        return _dataset->_name;
+        return _dataset->get_name();
     }
     catch (Exception& e) {
         // exception is already prepared for caller

--- a/src/python/src/pydataset.cpp
+++ b/src/python/src/pydataset.cpp
@@ -279,7 +279,7 @@ py::array PyDataset::get_meta_scalars(const std::string& name)
 std::string PyDataset::get_name()
 {
     try {
-        return _dataset->name;
+        return _dataset->_name;
     }
     catch (Exception& e) {
         // exception is already prepared for caller


### PR DESCRIPTION
The name of the dataset was stored in the variable "name", but this conflicted with the parameter "name" used in several of the dataset member functions. Renamed the parameter to "_name" to help show it as a member variable and eliminate the conflict.