### PR TITLE
Set enum_kind based on Fortran standard

### DIFF
--- a/include/enum_fortran.inc
+++ b/include/enum_fortran.inc
@@ -24,13 +24,7 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-! Dummy enum, used to set the integer kind used
-enum, bind(c)
-  enumerator :: dummy = 0
-end enum
-integer, parameter :: enum_kind = kind(dummy)
-
-! The following enums have analogues to the C and C++ clients. Fortran does not haven named enums, but the name:value
+! The following enums have analogues to the C and C++ clients. Fortran does not have named enums, but the name:value
 ! parameters must be the same. By convention negative enums, represent items that are not supported in the Fortran
 ! client.
 

--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -33,7 +33,7 @@ use iso_c_binding, only : c_loc, c_f_pointer
 use, intrinsic :: iso_fortran_env, only: stderr => error_unit
 
 use smartredis_dataset, only : dataset_type
-use fortran_c_interop, only : convert_char_array_to_c
+use fortran_c_interop, only : convert_char_array_to_c, enum_kind
 
 implicit none; private
 
@@ -46,6 +46,11 @@ implicit none; private
 #include "client/script_interfaces.inc"
 #include "client/client_dataset_interfaces.inc"
 #include "client/ensemble_interfaces.inc"
+
+public :: enum_kind !< The kind of integer equivalent to a C enum. According to C an Fortran
+                    !! standards this should be c_int, but is renamed here to ensure that
+                    !! users do not have to import the iso_c_binding module into their
+                    !! programs
 
 !> Stores all data and methods associated with the SmartRedis client that is used to communicate with the database
 type, public :: client_type

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -29,6 +29,7 @@ module smartredis_dataset
 use iso_c_binding,   only : c_ptr, c_bool, c_null_ptr, c_char, c_int
 use iso_c_binding,   only : c_int8_t, c_int16_t, c_int32_t, c_int64_t, c_float, c_double, c_size_t
 use iso_c_binding,   only : c_loc, c_f_pointer
+use fortran_c_interop, only : enum_kind
 
 implicit none; private
 
@@ -37,6 +38,11 @@ include 'dataset/dataset_interfaces.inc'
 include 'dataset/add_tensor_interfaces.inc'
 include 'dataset/unpack_dataset_tensor_interfaces.inc'
 include 'dataset/metadata_interfaces.inc'
+
+public :: enum_kind !< The kind of integer equivalent to a C enum. According to C an Fortran
+                    !! standards this should be c_int, but is renamed here to ensure that
+                    !! users do not have to import the iso_c_binding module into their
+                    !! programs
 
 !> Contains multiple tensors and metadata used to describe an entire set of data
 type, public :: dataset_type

--- a/src/fortran/fortran_c_interop.F90
+++ b/src/fortran/fortran_c_interop.F90
@@ -26,10 +26,12 @@
 
 module fortran_c_interop
 
-use iso_c_binding, only : c_ptr, c_char, c_size_t, c_loc, c_null_ptr
+use iso_c_binding, only : c_ptr, c_char, c_size_t, c_loc, c_null_ptr, c_int
 
 implicit none; private
 
+integer, parameter, public :: enum_kind = c_int !< The kind of integer equivalent to a C enum. According
+                                                !! to the standard this is a c_int
 public :: convert_char_array_to_c
 
 contains
@@ -76,7 +78,7 @@ subroutine convert_char_array_to_c(character_array_f, character_array_c, string_
         string_ptrs(i) = c_loc(character_array_c(i))
      else
         string_ptrs(i) = c_null_ptr;
-     endif 
+     endif
   enddo
   ptr_to_string_ptrs = c_loc(string_ptrs)
 

--- a/tests/docker/fortran/test_docker.F90
+++ b/tests/docker/fortran/test_docker.F90
@@ -32,7 +32,7 @@ program main
 
 #include "enum_fortran.inc"
 
-    integer(kind=enum_kind) :: result
+    integer :: result
     type(client_type) :: client
     integer, parameter :: dim1 = 10
     real(kind=8), dimension(dim1) :: tensor

--- a/tests/fortran/client_test_dataset.F90
+++ b/tests/fortran/client_test_dataset.F90
@@ -72,7 +72,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
   logical(kind=c_bool) :: exists
 
   call random_number(true_array_real_32)

--- a/tests/fortran/client_test_ensemble.F90
+++ b/tests/fortran/client_test_ensemble.F90
@@ -42,7 +42,7 @@ character(len=255) :: script_file, model_file
 
 real, dimension(10) :: tensor
 type(client_type) :: client
-integer(kind=enum_kind) :: result
+integer :: result
 logical(kind=c_bool) :: exists
 
 ensemble_keyout = "producer_0"

--- a/tests/fortran/client_test_initialized.F90
+++ b/tests/fortran/client_test_initialized.F90
@@ -36,7 +36,7 @@ program main
 #include "enum_fortran.inc"
 
   type(client_type) :: client
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   if (client%isinitialized()) stop 'client not initialized'
 

--- a/tests/fortran/client_test_misc_tensor.F90
+++ b/tests/fortran/client_test_misc_tensor.F90
@@ -43,7 +43,7 @@ program main
   real, dimension(10,10,10) :: array
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
   logical(kind=c_bool) :: exists
 
   result = client%initialize(use_cluster())

--- a/tests/fortran/client_test_mnist.F90
+++ b/tests/fortran/client_test_mnist.F90
@@ -42,7 +42,7 @@ program mnist_test
   type(client_type) :: client
   integer :: err_code
   character(len=2) :: key_suffix
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   result = client%initialize(use_cluster())
   if (result .ne. SRNoError) stop
@@ -74,7 +74,7 @@ subroutine run_mnist( client, model_name, script_name )
 
   character(len=255), dimension(1) :: inputs
   character(len=255), dimension(1) :: outputs
-  integer(kind=enum_kind) :: call_result
+  integer :: call_result
 
   ! Construct the keys used for the specifiying inputs and outputs
   in_key = "mnist_input"

--- a/tests/fortran/client_test_put_get_1D.F90
+++ b/tests/fortran/client_test_put_get_1D.F90
@@ -53,7 +53,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   call random_number(true_array_real_32)
   call random_number(true_array_real_64)

--- a/tests/fortran/client_test_put_get_2D.F90
+++ b/tests/fortran/client_test_put_get_2D.F90
@@ -54,7 +54,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   call random_number(true_array_real_32)
   call random_number(true_array_real_64)

--- a/tests/fortran/client_test_put_get_3D.F90
+++ b/tests/fortran/client_test_put_get_3D.F90
@@ -56,7 +56,7 @@ program main
   type(client_type) :: client
 
   integer :: err_code
-  integer(kind=enum_kind) :: result
+  integer :: result
 
   call random_number(true_array_real_32)
   call random_number(true_array_real_64)

--- a/tests/fortran/client_test_put_get_unpack_dataset.F90
+++ b/tests/fortran/client_test_put_get_unpack_dataset.F90
@@ -56,7 +56,7 @@ program main
   integer :: i, j, k
   type(client_type)  :: client
   type(dataset_type) :: send_dataset, recv_dataset
-  integer(kind=enum_kind) :: result
+  integer :: result
   logical(kind=c_bool) :: exists
 
   integer :: err_code


### PR DESCRIPTION
The enum_kind is now set in the fortran_c_interop module but made
publicly availabe via the client and dataset modules. This differs
from the previous implementation which attempted to set enum_kind
by creating a dummy enum and detecting the kind of it at compile
time. This however, broke compilation with GCC 6.3.0, because
that compiler chain allows for different 'types' of enums (a
departure from the Fortran standard).

This also removes the explicit declaration of the kind in most of
the tests since Fortran assignment should automatically convert
the value to the correct kind that the variable (e.g. err_code)
is declared as.

Closes https://github.com/CrayLabs/SmartRedis/issues/216