### PR TITLE
Update RedisAI calls to use non-deprecated API for Models

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -473,12 +473,17 @@ class Client
 
         /*!
         *   \brief Run a model in the database using the
+        *          specificed input and output tensors
         *   \details The model key used to locate the model to be run
         *            may be formed by applying a prefix to the supplied
         *            name. Similarly, the tensor names in the
         *            input and output vectors may be prefixed.
         *            See set_data_source(), use_model_ensemble_prefix(), and
-        *            use_tensor_ensemble_prefix() for more details
+        *            use_tensor_ensemble_prefix() for more details.
+        *            By default, models will run with a one hour timeout. To
+        *            modify the length of time that a model is allowed to run,
+        *            update the SR_MODEL_TIMEOUT to give a new value, in
+        *            milliseconds.
         *   \param name The name associated with the model
         *   \param inputs The tensor keys for inputs tensors to use
         *                 in the model

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -389,6 +389,11 @@ class RedisServer {
         static constexpr int _DEFAULT_CMD_TIMEOUT = 100;
 
         /*!
+        *   \brief Default value of model execution timeout (milliseconds)
+        */
+        static constexpr int _DEFAULT_MODEL_TIMEOUT = 60 * 1000 * 1000;
+
+        /*!
         *   \brief Default value of command execution attempt
         *          intervals (milliseconds)
         */

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -419,6 +419,12 @@ class RedisServer {
             "SR_CMD_INTERVAL";
 
         /*!
+        *   \brief Environment variable for model execution timeout
+        */
+        inline static const std::string _MODEL_TIMEOUT_ENV_VAR =
+            "SR_MODEL_TIMEOUT";
+
+        /*!
         *   \brief Retrieve a single address, randomly
         *          chosen from a list of addresses if
         *          applicable, from the SSDB environment

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -306,7 +306,7 @@ CommandReply Redis::run_model(const std::string& key,
     // Check for a non-default timeout setting
     int run_timeout;
     _init_integer_from_env(run_timeout, _MODEL_TIMEOUT_ENV_VAR,
-                           60 * 60 * 1000); // 1 hr
+                           _DEFAULT_MODEL_TIMEOUT);
 
     // Build the command
     CompoundCommand cmd;

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -261,7 +261,7 @@ CommandReply Redis::set_model(const std::string& model_name,
 {
     // Build the command
     SingleKeyCommand cmd;
-    cmd << "AI.MODELSET" << Keyfield(model_name) << backend << device;
+    cmd << "AI.MODELSTORE" << Keyfield(model_name) << backend << device;
 
     // Add optional fields if requested
     if (tag.size() > 0) {
@@ -274,10 +274,10 @@ CommandReply Redis::set_model(const std::string& model_name,
         cmd << "MINBATCHSIZE" << std::to_string(min_batch_size);
     }
     if (inputs.size() > 0) {
-        cmd << "INPUTS" << inputs;
+        cmd << "INPUTS" << std::to_string(inputs.size()) <<  inputs;
     }
     if (outputs.size() > 0) {
-        cmd << "OUTPUTS" << outputs;
+        cmd << "OUTPUTS" << std::to_string(outputs.size()) << outputs;
     }
     cmd << "BLOB" << model;
 
@@ -303,10 +303,17 @@ CommandReply Redis::run_model(const std::string& key,
                               std::vector<std::string> inputs,
                               std::vector<std::string> outputs)
 {
+    // Check for a non-default timeout setting
+    int run_timeout;
+    _init_integer_from_env(run_timeout, _MODEL_TIMEOUT_ENV_VAR,
+                           60 * 60 * 1000); // 1 hr
+
     // Build the command
     CompoundCommand cmd;
-    cmd << "AI.MODELRUN" << Keyfield(key)
-        << "INPUTS" << inputs << "OUTPUTS" << outputs;
+    cmd << "AI.MODELEXECUTE" << Keyfield(key)
+        << "INPUTS" << std::to_string(inputs.size()) << inputs
+        << "OUTPUTS" << std::to_string(outputs.size()) << outputs
+        << "TIMEOUT" << std::to_string(run_timeout);
 
     // Run it
     return run(cmd);

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -327,8 +327,6 @@ CommandReply RedisCluster::set_model(const std::string& model_name,
     for ( ; node != _db_nodes.cend(); node++) {
         // Build the node prefix
         std::string prefixed_key = "{" + node->prefix + "}." + model_name;
-        std::vector<std::string> tmp_inputs = _get_tmp_names(inputs, node->prefix);
-        std::vector<std::string> tmp_outputs = _get_tmp_names(outputs, node->prefix);
 
         // Build the MODELSET commnd
         CompoundCommand cmd;
@@ -345,10 +343,10 @@ CommandReply RedisCluster::set_model(const std::string& model_name,
             cmd << "MINBATCHSIZE" << std::to_string(min_batch_size);
         }
         if ( inputs.size() > 0) {
-            cmd << "INPUTS" << std::to_string(tmp_inputs.size()) << inputs;
+            cmd << "INPUTS" << std::to_string(inputs.size()) << inputs;
         }
         if (outputs.size() > 0) {
-            cmd << "OUTPUTS" << std::to_string(tmp_outputs.size()) << outputs;
+            cmd << "OUTPUTS" << std::to_string(outputs.size()) << outputs;
         }
         cmd << "BLOB" << model;
 

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -327,10 +327,12 @@ CommandReply RedisCluster::set_model(const std::string& model_name,
     for ( ; node != _db_nodes.cend(); node++) {
         // Build the node prefix
         std::string prefixed_key = "{" + node->prefix + "}." + model_name;
+        std::vector<std::string> tmp_inputs = _get_tmp_names(inputs, node->prefix);
+        std::vector<std::string> tmp_outputs = _get_tmp_names(outputs, node->prefix);
 
         // Build the MODELSET commnd
         CompoundCommand cmd;
-        cmd << "AI.MODELSET" << Keyfield(prefixed_key) << backend << device;
+        cmd << "AI.MODELSTORE" << Keyfield(prefixed_key) << backend << device;
 
         // Add optional fields as requested
         if (tag.size() > 0) {
@@ -343,10 +345,10 @@ CommandReply RedisCluster::set_model(const std::string& model_name,
             cmd << "MINBATCHSIZE" << std::to_string(min_batch_size);
         }
         if ( inputs.size() > 0) {
-            cmd << "INPUTS" << inputs;
+            cmd << "INPUTS" << std::to_string(tmp_inputs.size()) << inputs;
         }
         if (outputs.size() > 0) {
-            cmd << "OUTPUTS" << outputs;
+            cmd << "OUTPUTS" << std::to_string(tmp_outputs.size()) << outputs;
         }
         cmd << "BLOB" << model;
 
@@ -389,10 +391,15 @@ CommandReply RedisCluster::set_script(const std::string& key,
 }
 
 // Run a model in the database using the specificed input and output tensors
-CommandReply RedisCluster::run_model(const std::string& key,
+CommandReply RedisCluster::run_model(const std::string& model_name,
                                      std::vector<std::string> inputs,
                                      std::vector<std::string> outputs)
 {
+    // Check for a non-default timeout setting
+    int run_timeout;
+    _init_integer_from_env(run_timeout, _MODEL_TIMEOUT_ENV_VAR,
+                           60 * 60 * 1000); // 1 hr
+
     /*  For this version of run model, we have to copy all
         input and output tensors, so we will randomly select
         a model.  We can't use rand, because MPI would then
@@ -414,11 +421,15 @@ CommandReply RedisCluster::run_model(const std::string& key,
     // Copy all input tensors to temporary names to align hash slots
     copy_tensors(inputs, tmp_inputs);
 
+    // Use the model on our selected node
+    std::string model_key = "{" + db->prefix + "}." + std::string(model_name);
+
     // Build the MODELRUN command
-    std::string model_name = "{" + db->prefix + "}." + std::string(key);
     CompoundCommand cmd;
-    cmd << "AI.MODELRUN" << Keyfield(model_name) << "INPUTS" << tmp_inputs
-        << "OUTPUTS" << tmp_outputs;
+    cmd << "AI.MODELEXECUTE" << Keyfield(model_key)
+        << "INPUTS" << std::to_string(tmp_inputs.size()) << tmp_inputs
+        << "OUTPUTS" << std::to_string(tmp_outputs.size()) << tmp_outputs
+        << "TIMEOUT" << std::to_string(run_timeout);
 
     // Run it
     CommandReply reply = run(cmd);
@@ -433,12 +444,10 @@ CommandReply RedisCluster::run_model(const std::string& key,
 
     // Clean up the temp keys
     std::vector<std::string> keys_to_delete;
-    keys_to_delete.insert(keys_to_delete.end(),
-                            tmp_outputs.begin(),
-                            tmp_outputs.end());
-    keys_to_delete.insert(keys_to_delete.end(),
-                            tmp_inputs.begin(),
-                            tmp_inputs.end());
+    keys_to_delete.insert(
+        keys_to_delete.end(), tmp_outputs.begin(), tmp_outputs.end());
+    keys_to_delete.insert(
+        keys_to_delete.end(), tmp_inputs.begin(), tmp_inputs.end());
     _delete_keys(keys_to_delete);
 
     // Done

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -396,7 +396,7 @@ CommandReply RedisCluster::run_model(const std::string& model_name,
     // Check for a non-default timeout setting
     int run_timeout;
     _init_integer_from_env(run_timeout, _MODEL_TIMEOUT_ENV_VAR,
-                           60 * 60 * 1000); // 1 hr
+                           _DEFAULT_MODEL_TIMEOUT);
 
     /*  For this version of run model, we have to copy all
         input and output tensors, so we will randomly select


### PR DESCRIPTION
Migrate model_set () and model_run() to AI.MODELSTORE and AI.MODELEXECUTE, respectively; update docs.

Note: AI.MODELEXECUTE introduces a timeout for the duration of model execution that was not present in AI.MODELRUN. By default, we set a timeout of one hour; users may override this behavior by setting the environment variable SR_MODEL_TIMEOUT to a new value (in milliseconds).

This PR partially addresses ticket https://github.com/CrayLabs/SmartRedis/issues/133. The script_set() and script_run() commands have not been updated as this cannot be done without a breaking API change. Therefore ticket https://github.com/CrayLabs/SmartRedis/issues/133 should not be closed with this PR.

This is the reopened PR #229 