### PR TITLE
Move model commands to new RedisAI interface

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -473,12 +473,17 @@ class Client
 
         /*!
         *   \brief Run a model in the database using the
+        *          specificed input and output tensors
         *   \details The model key used to locate the model to be run
         *            may be formed by applying a prefix to the supplied
         *            name. Similarly, the tensor names in the
         *            input and output vectors may be prefixed.
         *            See set_data_source(), use_model_ensemble_prefix(), and
-        *            use_tensor_ensemble_prefix() for more details
+        *            use_tensor_ensemble_prefix() for more details.
+        *            By default, models will run with a one hour timeout. To
+        *            modify the length of time that a model is allowed to run,
+        *            update the SR_MODEL_TIMEOUT to give a new value, in
+        *            milliseconds.
         *   \param name The name associated with the model
         *   \param inputs The tensor keys for inputs tensors to use
         *                 in the model

--- a/include/command.h
+++ b/include/command.h
@@ -45,6 +45,19 @@ namespace SmartRedis {
 class RedisServer;
 
 /*!
+*   \brief The Keyfield class marks a command field as being a key.
+*   \details Keyfield inherits everything from std::string and has
+*            no additional functionality. RTTI enables differentiation
+*            between Keyfields and other command fields.
+*/
+class Keyfield: public std::string
+{
+    public:
+    Keyfield(std::string s) : _s(s) {};
+    std::string _s;
+};
+
+/*!
 *   \brief The Command class constructs Client commands.
 *   \details The Command class has multiple methods for adding
 *          fields to the Command.  The Command.add_field()
@@ -80,6 +93,80 @@ class Command
         Command& operator=(const Command& cmd);
 
         /*!
+        *   \brief Add a field to thecCommand from a string.
+        *   \details The string field value is copied
+        *            to the command.
+        *   \param field The field to add to the command
+        *   \returns The command object, for chaining.
+        */
+        virtual Command& operator<<(const std::string& field) {
+            add_field(field, false);
+            return *this;
+        }
+
+        /*!
+        *   \brief Add a field to the command from a string_view.
+        *   \details The string_view field value is copied
+        *            to the command.
+        *   \param field The field to add to the command
+        *   \returns The command object, for chaining.
+        */
+        virtual Command& operator<<(const std::string_view& field) {
+            add_field_ptr(field);
+            return *this;
+        }
+
+        /*!
+        *   \brief Add a field to the command from a c-string.
+        *   \details The c-string field value is copied
+        *            to the command.
+        *   \param field The field to add to the command
+        *   \returns The command object, for chaining.
+        */
+        virtual Command& operator<<(const char* field) {
+            add_field(field, false);
+            return *this;
+        }
+
+        /*!
+        *   \brief Add a key field to the command.
+        *   \details The key field value is copied to the command.
+        *   \param key The key field to add to the command
+        *   \returns The command object, for chaining.
+        */
+        virtual Command& operator<<(const Keyfield& key) {
+            add_field(key._s, true);
+            return *this;
+        }
+
+        /*!
+        *   \brief Add a vector of strings to the command.
+        *   \details The string values are copied to the command.
+        *            To add a vector of keys, use the add_keys()
+        *            method.
+        *   \param fields The strings to add to the command
+        *   \returns The command object, for chaining.
+        */
+        virtual Command& operator<<(const std::vector<std::string>& fields) {
+            add_fields(fields);
+            return *this;
+        }
+
+        /*!
+        *   \brief Add a vector of strings to the command.
+        *   \details The string values are copied to the command.
+        *            To add a vector of keys, use the add_keys()
+        *            method.
+        *   \param fields The strings to add to the command
+        *   \returns The command object, for chaining.
+        */
+        template <class T>
+        Command& operator<<(const std::vector<T>& fields) {
+            add_fields(fields);
+            return *this;
+        }
+
+        /*!
         *   \brief Command move assignment operator
         */
         Command& operator=(Command&& cmd) = default;
@@ -112,6 +199,23 @@ class Command
         virtual CommandReply run_me(RedisServer* server) = 0;
 
         /*!
+        *   \brief Add a field to the Command from a c-string.
+        *   \details The c-string will not be copied to the
+        *            Command object.  A pointer is kept that
+        *            points to the c-string location in
+        *            memory.  As a result, the c-string
+        *            memory must be valid up until the
+        *            execution of the Command.  A field
+        *            that is not copied cannot be a Command
+        *            key.
+        *   \param field The field to add to the Command
+        *   \param field_size The length of the c-string
+        */
+        void add_field_ptr(char* field, size_t field_size);
+
+
+        protected:
+        /*!
         *   \brief Add a field to the Command from a string.
         *   \details The string field value is copied to the
         *            Command.
@@ -133,21 +237,6 @@ class Command
         *                 Command.
         */
         void add_field(const char* field, bool is_key=false);
-
-        /*!
-        *   \brief Add a field to the Command from a c-string.
-        *   \details The c-string will not be copied to the
-        *            Command object.  A pointer is kept that
-        *            points to the c-string location in
-        *            memory.  As a result, the c-string
-        *            memory must be valid up until the
-        *            execution of the Command.  A field
-        *            that is not copied cannot be a Command
-        *            key.
-        *   \param field The field to add to the Command
-        *   \param field_size The length of the c-string
-        */
-        void add_field_ptr(char* field, size_t field_size);
 
         /*!
         *   \brief Add a field to the Command from a
@@ -176,7 +265,6 @@ class Command
         */
         void add_fields(const std::vector<std::string>& fields, bool is_key=false);
 
-
         /*!
         *   \brief Add fields to the Command
         *          from a vector of type T
@@ -185,13 +273,37 @@ class Command
         *            to a string via std::to_string.
         *   \tparam T Any type that can be converted
         *             to a string via std::to_string.
-        *
         *   \param fields The fields to add to the Command
         *   \param is_key Boolean indicating if the all
         *                 of the fields are Command keys
         */
         template <class T>
         void add_fields(const std::vector<T>& fields, bool is_key=false);
+
+    public:
+        /*!
+        *   \brief Add key fields to the Command
+        *          from a vector of strings.
+        *   \details The string key field values are copied to the
+        *            Command.
+        *   \param fields The key fields to add to the Command
+        *   \param is_key Boolean indicating if the all
+        *                 of the fields are Command keys
+        */
+        void add_keys(const std::vector<std::string>& fields);
+
+        /*!
+        *   \brief Add key fields to the Command
+        *          from a vector of type T
+        *   \details The key field values are copied to the
+        *            Command.  The type T must be convertable
+        *            to a string via std::to_string.
+        *   \tparam T Any type that can be converted
+        *             to a string via std::to_string.
+        *   \param keyfields The key fields to add to the Command
+        */
+        template <class T>
+        void add_keys(const std::vector<T>& fields);
 
         /*!
         *   \brief Return true if the Command has keys

--- a/include/command.tcc
+++ b/include/command.tcc
@@ -35,7 +35,14 @@ void Command::add_fields(const std::vector<T>& fields, bool is_key)
     for (size_t i = 0; i < fields.size(); i++) {
         this->add_field(std::to_string(fields[i]), is_key);
     }
-    return;
+}
+
+template <class T>
+void Command::add_keys(const std::vector<T>& keyfields)
+{
+    for (size_t i = 0; i < keyfields.size(); i++) {
+        this->add_field(std::to_string(keyfields[i]), true);
+    }
 }
 
 #endif //SMARTREDIS_COMMAND_TCC

--- a/include/compoundcommand.h
+++ b/include/compoundcommand.h
@@ -66,6 +66,7 @@ class CompoundCommand : public KeyedCommand
         *            type.
         */
         virtual Command* clone();
+
 };
 
 } //namespace SmartRedis

--- a/include/enum_fortran.inc
+++ b/include/enum_fortran.inc
@@ -24,13 +24,7 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-! Dummy enum, used to set the integer kind used
-enum, bind(c)
-  enumerator :: dummy = 0
-end enum
-integer, parameter :: enum_kind = kind(dummy)
-
-! The following enums have analogues to the C and C++ clients. Fortran does not haven named enums, but the name:value
+! The following enums have analogues to the C and C++ clients. Fortran does not have named enums, but the name:value
 ! parameters must be the same. By convention negative enums, represent items that are not supported in the Fortran
 ! client.
 

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -419,6 +419,12 @@ class RedisServer {
             "SR_CMD_INTERVAL";
 
         /*!
+        *   \brief Environment variable for model execution timeout
+        */
+        inline static const std::string _MODEL_TIMEOUT_ENV_VAR =
+            "SR_MODEL_TIMEOUT";
+
+        /*!
         *   \brief Retrieve a single address, randomly
         *          chosen from a list of addresses if
         *          applicable, from the SSDB environment

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -159,18 +159,15 @@ void Client::delete_dataset(const std::string& name)
     DataSet dataset(name);
     _unpack_dataset_metadata(dataset, reply);
 
-    // Build the delete command
-    MultiKeyCommand cmd;
-
     // Delete the metadata (which contains the ack key)
-    cmd.add_field("DEL");
-    cmd.add_field(_build_dataset_meta_key(dataset.get_name(), true), true);
+    MultiKeyCommand cmd;
+    cmd << "DEL" << Keyfield(_build_dataset_meta_key(dataset.get_name(), true));
 
     // Add in all the tensors to be deleted
     std::vector<std::string> tensor_names = dataset.get_tensor_names();
     std::vector<std::string> tensor_keys =
         _build_dataset_tensor_keys(dataset.get_name(), tensor_names, true);
-    cmd.add_fields(tensor_keys, true);
+    cmd.add_keys(tensor_keys);
 
     // Run the command
     reply = _run(cmd);
@@ -757,9 +754,7 @@ parsed_reply_nested_map Client::get_db_node_info(std::string address)
     uint64_t port = cmd.parse_port(address);
 
     cmd.set_exec_address_port(host, port);
-
-    cmd.add_field("INFO");
-    cmd.add_field("EVERYTHING");
+    cmd << "INFO" << "EVERYTHING";
     CommandReply reply = _run(cmd);
     if (reply.has_error())
         throw SRRuntimeException("INFO EVERYTHING command failed on server");
@@ -781,9 +776,7 @@ parsed_reply_map Client::get_db_cluster_info(std::string address)
     uint64_t port = cmd.parse_port(address);
 
     cmd.set_exec_address_port(host, port);
-
-    cmd.add_field("CLUSTER");
-    cmd.add_field("INFO");
+    cmd << "CLUSTER" << "INFO";
     CommandReply reply = _run(cmd);
     if (reply.has_error())
         throw SRRuntimeException("CLUSTER INFO command failed on server");
@@ -848,8 +841,7 @@ void Client::flush_db(std::string address)
                                  "is not a valid database node address.");
     }
     cmd.set_exec_address_port(host, port);
-
-    cmd.add_field("FLUSHDB");
+    cmd << "FLUSHDB";
 
     CommandReply reply = _run(cmd);
     if (reply.has_error() > 0)
@@ -865,10 +857,7 @@ Client::config_get(std::string expression, std::string address)
     uint64_t port = cmd.parse_port(address);
 
     cmd.set_exec_address_port(host, port);
-
-    cmd.add_field("CONFIG");
-    cmd.add_field("GET");
-    cmd.add_field(expression);
+    cmd << "CONFIG" << "GET" << expression;
 
     CommandReply reply = _run(cmd);
     if (reply.has_error() > 0)
@@ -892,11 +881,7 @@ void Client::config_set(std::string config_param, std::string value, std::string
     uint64_t port = cmd.parse_port(address);
 
     cmd.set_exec_address_port(host, port);
-
-    cmd.add_field("CONFIG");
-    cmd.add_field("SET");
-    cmd.add_field(config_param);
-    cmd.add_field(value);
+    cmd << "CONFIG" << "SET" << config_param << value;
 
     CommandReply reply = _run(cmd);
     if (reply.has_error() > 0)
@@ -910,7 +895,7 @@ void Client::save(std::string address)
     uint64_t port = cmd.parse_port(address);
 
     cmd.set_exec_address_port(host, port);
-    cmd.add_field("SAVE");
+    cmd << "SAVE";
 
     CommandReply reply = _run(cmd);
     if (reply.has_error() > 0)
@@ -992,8 +977,7 @@ inline void Client::_append_with_put_prefix(std::vector<std::string>& keys)
 inline CommandReply Client::_get_dataset_metadata(const std::string& name)
 {
     SingleKeyCommand cmd;
-    cmd.add_field("HGETALL");
-    cmd.add_field(_build_dataset_meta_key(name, true), true);
+    cmd << "HGETALL" << Keyfield(_build_dataset_meta_key(name, true));
     return _run(cmd);
 }
 
@@ -1089,18 +1073,15 @@ void Client::_append_dataset_metadata_commands(CommandList& cmd_list,
     }
 
     SingleKeyCommand* del_cmd = cmd_list.add_command<SingleKeyCommand>();
-    del_cmd->add_field("DEL");
-    del_cmd->add_field(meta_key, true);
+    *del_cmd << "DEL" << Keyfield(meta_key);
 
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
     if (cmd == NULL) {
         throw SRRuntimeException("Failed to create SingleKeyCommand.");
     }
-    cmd->add_field("HMSET");
-    cmd->add_field (meta_key, true);
+    *cmd << "HMSET" << Keyfield(meta_key);
     for (size_t i = 0; i < mdf.size(); i++) {
-        cmd->add_field(mdf[i].first);
-        cmd->add_field(mdf[i].second);
+        *cmd << mdf[i].first << mdf[i].second;
     }
 }
 
@@ -1115,12 +1096,8 @@ void Client::_append_dataset_tensor_commands(CommandList& cmd_list,
         std::string tensor_key = _build_dataset_tensor_key(
             dataset.get_name(), tensor->name(), false);
         SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
-        cmd->add_field("AI.TENSORSET");
-        cmd->add_field(tensor_key, true);
-        cmd->add_field(tensor->type_str());
-        cmd->add_fields(tensor->dims());
-        cmd->add_field("BLOB");
-        cmd->add_field_ptr(tensor->buf());
+        *cmd << "AI.TENSORSET" << Keyfield(tensor_key) << tensor->type_str()
+             << tensor->dims() << "BLOB" << tensor->buf();
     }
 }
 
@@ -1130,10 +1107,7 @@ void Client::_append_dataset_ack_command(CommandList& cmd_list, DataSet& dataset
 {
     std::string key = _build_dataset_ack_key(dataset.get_name(), false);
     SingleKeyCommand* cmd = cmd_list.add_command<SingleKeyCommand>();
-    cmd->add_field("HSET");
-    cmd->add_field(key, true);
-    cmd->add_field(_DATASET_ACK_FIELD);
-    cmd->add_field("1");
+    *cmd << "HSET" << Keyfield(key) << _DATASET_ACK_FIELD << "1";
 }
 
 // Put the metadata fields embedded in a CommandReply into the DataSet

--- a/src/cpp/command.cpp
+++ b/src/cpp/command.cpp
@@ -187,6 +187,19 @@ void Command::add_fields(const std::vector<std::string>& fields, bool is_key)
     }
 }
 
+// Add fields to the Command from a vector of strings.
+void Command::add_keys(const std::vector<std::string>& keyfields)
+{
+    /* Copy field strings into a char* that is stored
+    locally in the Command object.  The new string is not
+    null terminated because the fields vector is of type
+    string_view which stores the length of the string
+    */
+    for (size_t i = 0; i < keyfields.size(); i++) {
+        add_field(keyfields[i], true);
+    }
+}
+
 // Get the value of the field field
 std::string Command::first_field() const
 {

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -106,8 +106,7 @@ bool Redis::key_exists(const std::string& key)
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("EXISTS");
-    cmd.add_field(key);
+    cmd << "EXISTS" << key;
 
     // Run it
     CommandReply reply = run(cmd);
@@ -123,9 +122,7 @@ bool Redis::hash_field_exists(const std::string& key,
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("HEXISTS");
-    cmd.add_field(key, true);
-    cmd.add_field(field);
+    cmd << "HEXISTS" << Keyfield(key) << field;
 
     // Run it
     CommandReply reply = run(cmd);
@@ -149,12 +146,8 @@ CommandReply Redis::put_tensor(TensorBase& tensor)
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("AI.TENSORSET");
-    cmd.add_field(tensor.name());
-    cmd.add_field(tensor.type_str());
-    cmd.add_fields(tensor.dims());
-    cmd.add_field("BLOB");
-    cmd.add_field_ptr(tensor.buf());
+    cmd << "AI.TENSORSET" << Keyfield(tensor.name()) << tensor.type_str()
+        << tensor.dims() << "BLOB" << tensor.buf();
 
     // Run it
     return run(cmd);
@@ -165,10 +158,7 @@ CommandReply Redis::get_tensor(const std::string& key)
 {
     // Build the command
     GetTensorCommand cmd;
-    cmd.add_field("AI.TENSORGET");
-    cmd.add_field(key);
-    cmd.add_field("META");
-    cmd.add_field("BLOB");
+    cmd << "AI.TENSORGET" << Keyfield(key) << "META" << "BLOB";
 
     // Run it
     return run(cmd);
@@ -180,9 +170,7 @@ CommandReply Redis::rename_tensor(const std::string& key,
 {
     // Build the command
     MultiKeyCommand cmd;
-    cmd.add_field("RENAME");
-    cmd.add_field(key);
-    cmd.add_field(new_key);
+    cmd << "RENAME" << Keyfield(key) << Keyfield(new_key);
 
     // Run it
     return run(cmd);
@@ -193,8 +181,7 @@ CommandReply Redis::delete_tensor(const std::string& key)
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("DEL");
-    cmd.add_field(key, true);
+    cmd << "DEL" << Keyfield(key);
 
     // Run it
     return run(cmd);
@@ -208,10 +195,7 @@ CommandReply Redis::copy_tensor(const std::string& src_key,
 
     // Build a GET command to fetch the tensor
     GetTensorCommand cmd_get;
-    cmd_get.add_field("AI.TENSORGET");
-    cmd_get.add_field(src_key, true);
-    cmd_get.add_field("META");
-    cmd_get.add_field("BLOB");
+    cmd_get << "AI.TENSORGET" << Keyfield(src_key) << "META" << "BLOB";
 
     // Run the GET command
     CommandReply cmd_get_reply = run(cmd_get);
@@ -228,12 +212,8 @@ CommandReply Redis::copy_tensor(const std::string& src_key,
     // Build a PUT command to send the tensor back to the database
     // under the new key
     MultiKeyCommand cmd_put;
-    cmd_put.add_field("AI.TENSORSET");
-    cmd_put.add_field(dest_key, true);
-    cmd_put.add_field(TENSOR_STR_MAP.at(type));
-    cmd_put.add_fields(dims);
-    cmd_put.add_field("BLOB");
-    cmd_put.add_field_ptr(blob);
+    cmd_put << "AI.TENSORSET" << Keyfield(dest_key) << TENSOR_STR_MAP.at(type)
+            << dims << "BLOB" << blob;
 
     // Run the PUT command
     return run(cmd_put);
@@ -281,34 +261,25 @@ CommandReply Redis::set_model(const std::string& model_name,
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("AI.MODELSET");
-    cmd.add_field(model_name);
-    cmd.add_field(backend);
-    cmd.add_field(device);
+    cmd << "AI.MODELSET" << Keyfield(model_name) << backend << device;
 
     // Add optional fields if requested
     if (tag.size() > 0) {
-        cmd.add_field("TAG");
-        cmd.add_field(tag);
+        cmd << "TAG" << tag;
     }
     if (batch_size > 0) {
-        cmd.add_field("BATCHSIZE");
-        cmd.add_field(std::to_string(batch_size));
+        cmd << "BATCHSIZE" << std::to_string(batch_size);
     }
     if (min_batch_size > 0) {
-        cmd.add_field("MINBATCHSIZE");
-        cmd.add_field(std::to_string(min_batch_size));
+        cmd << "MINBATCHSIZE" << std::to_string(min_batch_size);
     }
     if (inputs.size() > 0) {
-        cmd.add_field("INPUTS");
-        cmd.add_fields(inputs);
+        cmd << "INPUTS" << inputs;
     }
     if (outputs.size() > 0) {
-        cmd.add_field("OUTPUTS");
-        cmd.add_fields(outputs);
+        cmd << "OUTPUTS" << outputs;
     }
-    cmd.add_field("BLOB");
-    cmd.add_field_ptr(model);
+    cmd << "BLOB" << model;
 
     // Run it
     return run(cmd);
@@ -321,11 +292,7 @@ CommandReply Redis::set_script(const std::string& key,
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("AI.SCRIPTSET");
-    cmd.add_field(key, true);
-    cmd.add_field(device);
-    cmd.add_field("SOURCE");
-    cmd.add_field_ptr(script);
+    cmd << "AI.SCRIPTSET" << Keyfield(key) << device << "SOURCE" << script;
 
     // Run it
     return run(cmd);
@@ -338,12 +305,8 @@ CommandReply Redis::run_model(const std::string& key,
 {
     // Build the command
     CompoundCommand cmd;
-    cmd.add_field("AI.MODELRUN");
-    cmd.add_field(key);
-    cmd.add_field("INPUTS");
-    cmd.add_fields(inputs);
-    cmd.add_field("OUTPUTS");
-    cmd.add_fields(outputs);
+    cmd << "AI.MODELRUN" << Keyfield(key)
+        << "INPUTS" << inputs << "OUTPUTS" << outputs;
 
     // Run it
     return run(cmd);
@@ -358,13 +321,8 @@ CommandReply Redis::run_script(const std::string& key,
 {
     // Build the command
     CompoundCommand cmd;
-    cmd.add_field("AI.SCRIPTRUN");
-    cmd.add_field(key);
-    cmd.add_field(function);
-    cmd.add_field("INPUTS");
-    cmd.add_fields(inputs);
-    cmd.add_field("OUTPUTS");
-    cmd.add_fields(outputs);
+    cmd << "AI.SCRIPTRUN" << Keyfield(key) << function
+        << "INPUTS" << inputs << "OUTPUTS" << outputs;
 
     // Run it
     return run(cmd);
@@ -375,9 +333,7 @@ CommandReply Redis::get_model(const std::string& key)
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("AI.MODELGET");
-    cmd.add_field(key);
-    cmd.add_field("BLOB");
+    cmd << "AI.MODELGET" << Keyfield(key) << "BLOB";
 
     // Run it
     return run(cmd);
@@ -388,9 +344,7 @@ CommandReply Redis::get_script(const std::string& key)
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd.add_field("AI.SCRIPTGET");
-    cmd.add_field(key, true);
-    cmd.add_field("SOURCE");
+    cmd << "AI.SCRIPTGET" << Keyfield(key) << "SOURCE";
 
     // Run it
     return run(cmd);
@@ -416,12 +370,11 @@ CommandReply Redis::get_model_script_ai_info(const std::string& address,
 
     //Build the Command
     cmd.set_exec_address_port(host, port);
-    cmd.add_field("AI.INFO");
-    cmd.add_field(key);
+    cmd << "AI.INFO" << Keyfield(key);
 
     // Optionally add RESETSTAT to the command
     if (reset_stat) {
-        cmd.add_field("RESETSTAT");
+        cmd << "RESETSTAT";
     }
 
     return run(cmd);

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -261,7 +261,7 @@ CommandReply Redis::set_model(const std::string& model_name,
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd << "AI.MODELSET" << Keyfield(model_name) << backend << device;
+    cmd << "AI.MODELSTORE" << Keyfield(model_name) << backend << device;
 
     // Add optional fields if requested
     if (tag.size() > 0) {
@@ -274,10 +274,10 @@ CommandReply Redis::set_model(const std::string& model_name,
         cmd << "MINBATCHSIZE" << std::to_string(min_batch_size);
     }
     if (inputs.size() > 0) {
-        cmd << "INPUTS" << inputs;
+        cmd << "INPUTS" << std::to_string(inputs.size()) <<  inputs;
     }
     if (outputs.size() > 0) {
-        cmd << "OUTPUTS" << outputs;
+        cmd << "OUTPUTS" << std::to_string(outputs.size()) << outputs;
     }
     cmd << "BLOB" << model;
 
@@ -303,10 +303,17 @@ CommandReply Redis::run_model(const std::string& key,
                               std::vector<std::string> inputs,
                               std::vector<std::string> outputs)
 {
+    // Check for a non-default timeout setting
+    int run_timeout;
+    _init_integer_from_env(run_timeout, _MODEL_TIMEOUT_ENV_VAR,
+                           60 * 60 * 1000); // 1 hr
+
     // Build the command
     CompoundCommand cmd;
-    cmd << "AI.MODELRUN" << Keyfield(key)
-        << "INPUTS" << inputs << "OUTPUTS" << outputs;
+    cmd << "AI.MODELEXECUTE" << Keyfield(key)
+        << "INPUTS" << std::to_string(inputs.size()) << inputs
+        << "OUTPUTS" << std::to_string(outputs.size()) << outputs
+        << "TIMEOUT" << std::to_string(run_timeout);
 
     // Run it
     return run(cmd);

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -327,10 +327,12 @@ CommandReply RedisCluster::set_model(const std::string& model_name,
     for ( ; node != _db_nodes.cend(); node++) {
         // Build the node prefix
         std::string prefixed_key = "{" + node->prefix + "}." + model_name;
+        std::vector<std::string> tmp_inputs = _get_tmp_names(inputs, node->prefix);
+        std::vector<std::string> tmp_outputs = _get_tmp_names(outputs, node->prefix);
 
         // Build the MODELSET commnd
         CompoundCommand cmd;
-        cmd << "AI.MODELSET" << Keyfield(prefixed_key) << backend << device;
+        cmd << "AI.MODELSTORE" << Keyfield(prefixed_key) << backend << device;
 
         // Add optional fields as requested
         if (tag.size() > 0) {
@@ -343,10 +345,10 @@ CommandReply RedisCluster::set_model(const std::string& model_name,
             cmd << "MINBATCHSIZE" << std::to_string(min_batch_size);
         }
         if ( inputs.size() > 0) {
-            cmd << "INPUTS" << inputs;
+            cmd << "INPUTS" << std::to_string(tmp_inputs.size()) << inputs;
         }
         if (outputs.size() > 0) {
-            cmd << "OUTPUTS" << outputs;
+            cmd << "OUTPUTS" << std::to_string(tmp_outputs.size()) << outputs;
         }
         cmd << "BLOB" << model;
 
@@ -389,10 +391,15 @@ CommandReply RedisCluster::set_script(const std::string& key,
 }
 
 // Run a model in the database using the specificed input and output tensors
-CommandReply RedisCluster::run_model(const std::string& key,
+CommandReply RedisCluster::run_model(const std::string& model_name,
                                      std::vector<std::string> inputs,
                                      std::vector<std::string> outputs)
 {
+    // Check for a non-default timeout setting
+    int run_timeout;
+    _init_integer_from_env(run_timeout, _MODEL_TIMEOUT_ENV_VAR,
+                           60 * 60 * 1000); // 1 hr
+
     /*  For this version of run model, we have to copy all
         input and output tensors, so we will randomly select
         a model.  We can't use rand, because MPI would then
@@ -414,11 +421,15 @@ CommandReply RedisCluster::run_model(const std::string& key,
     // Copy all input tensors to temporary names to align hash slots
     copy_tensors(inputs, tmp_inputs);
 
+    // Use the model on our selected node
+    std::string model_key = "{" + db->prefix + "}." + std::string(model_name);
+
     // Build the MODELRUN command
-    std::string model_name = "{" + db->prefix + "}." + std::string(key);
     CompoundCommand cmd;
-    cmd << "AI.MODELRUN" << Keyfield(model_name) << "INPUTS" << tmp_inputs
-        << "OUTPUTS" << tmp_outputs;
+    cmd << "AI.MODELEXECUTE" << Keyfield(model_key)
+        << "INPUTS" << std::to_string(tmp_inputs.size()) << tmp_inputs
+        << "OUTPUTS" << std::to_string(tmp_outputs.size()) << tmp_outputs
+        << "TIMEOUT" << std::to_string(run_timeout);
 
     // Run it
     CommandReply reply = run(cmd);
@@ -433,12 +444,10 @@ CommandReply RedisCluster::run_model(const std::string& key,
 
     // Clean up the temp keys
     std::vector<std::string> keys_to_delete;
-    keys_to_delete.insert(keys_to_delete.end(),
-                            tmp_outputs.begin(),
-                            tmp_outputs.end());
-    keys_to_delete.insert(keys_to_delete.end(),
-                            tmp_inputs.begin(),
-                            tmp_inputs.end());
+    keys_to_delete.insert(
+        keys_to_delete.end(), tmp_outputs.begin(), tmp_outputs.end());
+    keys_to_delete.insert(
+        keys_to_delete.end(), tmp_inputs.begin(), tmp_inputs.end());
     _delete_keys(keys_to_delete);
 
     // Done

--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -33,7 +33,7 @@ use iso_c_binding, only : c_loc, c_f_pointer
 use, intrinsic :: iso_fortran_env, only: stderr => error_unit
 
 use smartredis_dataset, only : dataset_type
-use fortran_c_interop, only : convert_char_array_to_c
+use fortran_c_interop, only : convert_char_array_to_c, enum_kind
 
 implicit none; private
 
@@ -46,6 +46,11 @@ implicit none; private
 #include "client/script_interfaces.inc"
 #include "client/client_dataset_interfaces.inc"
 #include "client/ensemble_interfaces.inc"
+
+public :: enum_kind !< The kind of integer equivalent to a C enum. According to C an Fortran
+                    !! standards this should be c_int, but is renamed here to ensure that
+                    !! users do not have to import the iso_c_binding module into their
+                    !! programs
 
 !> Stores all data and methods associated with the SmartRedis client that is used to communicate with the database
 type, public :: client_type

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -29,6 +29,7 @@ module smartredis_dataset
 use iso_c_binding,   only : c_ptr, c_bool, c_null_ptr, c_char, c_int
 use iso_c_binding,   only : c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double, c_size_t
 use iso_c_binding,   only : c_loc, c_f_pointer
+use fortran_c_interop, only : enum_kind
 
 implicit none; private
 
@@ -37,6 +38,11 @@ include 'dataset/dataset_interfaces.inc'
 include 'dataset/add_tensor_interfaces.inc'
 include 'dataset/unpack_dataset_tensor_interfaces.inc'
 include 'dataset/metadata_interfaces.inc'
+
+public :: enum_kind !< The kind of integer equivalent to a C enum. According to C an Fortran
+                    !! standards this should be c_int, but is renamed here to ensure that
+                    !! users do not have to import the iso_c_binding module into their
+                    !! programs
 
 !> Contains multiple tensors and metadata used to describe an entire set of data
 type, public :: dataset_type

--- a/src/fortran/fortran_c_interop.F90
+++ b/src/fortran/fortran_c_interop.F90
@@ -26,10 +26,12 @@
 
 module fortran_c_interop
 
-use iso_c_binding, only : c_ptr, c_char, c_size_t, c_loc, c_null_ptr
+use iso_c_binding, only : c_ptr, c_char, c_size_t, c_loc, c_null_ptr, c_int
 
 implicit none; private
 
+integer, parameter, public :: enum_kind = c_int !< The kind of integer equivalent to a C enum. According
+                                                !! to the standard this is a c_int
 public :: convert_char_array_to_c
 
 contains
@@ -76,7 +78,7 @@ subroutine convert_char_array_to_c(character_array_f, character_array_c, string_
         string_ptrs(i) = c_loc(character_array_c(i))
      else
         string_ptrs(i) = c_null_ptr;
-     endif 
+     endif
   enddo
   ptr_to_string_ptrs = c_loc(string_ptrs)
 

--- a/tests/cpp/unit-tests/test_addressanycommand.cpp
+++ b/tests/cpp/unit-tests/test_addressanycommand.cpp
@@ -56,19 +56,16 @@ SCENARIO("Testing assignment operator for AddressAnyCommand", "[AddressAnyComman
             std::vector<std::string> cmd_keys;
 
             // add the fields to the Command
-            cmd.add_field(field_1, false);
-            cmd.add_field(field_2);
-            cmd.add_field(field_3);
+            cmd << field_1 << field_2 << field_3;
             cmd.add_field_ptr(field_4, field_size_4);
-            cmd.add_field_ptr(field_5);
-            cmd.add_fields(fields_1);
+            cmd << field_5 << fields_1;
 
 
             THEN("The AddressAnyCommand object can be copied "
                      "with the assignment operator")
             {
                 AddressAnyCommand* cmd_cpy = new AddressAnyCommand;
-                cmd_cpy->add_field("field_to_be_destroyed", true);
+                *cmd_cpy << Keyfield("field_to_be_destroyed");
 
                 *cmd_cpy = cmd;
 

--- a/tests/cpp/unit-tests/test_addressatcommand.cpp
+++ b/tests/cpp/unit-tests/test_addressatcommand.cpp
@@ -37,7 +37,7 @@ SCENARIO("Ensuring the iterators for an AddressAtCommand are correct", "[Address
     {
         AddressAtCommand cmd;
         std::string field = "INFO";
-        cmd.add_field(field);
+        cmd << field;
         WHEN("Iterators from the AddressAtKeyCommand object's "
              "_fields data member are retrieved")
         {
@@ -83,20 +83,16 @@ SCENARIO("Testing assignment operator for AddressAtCommand on heap", "[AddressAt
             std::vector<std::string> cmd_keys;
 
             // add fields
-            cmd->add_field(field_1, false);
-            cmd->add_field(field_2);
-            cmd->add_field(field_3);
+            *cmd << field_1 << field_2 << field_3;
             cmd->add_field_ptr(field_4, field_size_4);
-            cmd->add_field_ptr(field_5);
-            cmd->add_fields(fields_1);
-            cmd->add_field_ptr(field_sv);
+            *cmd << field_5 << fields_1 << field_sv;
 
             THEN("The AddressAtCommand can be copied with the assign "
                 "operator and then can be deleted while preserving "
                 "the original AddressAtCommand's state")
             {
                 AddressAtCommand* cmd_cpy = new AddressAtCommand;
-                cmd_cpy->add_field("field_to_be_destroyed", true);
+                *cmd_cpy << Keyfield("field_to_be_destroyed");
 
                 *cmd_cpy = *cmd;
 

--- a/tests/cpp/unit-tests/test_commandlist.cpp
+++ b/tests/cpp/unit-tests/test_commandlist.cpp
@@ -53,11 +53,11 @@ SCENARIO("Testing CommandList object", "[CommandList]")
             AddressAnyCommand* aany_cmd = cmd_lst.add_command<AddressAnyCommand>();
 
             std::vector<std::string> fields = {"TAG", "BLOB", "TAG", "INFO", "FLUSHALL"};
-            sk_cmd->add_field(fields[0], true);
-            mk_cmd->add_field(fields[1], true);
-            c_cmd->add_field(fields[2], true);
-            aat_cmd->add_field(fields[3]);
-            aany_cmd->add_field(fields[4]);
+            *sk_cmd << Keyfield(fields[0]);
+            *mk_cmd << Keyfield(fields[1]);
+            *c_cmd << Keyfield(fields[2]);
+            *aat_cmd << fields[3];
+            *aany_cmd << fields[4];
 
             THEN("The commands in the CommandList can be iterated "
                  "over with regular and const iterators")
@@ -196,7 +196,7 @@ SCENARIO("Testing CommandList object", "[CommandList]")
             {
                 CommandList* cmd_lst_cpy = new CommandList;
                 Command* tmp_cmd = cmd_lst_cpy->add_command<SingleKeyCommand>();
-                tmp_cmd->add_field("tmp_field", true);
+                *tmp_cmd << Keyfield("tmp_field");
 
                 *cmd_lst_cpy = cmd_lst;
 
@@ -285,16 +285,16 @@ SCENARIO("Testing CommandList object on heap", "[CommandList]")
         CompoundCommand* c_cmd = cmd_lst->add_command<CompoundCommand>();
 
         std::vector<std::string> fields = {"TAG", "BLOB", "TAG"};
-        sk_cmd->add_field(fields[0], true);
-        mk_cmd->add_field(fields[1], true);
-        c_cmd->add_field(fields[2], true);
+        *sk_cmd << Keyfield(fields[0]);
+        *mk_cmd << Keyfield(fields[1]);
+        *c_cmd << Keyfield(fields[2]);
 
         WHEN("A new CommandList is created usig the assignment "
              "operator and then the original is deleted")
         {
             CommandList* cmd_lst_cpy = new CommandList;
             SingleKeyCommand* tmp_cmd = cmd_lst_cpy->add_command<SingleKeyCommand>();
-            tmp_cmd->add_field("tmp_field", true);
+            *tmp_cmd << Keyfield("tmp_field");
 
             *cmd_lst_cpy = *cmd_lst;
 

--- a/tests/cpp/unit-tests/test_compoundcommand.cpp
+++ b/tests/cpp/unit-tests/test_compoundcommand.cpp
@@ -56,12 +56,10 @@ SCENARIO("Testing copy constructor and deep copy operator for CompoundCommand", 
             std::vector<std::string> cmd_keys;
 
             // add the fields to the Command
-            cmd.add_field(field_1, false);
-            cmd.add_field(field_2, true);
-            cmd.add_field(field_3, true);
+            cmd << field_1 << Keyfield(field_2) << Keyfield(field_3);
             cmd.add_field_ptr(field_4, field_size_4);
-            cmd.add_field_ptr(field_5);
-            cmd.add_fields(fields_1, true);
+            cmd << field_5;
+            cmd.add_keys(fields_1);
 
             THEN("A new CompoundCommand object can be constructed "
                      "with the copy constructor")

--- a/tests/cpp/unit-tests/test_multikeycommand.cpp
+++ b/tests/cpp/unit-tests/test_multikeycommand.cpp
@@ -56,12 +56,10 @@ SCENARIO("Adding fields of different types", "[MultiKeyCommand]")
             std::vector<std::string> cmd_keys;
 
             // add the fields to the Command
-            cmd.add_field(field_1, false);
-            cmd.add_field(field_2, true);
-            cmd.add_field(field_3, true);
+            cmd << field_1 << Keyfield(field_2) << Keyfield(field_3);
             cmd.add_field_ptr(field_4, field_size_4);
-            cmd.add_field_ptr(field_5);
-            cmd.add_fields(fields_1, true);
+            cmd << field_5;
+            cmd.add_keys(fields_1);
 
             THEN("The MultiKeyCommand object is structured correctly")
             {

--- a/tests/cpp/unit-tests/test_singlekeycommand.cpp
+++ b/tests/cpp/unit-tests/test_singlekeycommand.cpp
@@ -76,13 +76,11 @@ SCENARIO("Testing copy constructor for SingleKeyCommand on heap", "[SingleKeyCom
         std::vector<std::string> cmd_keys;
 
         // add fields
-        cmd->add_field(field_1, false);
-        cmd->add_field(field_2, true);
-        cmd->add_field(field_3, true);
+        *cmd << field_1 << Keyfield(field_2) << Keyfield(field_3);
         cmd->add_field_ptr(field_4, field_size_4);
-        cmd->add_field_ptr(field_5);
-        cmd->add_fields(fields_1, true);
-        cmd->add_field_ptr(field_sv);
+        *cmd << field_5;
+        cmd->add_keys(fields_1);
+        *cmd << field_sv;
 
         THEN("The SingleKeyCommand can be copied with the copy "
                  "constructor and then can be deleted while "

--- a/tests/docker/fortran/test_docker.F90
+++ b/tests/docker/fortran/test_docker.F90
@@ -32,7 +32,7 @@ program main
 
 #include "enum_fortran.inc"
 
-    integer(kind=enum_kind) :: result
+    integer :: result
     type(client_type) :: client
     integer, parameter :: dim1 = 10
     real(kind=8), dimension(dim1) :: tensor

--- a/tests/fortran/client_test_dataset.F90
+++ b/tests/fortran/client_test_dataset.F90
@@ -72,7 +72,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
   logical(kind=c_bool) :: exists
 
   call random_number(true_array_real_32)

--- a/tests/fortran/client_test_ensemble.F90
+++ b/tests/fortran/client_test_ensemble.F90
@@ -42,7 +42,7 @@ character(len=255) :: script_file, model_file
 
 real, dimension(10) :: tensor
 type(client_type) :: client
-integer(kind=enum_kind) :: result
+integer :: result
 logical(kind=c_bool) :: exists
 
 ensemble_keyout = "producer_0"

--- a/tests/fortran/client_test_initialized.F90
+++ b/tests/fortran/client_test_initialized.F90
@@ -36,7 +36,7 @@ program main
 #include "enum_fortran.inc"
 
   type(client_type) :: client
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   if (client%isinitialized()) stop 'client not initialized'
 

--- a/tests/fortran/client_test_misc_tensor.F90
+++ b/tests/fortran/client_test_misc_tensor.F90
@@ -43,7 +43,7 @@ program main
   real, dimension(10,10,10) :: array
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
   logical(kind=c_bool) :: exists
 
   result = client%initialize(use_cluster())

--- a/tests/fortran/client_test_mnist.F90
+++ b/tests/fortran/client_test_mnist.F90
@@ -42,7 +42,7 @@ program mnist_test
   type(client_type) :: client
   integer :: err_code
   character(len=2) :: key_suffix
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   result = client%initialize(use_cluster())
   if (result .ne. SRNoError) stop
@@ -74,7 +74,7 @@ subroutine run_mnist( client, model_name, script_name )
 
   character(len=255), dimension(1) :: inputs
   character(len=255), dimension(1) :: outputs
-  integer(kind=enum_kind) :: call_result
+  integer :: call_result
 
   ! Construct the keys used for the specifiying inputs and outputs
   in_key = "mnist_input"

--- a/tests/fortran/client_test_put_get_1D.F90
+++ b/tests/fortran/client_test_put_get_1D.F90
@@ -53,7 +53,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   call random_number(true_array_real_32)
   call random_number(true_array_real_64)

--- a/tests/fortran/client_test_put_get_2D.F90
+++ b/tests/fortran/client_test_put_get_2D.F90
@@ -54,7 +54,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   call random_number(true_array_real_32)
   call random_number(true_array_real_64)

--- a/tests/fortran/client_test_put_get_3D.F90
+++ b/tests/fortran/client_test_put_get_3D.F90
@@ -56,7 +56,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   call random_number(true_array_real_32)
   call random_number(true_array_real_64)

--- a/tests/fortran/client_test_put_get_unpack_dataset.F90
+++ b/tests/fortran/client_test_put_get_unpack_dataset.F90
@@ -56,7 +56,7 @@ program main
   integer :: i, j, k
   type(client_type)  :: client
   type(dataset_type) :: send_dataset, recv_dataset
-  integer(kind=enum_kind) :: result
+  integer :: result
   logical(kind=c_bool) :: exists
 
   integer :: err_code


### PR DESCRIPTION
Migrate `model_set ()` and `model_run()` to `AI.MODELSTORE` and `AI.MODELEXECUTE`, respectively; update docs.

Note: `AI.MODELEXECUTE` introduces a timeout for the duration of model execution that was not present in `AI.MODELRUN`. By default, we set a timeout of one hour; users may override this behavior by setting the environment variable `SR_MODEL_TIMEOUT` to a new value (in milliseconds).

This PR partially addresses ticket #133. The `script_set()` and `script_run()` commands have not been updated as this cannot be done without a breaking API change. Therefore ticket #133 should not be closed with this PR.