### PR TITLE
Update random number generation to not interfere with client code

### DIFF
--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -31,6 +31,7 @@
 
 #include <thread>
 #include <iostream>
+#include <random>
 #include "limits.h"
 
 #include <sw/redis++/redis++.h>
@@ -393,6 +394,16 @@ class RedisServer {
         *          intervals (milliseconds)
         */
         static constexpr int _DEFAULT_CMD_INTERVAL = 1000;
+
+        /*!
+        *   \brief Seeding for the random number engine
+        */
+        std::random_device _rd;
+
+        /*!
+        *   \brief Random number generator
+        */
+        std::mt19937 _gen;
 
         /*!
         *   \brief Environment variable for connection timeout

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -38,6 +38,7 @@ static bool ___srand_seeded = false;
 
 // RedisServer constructor
 RedisServer::RedisServer()
+    : _gen(_rd())
 {
     _init_integer_from_env(_connection_timeout, _CONN_TIMEOUT_ENV_VAR,
                            _DEFAULT_CONN_TIMEOUT);

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -32,10 +32,6 @@
 
 using namespace SmartRedis;
 
-// We should never seed srand more than once. There are more elegant ways
-// to prevent it, but this will suffice
-static bool ___srand_seeded = false;
-
 // RedisServer constructor
 RedisServer::RedisServer()
     : _gen(_rd())
@@ -87,19 +83,9 @@ std::string RedisServer::_get_ssdb()
         hosts_ports.push_back("tcp://"+
         env_str.substr(i_pos, j_pos - i_pos));
 
-    // Pick an entry from the list at random, seeding the RNG if needed
-    if (!___srand_seeded) {
-        std::chrono::high_resolution_clock::time_point t =
-            std::chrono::high_resolution_clock::now();
-
-        srand(std::chrono::time_point_cast<std::chrono::nanoseconds>(t).
-            time_since_epoch().count());
-        ___srand_seeded = true;
-    }
-    size_t hp = ((size_t)rand()) % hosts_ports.size();
-
-    // Done
-    return hosts_ports[hp];
+    // Pick an entry from the list at random
+    std::uniform_int_distribution<> distrib(0, hosts_ports.size() - 1);
+    return hosts_ports[distrib(_gen)];
 }
 
 // Check that the SSDB environment variable value does not have any errors


### PR DESCRIPTION
Replace usage of C-style global srand()/rand() methods with C++ local RNGs 