### PR TITLE
Make sure that CPP test coverage includes all source files

### DIFF
--- a/tests/cpp/unit-tests/CMakeLists.txt
+++ b/tests/cpp/unit-tests/CMakeLists.txt
@@ -93,8 +93,8 @@ file(GLOB UNIT_TEST_FILES *.cpp)
 list(LENGTH UNIT_TEST_FILES cpp_unit_test_file_count)
 
 if(NOT (unit_test_count EQUAL cpp_unit_test_file_count))
-	message(FATAL_ERROR "CPP test coverage sources count (${unit_test_count}) \
-does not match count of cpp source files: ${cpp_unit_test_file_count}")
+	message(FATAL_ERROR "CPP unit test count (${unit_test_count}) \
+does not match count of cpp unit test files: ${cpp_unit_test_file_count}")
 endif()
 
 add_executable(cpp_unit_tests ${SOURCES} ${UNIT_TESTS})

--- a/tests/cpp/unit-tests/CMakeLists.txt
+++ b/tests/cpp/unit-tests/CMakeLists.txt
@@ -65,6 +65,21 @@ set(UNIT_TESTS
     test_redisserver.cpp
 )
 
+# Compare the number of files given above to the number of CPP files
+# in the directory. If the two numbers aren't equal, we're not testing
+# coverate completely. It is not recommended to use globbed file lists
+# in add_executable()
+list(LENGTH SOURCES source_count)
+
+file(GLOB cpp_files ../../../src/cpp/*.cpp)
+
+list(LENGTH cpp_files cpp_file_count)
+
+if(NOT (source_count EQUAL cpp_file_count))
+	message(FATAL_ERROR "CPP test coverage sources (${source_count}) does not match \
+count of cpp source files: ${cpp_file_count}")
+endif()
+
 add_executable(cpp_unit_tests ${SOURCES} ${UNIT_TESTS})
 
 target_link_libraries(cpp_unit_tests ${SR_LIB})

--- a/tests/cpp/unit-tests/CMakeLists.txt
+++ b/tests/cpp/unit-tests/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(SYSTEM
 	../../../install/include
 )
 
+# The source files to assess coverage on
 set(SOURCES
 	../../../src/cpp/addressanycommand.cpp
 	../../../src/cpp/addressatcommand.cpp
@@ -42,6 +43,7 @@ set(SOURCES
 	../../../src/cpp/tensorpack.cpp
 )
 
+# The unit tests to be executed
 set(UNIT_TESTS
 	main.cpp
 	test_client.cpp
@@ -65,19 +67,34 @@ set(UNIT_TESTS
     test_redisserver.cpp
 )
 
-# Compare the number of files given above to the number of CPP files
-# in the directory. If the two numbers aren't equal, we're not testing
+# Compare the number of source files given above to the number of source CPP
+# files in the directory. If the two numbers aren't equal, we're not testing
 # coverate completely. It is not recommended to use globbed file lists
 # in add_executable()
 list(LENGTH SOURCES source_count)
 
-file(GLOB cpp_files ../../../src/cpp/*.cpp)
+file(GLOB CPP_SOURCE_FILES ../../../src/cpp/*.cpp)
 
-list(LENGTH cpp_files cpp_file_count)
+list(LENGTH CPP_SOURCE_FILES cpp_source_file_count)
 
-if(NOT (source_count EQUAL cpp_file_count))
-	message(FATAL_ERROR "CPP test coverage sources (${source_count}) does not match \
-count of cpp source files: ${cpp_file_count}")
+if(NOT (source_count EQUAL cpp_source_file_count))
+	message(FATAL_ERROR "CPP test coverage sources count (${source_count}) \
+does not match count of cpp source files: ${cpp_source_file_count}")
+endif()
+
+# Compare the number of unit test files given above to the number of unit
+# test CPP files in the directory. If the two numbers aren't equal, we're
+# not running all the tests! It is not recommended to use globbed file lists
+# in add_executable()
+list(LENGTH UNIT_TESTS unit_test_count)
+
+file(GLOB UNIT_TEST_FILES *.cpp)
+
+list(LENGTH UNIT_TEST_FILES cpp_unit_test_file_count)
+
+if(NOT (unit_test_count EQUAL cpp_unit_test_file_count))
+	message(FATAL_ERROR "CPP test coverage sources count (${unit_test_count}) \
+does not match count of cpp source files: ${cpp_unit_test_file_count}")
 endif()
 
 add_executable(cpp_unit_tests ${SOURCES} ${UNIT_TESTS})


### PR DESCRIPTION
Generate an error if the .cpp SOURCES list is found to have a different number of files in it than the number of .cpp files in src/cpp. This will ensure that our test coverage stays accurate when new files are added to the library. 