### PR TITLE
Update CMake minimum version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(SmartRedis)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 option(BUILD_PYTHON "Build the python module" ON)
 

--- a/doc/install/docker.rst
+++ b/doc/install/docker.rst
@@ -69,7 +69,7 @@ for a containerized application.
 
     project(DockerTester)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     set(CMAKE_CXX_STANDARD 17)
 
@@ -113,7 +113,7 @@ for a containerized application.
 
     project(DockerTester)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     set(CMAKE_CXX_STANDARD 17)
 
@@ -171,7 +171,7 @@ for a containerized application.
 
     project(DockerTester)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     enable_language(Fortran)
 

--- a/doc/install/from_source.rst
+++ b/doc/install/from_source.rst
@@ -124,7 +124,7 @@ compile a C or C++ application with SmartRedis.
 
     project(Example)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     set(CMAKE_CXX_STANDARD 17)
 
@@ -158,7 +158,7 @@ shown below for a Fortran application.
 
     project(Example)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     enable_language(Fortran)
 

--- a/doc/install/lib.rst
+++ b/doc/install/lib.rst
@@ -30,7 +30,7 @@ compile a C or C++ application with SmartRedis.
 
     project(Example)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     set(CMAKE_CXX_STANDARD 17)
 
@@ -64,7 +64,7 @@ shown below for a Fortran application.
 
     project(Example)
 
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.13)
 
     enable_language(Fortran)
 

--- a/examples/parallel/cpp/CMakeLists.txt
+++ b/examples/parallel/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(CppClientExamples)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 17)

--- a/examples/parallel/fortran/CMakeLists.txt
+++ b/examples/parallel/fortran/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(FortranClientExamples)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 enable_language(Fortran)
 

--- a/examples/serial/c/CMakeLists.txt
+++ b/examples/serial/c/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(CClientExamples)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_BUILD_TYPE RELEASE)
 set(CMAKE_CXX_STANDARD 17)

--- a/examples/serial/cpp/CMakeLists.txt
+++ b/examples/serial/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(CppClientExamples)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_BUILD_TYPE RELEASE)
 set(CMAKE_CXX_STANDARD 17)

--- a/examples/serial/fortran/CMakeLists.txt
+++ b/examples/serial/fortran/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(FortranClientExamples)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 enable_language(Fortran)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [build-system]
 requires = ["setuptools>=42",
             "wheel",
-            "cmake>=3.10"]
+            "cmake>=3.13"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/tests/c/CMakeLists.txt
+++ b/tests/c/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(CClientTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_BUILD_TYPE DEBUG)

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(CppClientTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_BUILD_TYPE DEBUG)

--- a/tests/cpp/unit-tests/CMakeLists.txt
+++ b/tests/cpp/unit-tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(CppClientUnitTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_BUILD_TYPE DEBUG)

--- a/tests/docker/c/CMakeLists.txt
+++ b/tests/docker/c/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 project(DockerTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_BUILD_TYPE DEBUG)

--- a/tests/docker/cpp/CMakeLists.txt
+++ b/tests/docker/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 project(DockerTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_BUILD_TYPE DEBUG)

--- a/tests/docker/fortran/CMakeLists.txt
+++ b/tests/docker/fortran/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 project(DockerTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 enable_language(Fortran)
 

--- a/tests/fortran/CMakeLists.txt
+++ b/tests/fortran/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(FortranClientTester)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 enable_language(Fortran)
 


### PR DESCRIPTION
The SmartRedis build process uses the CMake function ``add_link_options()`` which was added in version 3.13 (https://cmake.org/cmake/help/git-master/command/add_link_options.html).  As a result, we should bump our minimum version from 3.10 to 3.13.  The current version of CMake is 3.23, so users are unlikely to encounter an error unless they are using a very old version of CMake, and newer versions of CMake are easily installed in a ``conda`` environment.