### PR TITLE
GPU Support Utilities [preview -- do not merge] 

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -812,7 +812,7 @@ class Client
         /*!
         *   \brief Performs a synchronous save of the database shard,
         *          capturing a snapshot of all the data inside the Redis
-        *          instance  in the form of an RDB file.
+        *          instance in the form of an RDB file.
         *   \param address The address of the database node (host:port)
         *   \throw SmartRedis::Exception if the command fails or if the
         *          address is not addressable by this client.
@@ -825,6 +825,16 @@ class Client
         *          being thrown.
         */
         void save(std::string address);
+
+        /*!
+        *   \brief Configure which GPUs to use for scripts and models.
+        *   \param gpu_list a semicolon delimited list of GPUs to use for scripts
+        *                   and models, in the form "GPU:0; GPU:1; ..."
+        *   \throw SmartRedis::Exception if the command fails. Note that
+        *          this method makes no effort to verify that the requested
+        *          GPUs are present.
+        */
+        void select_gpus(std::string gpu_list);
 
     protected:
 

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -551,6 +551,16 @@ class PyClient
         */
         void save(std::vector<std::string> addresses);
 
+        /*!
+        *   \brief Configure which GPUs to use for scripts and models.
+        *   \param gpu_list a semicolon delimited list of GPUs to use for scripts
+        *                   and models, in the form "GPU:0; GPU:1; ..."
+        *   \throw RuntimeException if the command fails. Note that
+        *          this method makes no effort to verify that the requested
+        *          GPUs are present.
+        */
+        void select_gpus(std::string gpu_list);
+
     private:
 
         /*!

--- a/include/redis.h
+++ b/include/redis.h
@@ -348,21 +348,18 @@ class Redis : public RedisServer
     protected:
 
         /*!
+        *   \brief Get the list of devices registered for a model or script
+        *   \returns A vector of device names
+        *   \throw SmartRedis::RuntimeException if retrieval fails
+        */
+        std::vector<std::string> _get_device_list(std::string key);
+
+        /*!
         *   \brief Retrieve the list of GPUs to use for models and scripts
         *   \returns A vector of GPU selections
         *   \throw SmartRedis::RuntimeException if retrieval fails
         */
         virtual std::vector<std::string> _get_gpu_selection();
-
-        /*!
-        *   \brief Select a device for a script or model based on user request
-        *   \details If the user requests "GPU" and a set of GPUs have been
-        *            previously offered for execution, we give a random GPU
-        *            selection. Otherwise, we honor the user's request.
-        *   \param request The user request
-        *   \returns The selected device
-        */
-        std::string _select_device(std::string request);
 
     private:
 

--- a/include/redis.h
+++ b/include/redis.h
@@ -354,6 +354,16 @@ class Redis : public RedisServer
         */
         virtual std::vector<std::string> _get_gpu_selection();
 
+        /*!
+        *   \brief Select a device for a script or model based on user request
+        *   \details If the user requests "GPU" and a set of GPUs have been
+        *            previously offered for execution, we give a random GPU
+        *            selection. Otherwise, we honor the user's request.
+        *   \param request The user request
+        *   \returns The selected device
+        */
+        std::string _select_device(std::string request);
+
     private:
 
         /*!

--- a/include/redis.h
+++ b/include/redis.h
@@ -336,6 +336,24 @@ class Redis : public RedisServer
                                  const std::string& key,
                                  const bool reset_stat);
 
+        /*!
+        *   \brief Establish a list of GPUs to use for models and scripts
+        *   \param gpu_list A vector of GPU selections to select
+        *   \returns The CommandReply that contains the result
+        *            of adding the GPU list to the server
+        */
+        virtual CommandReply
+        select_gpus(std::vector<std::string> gpu_list);
+
+    protected:
+
+        /*!
+        *   \brief Retrieve the list of GPUs to use for models and scripts
+        *   \returns A vector of GPU selections
+        *   \throw SmartRedis::RuntimeException if retrieval fails
+        */
+        virtual std::vector<std::string> _get_gpu_selection();
+
     private:
 
         /*!

--- a/include/redis.h
+++ b/include/redis.h
@@ -349,10 +349,11 @@ class Redis : public RedisServer
 
         /*!
         *   \brief Get the list of devices registered for a model or script
-        *   \returns A vector of device names
+        *   \param key the key under which model/script devices were registered
+        *   \param result Receives a vector of device names
         *   \throw SmartRedis::RuntimeException if retrieval fails
         */
-        std::vector<std::string> _get_device_list(std::string key);
+        void _get_device_list(std::string key, std::vector<std::string>& result);
 
         /*!
         *   \brief Retrieve the list of GPUs to use for models and scripts

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -378,6 +378,16 @@ class RedisCluster : public RedisServer
         */
         virtual std::vector<std::string> _get_gpu_selection();
 
+        /*!
+        *   \brief Select a device for a script or model based on user request
+        *   \details If the user requests "GPU" and a set of GPUs have been
+        *            previously offered for execution, we give a random GPU
+        *            selection. Otherwise, we honor the user's request.
+        *   \param request The user request
+        *   \returns The selected device
+        */
+        std::string _select_device(std::string request);
+
     private:
 
         /*!

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -372,21 +372,18 @@ class RedisCluster : public RedisServer
         std::string _get_crc16_prefix(uint64_t hash_slot);
 
         /*!
+        *   \brief Get the list of devices registered for a model or script
+        *   \returns A vector of device names
+        *   \throw SmartRedis::RuntimeException if retrieval fails
+        */
+        std::vector<std::string> _get_device_list(std::string key);
+
+        /*!
         *   \brief Retrieve the list of GPUs to use for models and scripts
         *   \returns A vector of GPU selections
         *   \throw SmartRedis::RuntimeException if retrieval fails
         */
         virtual std::vector<std::string> _get_gpu_selection();
-
-        /*!
-        *   \brief Select a device for a script or model based on user request
-        *   \details If the user requests "GPU" and a set of GPUs have been
-        *            previously offered for execution, we give a random GPU
-        *            selection. Otherwise, we honor the user's request.
-        *   \param request The user request
-        *   \returns The selected device
-        */
-        std::string _select_device(std::string request);
 
     private:
 

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -351,6 +351,15 @@ class RedisCluster : public RedisServer
                                  const std::string& key,
                                  const bool reset_stat);
 
+        /*!
+        *   \brief Establish a list of GPUs to use for models and scripts
+        *   \param gpu_list A vector of GPU selections to select
+        *   \returns The CommandReply that contains the result
+        *            of adding the GPU list to the server
+        */
+        virtual CommandReply
+        select_gpus(std::vector<std::string> gpu_list);
+
     protected:
 
         /*!
@@ -361,6 +370,13 @@ class RedisCluster : public RedisServer
         *          or if hash_slot is greater than 16384.
         */
         std::string _get_crc16_prefix(uint64_t hash_slot);
+
+        /*!
+        *   \brief Retrieve the list of GPUs to use for models and scripts
+        *   \returns A vector of GPU selections
+        *   \throw SmartRedis::RuntimeException if retrieval fails
+        */
+        virtual std::vector<std::string> _get_gpu_selection();
 
     private:
 

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -373,10 +373,11 @@ class RedisCluster : public RedisServer
 
         /*!
         *   \brief Get the list of devices registered for a model or script
-        *   \returns A vector of device names
+        *   \param key the key under which model/script devices were registered
+        *   \param result Receives a vector of device names
         *   \throw SmartRedis::RuntimeException if retrieval fails
         */
-        std::vector<std::string> _get_device_list(std::string key);
+        void _get_device_list(std::string key, std::vector<std::string>& result);
 
         /*!
         *   \brief Retrieve the list of GPUs to use for models and scripts

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -341,6 +341,16 @@ class RedisServer {
                                  const std::string& key,
                                  const bool reset_stat) = 0;
 
+
+        /*!
+        *   \brief Establish a list of GPUs to use for models and scripts
+        *   \param gpu_list A vector of GPU selections to select
+        *   \returns The CommandReply that contains the result
+        *            of adding the GPU list to the server
+        */
+        virtual CommandReply
+        select_gpus(std::vector<std::string> gpu_list) = 0;
+
     protected:
 
         /*!
@@ -419,6 +429,12 @@ class RedisServer {
             "SR_CMD_INTERVAL";
 
         /*!
+        *   \brief Database key for the current GPU selection menu
+        */
+        inline static const std::string _DB_GPU_KEY =
+            "__SMARTSIM_GPUS";
+
+        /*!
         *   \brief Retrieve a single address, randomly
         *          chosen from a list of addresses if
         *          applicable, from the SSDB environment
@@ -469,7 +485,12 @@ class RedisServer {
         */
         void _check_runtime_variables();
 
-
+        /*!
+        *   \brief Retrieve the list of GPUs to use for models and scripts
+        *   \returns A vector of GPU selections
+        *   \throw SmartRedis::RuntimeException if retrieval fails
+        */
+        virtual std::vector<std::string> _get_gpu_selection() = 0;
 };
 
 } // namespace SmartRedis

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -32,6 +32,7 @@
 #include <thread>
 #include <iostream>
 #include "limits.h"
+#include <random>
 
 #include <sw/redis++/redis++.h>
 
@@ -382,6 +383,16 @@ class RedisServer {
         *   \brief The number of client command execution attempts
         */
         int _command_attempts;
+
+        /*!
+        *   \brief Seeding for the random number engine
+        */
+        std::random_device _rd;
+
+        /*!
+        *   \brief Random number generator
+        */
+        std::mt19937 _gen;
 
         /*!
         *   \brief Default value of connection timeout (seconds)

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -926,13 +926,19 @@ void Client::select_gpus(std::string gpu_list)
     const char *start = gpu_list.c_str();
     const char *gpus = gpu_list.c_str();
     do {
+        while (iswspace(*start))
+            start++;
+        gpus = start;
         while (*start != '\0') {
             if (*start == ';')
                 break;
+            start++;
         }
-        std::string gpu(gpus, start-gpus);
+        std::string gpu(gpus, start - gpus);
         parsed_list.push_back(gpu);
-        gpus = start + 1;
+        if (*start != '\0')
+            start++;
+        gpus = start;
     }
     while (*start != '\0');
 

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -903,6 +903,7 @@ void Client::config_set(std::string config_param, std::string value, std::string
         throw SRRuntimeException("CONFIG SET command failed");
 }
 
+// Performs a synchronous save of the database shard
 void Client::save(std::string address)
 {
     AddressAtCommand cmd;
@@ -916,6 +917,29 @@ void Client::save(std::string address)
     if (reply.has_error() > 0)
         throw SRRuntimeException("SAVE command failed");
 }
+
+// Configure which GPUs to use for scripts and models.
+void Client::select_gpus(std::string gpu_list)
+{
+    // Parse the string to extract the GPU list
+    std::vector<std::string> parsed_list;
+    const char *start = gpu_list.c_str();
+    const char *gpus = gpu_list.c_str();
+    do {
+        while (*start != '\0') {
+            if (*start == ';')
+                break;
+        }
+        std::string gpu(gpus, start-gpus);
+        parsed_list.push_back(gpu);
+        gpus = start + 1;
+    }
+    while (*start != '\0');
+
+    // Stuff the gpu list into the SMARTSIM key
+    _redis_server->select_gpus(parsed_list);
+}
+
 
 // Set the prefixes that are used for set and get methods using SSKEYIN
 // and SSKEYOUT environment variables.

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -843,7 +843,7 @@ void Client::flush_db(std::string address)
     AddressAtCommand cmd;
     std::string host = cmd.parse_host(address);
     uint64_t port = cmd.parse_port(address);
-    if (host.empty() or port == 0){
+    if (host.empty() || port == 0){
         throw SRRuntimeException(std::string(address) +
                                  "is not a valid database node address.");
     }

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -546,7 +546,7 @@ CommandReply Redis::select_gpus(std::vector<std::string> gpu_list)
 // Get the list of devices registered for a model or script
 void Redis::_get_device_list(std::string key, std::vector<std::string>& result)
 {
-    result.empty();
+    result.clear();
     std::string devices_key = key + ".devices";
 
     // Build the command

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -98,7 +98,8 @@ std::vector<CommandReply> Redis::run(CommandList& cmds)
 // Check if a model or script key exists in the database
 bool Redis::model_key_exists(const std::string& key)
 {
-    return key_exists(key);
+    // We'll check for the device registration
+    return key_exists(key + ".devices");
 }
 
 // Check if a key exists in the database
@@ -279,56 +280,110 @@ CommandReply Redis::set_model(const std::string& model_name,
                               const std::vector<std::string>& outputs
                               )
 {
-    // Build the command
-    SingleKeyCommand cmd;
-    cmd.add_field("AI.MODELSET");
-    cmd.add_field(model_name);
-    cmd.add_field(backend);
-    cmd.add_field(_select_device(device));
+    // Make a list of the devices to apply this model to
+    std::vector<std::string> device_list;
+    std::string GPU("GPU");
+    if (device.compare(GPU) == 0 || device.size() != GPU.size())
+        device_list.push_back(device);
+    else
+        device_list = _get_gpu_selection();
 
-    // Add optional fields if requested
-    if (tag.size() > 0) {
-        cmd.add_field("TAG");
-        cmd.add_field(tag);
+    // Register the device selection for this model
+    SingleKeyCommand register_cmd;
+    register_cmd.add_field("HMSET");
+    register_cmd.add_field(model_name + ".devices", true);
+    register_cmd.add_fields(device_list);
+    CommandReply result = run(register_cmd);
+    if (result.has_error() > 0) {
+        throw SRRuntimeException("Failed to register device list for model");
     }
-    if (batch_size > 0) {
-        cmd.add_field("BATCHSIZE");
-        cmd.add_field(std::to_string(batch_size));
-    }
-    if (min_batch_size > 0) {
-        cmd.add_field("MINBATCHSIZE");
-        cmd.add_field(std::to_string(min_batch_size));
-    }
-    if (inputs.size() > 0) {
-        cmd.add_field("INPUTS");
-        cmd.add_fields(inputs);
-    }
-    if (outputs.size() > 0) {
-        cmd.add_field("OUTPUTS");
-        cmd.add_fields(outputs);
-    }
-    cmd.add_field("BLOB");
-    cmd.add_field_ptr(model);
 
-    // Run it
-    return run(cmd);
+    // Send the model to Redis for each device
+    for (size_t i = 0; i < device_list.size(); i++) {
+        // Build the command
+        SingleKeyCommand cmd;
+        cmd.add_field("AI.MODELSET");
+        cmd.add_field(model_name + "." + device_list[i], true);
+        cmd.add_field(backend);
+        cmd.add_field(device_list[i]);
+
+        // Add optional fields if requested
+        if (tag.size() > 0) {
+            cmd.add_field("TAG");
+            cmd.add_field(tag);
+        }
+        if (batch_size > 0) {
+            cmd.add_field("BATCHSIZE");
+            cmd.add_field(std::to_string(batch_size));
+        }
+        if (min_batch_size > 0) {
+            cmd.add_field("MINBATCHSIZE");
+            cmd.add_field(std::to_string(min_batch_size));
+        }
+        if (inputs.size() > 0) {
+            cmd.add_field("INPUTS");
+            cmd.add_fields(inputs);
+        }
+        if (outputs.size() > 0) {
+            cmd.add_field("OUTPUTS");
+            cmd.add_fields(outputs);
+        }
+        cmd.add_field("BLOB");
+        cmd.add_field_ptr(model);
+
+        // Run it
+        result = run(cmd);
+        if (result.has_error() > 0) {
+            throw SRRuntimeException("Setting model failed for device: " + device_list[i]);
+        }
+    }
+
+    // Done
+    return result;
 }
 
 // Set a script from a string_view buffer in the database for future execution
-CommandReply Redis::set_script(const std::string& key,
+CommandReply Redis::set_script(const std::string& script_name,
                                const std::string& device,
                                std::string_view script)
 {
-    // Build the command
-    SingleKeyCommand cmd;
-    cmd.add_field("AI.SCRIPTSET");
-    cmd.add_field(key, true);
-    cmd.add_field(_select_device(device));
-    cmd.add_field("SOURCE");
-    cmd.add_field_ptr(script);
+    // Make a list of the devices to apply this script to
+    std::vector<std::string> device_list;
+    std::string GPU("GPU");
+    if (device.compare(GPU) == 0 || device.size() != GPU.size())
+        device_list.push_back(device);
+    else
+        device_list = _get_gpu_selection();
 
-    // Run it
-    return run(cmd);
+    // Register the device selection for this script
+    SingleKeyCommand register_cmd;
+    register_cmd.add_field("HMSET");
+    register_cmd.add_field(script_name + ".devices", true);
+    register_cmd.add_fields(device_list);
+    CommandReply result = run(register_cmd);
+    if (result.has_error() > 0) {
+        throw SRRuntimeException("Failed to register device list for script");
+    }
+
+    // Send the script to Redis for each device
+    for (size_t i = 0; i < device_list.size(); i++) {
+        // Build the command
+        SingleKeyCommand cmd;
+        cmd.add_field("AI.SCRIPTSET");
+        cmd.add_field(script_name + "." + device_list[i], true);
+        cmd.add_field(device_list[i]);
+        cmd.add_field("SOURCE");
+        cmd.add_field_ptr(script);
+
+        // Run it
+        result = run(cmd);
+        if (result.has_error() > 0) {
+            throw SRRuntimeException("Setting script failed for device: " + device_list[i]);
+        }
+    }
+
+    // Done
+    return result;
 }
 
 // Run a model in the database using the specificed input and output tensors
@@ -336,10 +391,15 @@ CommandReply Redis::run_model(const std::string& key,
                               std::vector<std::string> inputs,
                               std::vector<std::string> outputs)
 {
+    // Pick a device to run the model on
+    std::vector<std::string> device_list = _get_device_list(key);
+    std::uniform_int_distribution<> distrib(0, device_list.size() - 1);
+    std::string device = device_list[distrib(_gen)];
+
     // Build the command
     CompoundCommand cmd;
     cmd.add_field("AI.MODELRUN");
-    cmd.add_field(key);
+    cmd.add_field(key + "." + device);
     cmd.add_field("INPUTS");
     cmd.add_fields(inputs);
     cmd.add_field("OUTPUTS");
@@ -356,10 +416,15 @@ CommandReply Redis::run_script(const std::string& key,
                               std::vector<std::string> inputs,
                               std::vector<std::string> outputs)
 {
+    // Pick a device to run the script on
+    std::vector<std::string> device_list = _get_device_list(key);
+    std::uniform_int_distribution<> distrib(0, device_list.size() - 1);
+    std::string device = device_list[distrib(_gen)];
+
     // Build the command
     CompoundCommand cmd;
     cmd.add_field("AI.SCRIPTRUN");
-    cmd.add_field(key);
+    cmd.add_field(key + "." + device);
     cmd.add_field(function);
     cmd.add_field("INPUTS");
     cmd.add_fields(inputs);
@@ -373,10 +438,14 @@ CommandReply Redis::run_script(const std::string& key,
 // Retrieve the model from the database
 CommandReply Redis::get_model(const std::string& key)
 {
+    // Pick a device to get the model for
+    std::vector<std::string> device_list = _get_device_list(key + ".devices");
+    std::string device = device_list[0];
+
     // Build the command
     SingleKeyCommand cmd;
     cmd.add_field("AI.MODELGET");
-    cmd.add_field(key);
+    cmd.add_field(key + "." + device);
     cmd.add_field("BLOB");
 
     // Run it
@@ -386,10 +455,14 @@ CommandReply Redis::get_model(const std::string& key)
 // Retrieve the script from the database
 CommandReply Redis::get_script(const std::string& key)
 {
+    // Pick a device to get the script for
+    std::vector<std::string> device_list = _get_device_list(key + ".devices");
+    std::string device = device_list[0];
+
     // Build the command
     SingleKeyCommand cmd;
     cmd.add_field("AI.SCRIPTGET");
-    cmd.add_field(key, true);
+    cmd.add_field(key + "." + device, true);
     cmd.add_field("SOURCE");
 
     // Run it
@@ -414,10 +487,14 @@ CommandReply Redis::get_model_script_ai_info(const std::string& address,
                                  "non-cluster client connection.");
     }
 
+    // Pick a device to get info for
+    std::vector<std::string> device_list = _get_device_list(key);
+    std::string device = device_list[0];
+
     // Build the Command
     cmd.set_exec_address_port(host, port);
     cmd.add_field("AI.INFO");
-    cmd.add_field(key);
+    cmd.add_field(key + "." + device);
 
     // Optionally add RESETSTAT to the command
     if (reset_stat) {
@@ -443,6 +520,39 @@ CommandReply Redis::select_gpus(std::vector<std::string> gpu_list)
 
     // Run the command
     return run(cmd);
+}
+
+// Get the list of devices registered for a model or script
+std::vector<std::string> Redis::_get_device_list(std::string key)
+{
+    std::vector<std::string> result;
+    std::string devices_key = key + ".devices";
+
+    // Build the command
+    SingleKeyCommand cmd;
+    cmd.add_field("HGETALL");
+    cmd.add_field(devices_key, true);
+
+    // Run it
+    CommandReply reply = run(cmd);
+    if (reply.has_error() > 0) {
+        throw SRRuntimeException("no devices registered for script/model");
+    }
+
+    // Make sure we have paired elements
+    if ((reply.n_elements() % 2) != 0)
+        throw SRRuntimeException("The device registration reply "\
+                                "contains the wrong number of "\
+                                "elements.");
+
+    // Extract the GPU selections
+    for (size_t i = 0; i < reply.n_elements(); i += 2) {
+        std::string gpu_selection(reply[i + 1].str(), reply[i + 1].str_len());
+        result.push_back(gpu_selection);
+    }
+
+    // Done
+    return result;
 }
 
 // Retrieve the list of GPUs to use for models and scripts
@@ -483,26 +593,6 @@ std::vector<std::string> Redis::_get_gpu_selection()
 
     // Done
     return result;
-}
-
-std::string Redis::_select_device(std::string request)
-{
-    static std::vector<std::string> gpu_list;
-    static bool gpu_list_cached = false;
-
-    // If the user didn't request GPU, or requested a specific GPU,
-    // honor their choice
-    std::string GPU("GPU");
-    if (request.compare(GPU) == 0 || request.size() != GPU.size())
-        return request;
-
-    // Otherwise, pick a random GPU from the list
-    if (!gpu_list_cached) {
-        gpu_list = _get_gpu_selection();
-        gpu_list_cached = true;
-    }
-    std::uniform_int_distribution<> distrib(0, gpu_list.size() - 1);
-    return gpu_list[distrib(_gen)];
 }
 
 inline CommandReply Redis::_run(const Command& cmd)

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -722,7 +722,7 @@ CommandReply RedisCluster::select_gpus(std::vector<std::string> gpu_list)
 // Get the list of devices registered for a model or script
 void RedisCluster::_get_device_list(std::string key, std::vector<std::string>& result)
 {
-    result.empty();
+    result.clear();
     std::string devices_key = key + ".devices";
 
     // Build the command

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -38,6 +38,7 @@ static bool ___srand_seeded = false;
 
 // RedisServer constructor
 RedisServer::RedisServer()
+    : _gen(_rd())
 {
     _init_integer_from_env(_connection_timeout, _CONN_TIMEOUT_ENV_VAR,
                            _DEFAULT_CONN_TIMEOUT);

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -74,7 +74,8 @@ PYBIND11_MODULE(smartredisPy, m) {
         .def("flush_db", &PyClient::flush_db)
         .def("config_set", &PyClient::config_set)
         .def("config_get", &PyClient::config_get)
-        .def("save", &PyClient::save);
+        .def("save", &PyClient::save)
+        .def("select_gpus", &PyClient::select_gpus);
 
     // Python Dataset class
     py::class_<PyDataset>(m, "PyDataset")

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -973,6 +973,20 @@ class Client(PyClient):
         typecheck(addresses, "addresses", list)
         super().save(addresses)
 
+    @exception_handler
+    def select_gpus(self, gpu_list):
+        """Configures which GPUs to use for scripts and models.
+
+        :param gpu_list: a semicolon delimited list of GPUs to use for scripts
+                         and models, in the form "GPU:0; GPU:1; ..."
+        :type gpu_list: str
+        :raises RedisReplyError: if the command fails. Note that
+                                 this method makes no effort to verify that
+                                 the requested GPUs are present.
+        """
+        typecheck(gpu_list, "gpu_list", str)
+        super().select_gpus(gpu_list)
+
     # ---- helpers --------------------------------------------------------
 
     @staticmethod

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -869,4 +869,24 @@ void PyClient::save(std::vector<std::string> addresses)
     }
 }
 
+void PyClient::select_gpus(std::string gpu_list)
+{
+    try {
+        _client->select_gpus(gpu_list);
+    }
+    catch (Exception& e) {
+        // exception is already prepared for caller
+        throw;
+    }
+    catch (std::exception& e) {
+        // should never happen
+        throw SRInternalException(e.what());
+    }
+    catch (...) {
+        // should never happen
+        throw SRInternalException("A non-standard exception was encountered "\
+                                    "while executing select_gpus.");
+    }
+}
+
 // EOF


### PR DESCRIPTION
When setting a script or model with "GPU" allow SmartRedis to distribute the request to any available GPU if mulitple GPUs have previously been configured via a select_gpus command.