### PR TITLE
Add Redis cluster testing

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - redis-cluster-testing
   pull_request:
     branches:
       - master
@@ -16,6 +17,8 @@ env:
   HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
   HOMEBREW_NO_GITHUB_API: "ON"
   HOMEBREW_NO_INSTALL_CLEANUP: "ON"
+  TZ: "America/New_York" # for tzdata apt package
+  DEBIAN_FRONTEND: "noninteractive" # disable interactive apt installs
   SSDB: "127.0.0.1:6379"
   SMARTREDIS_TEST_CLUSTER: False
 
@@ -60,6 +63,27 @@ jobs:
         with:
           python-version: ${{ matrix.py_v }}
 
+      - name: Install utility software
+        run: |
+          sudo apt update && sudo apt-get -y install curl gnupg lsb-release software-properties-common ca-certificates && \
+          # Add latest redis to apt sources
+          echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list && \
+          curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
+          # Add latest docker to apt sources
+          echo  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+          sudo apt update && \
+          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server
+
+      - name: Copy redisai from docker image
+        run: |
+          docker create --name redisai --rm redislabs/redisai:1.2.5-cpu-bionic && \
+          docker cp redisai:/usr/lib/redis/modules/redisai.so $HOME &&
+          sudo mkdir -p /usr/lib/redis/modules/backends &&
+          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /home/runner/ &&
+          sudo mkdir -p /usr/lib/redis/modules/ &&
+          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /usr/lib/redis/modules/
+
       - name: Install GFortran Linux
         if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
         run: |
@@ -84,7 +108,7 @@ jobs:
           echo "CC=icc" >> $GITHUB_ENV &&
           echo "CXX=icpc" >> $GITHUB_ENV &&
           echo "FC=ifort" >> $GITHUB_ENV
-          
+
       - name: Install Cmake Linux
         if: contains(matrix.os, 'ubuntu')
         run: sudo apt-get install cmake
@@ -106,6 +130,29 @@ jobs:
 
       - name: Run C++ coverage tests # unit tests already built
         run: bash ./build-scripts/build_cpp_cov.sh
+
+      - name: setup local redis servers
+        run: |
+          redis-server --port 7000 --daemonize yes --cluster-enabled yes --cluster-config-file 7000.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
+          redis-server --port 7001 --daemonize yes --cluster-enabled yes --cluster-config-file 7001.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
+          redis-server --port 7002 --daemonize yes --cluster-enabled yes --cluster-config-file 7002.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so
+
+      - name: ping redis servers (for debugging)
+        run: |
+          redis-cli -p 7000 ping &&
+          redis-cli -p 7001 ping &&
+          redis-cli -p 7002 ping
+
+      - name: overwrite envs
+        run: |
+         echo "SSDB=127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002" > $GITHUB_ENV &&
+         echo "SMARTREDIS_TEST_CLUSTER=True" > $GITHUB_ENV
+
+      - name: start redis cluster
+        run: redis-cli --cluster create $(echo $SSDB | tr "," " ") --cluster-yes
+
+      - name: run cluster testing
+        run: make test-verbose
 
       - name: Upload Python coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           files: ./tests/cpp/unit-tests/build/CMakeFiles/cpp_unit_tests.dir/coverage.info
 
-      - name: Cluster setup: Install docker and redis-server
+      - name: Install docker and redis-server
         run: |
           sudo apt-get update && sudo apt-get -y install curl gnupg lsb-release software-properties-common ca-certificates && \
           # Add latest redis to apt sources
@@ -130,25 +130,25 @@ jobs:
           sudo apt-get update && \
           sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server
 
-      - name: Cluster setup: Copy redisai from docker image
+      - name: Copy redisai from docker image
         run: |
           docker create --name redisai --rm redislabs/redisai:${{ matrix.rai_v }}-cpu-bionic && \
           docker cp redisai:/usr/lib/redis/modules/redisai.so $HOME &&
           sudo mkdir -p /usr/lib/redis/modules/ &&
           sudo docker cp redisai:/usr/lib/redis/modules/backends/ /usr/lib/redis/modules/
 
-      - name: Cluster setup: Setup local redis servers
+      - name: Setup local redis servers
         run: |
           redis-server --port 7000 --daemonize yes --cluster-enabled yes --cluster-config-file 7000.conf --protected-mode no --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
           redis-server --port 7001 --daemonize yes --cluster-enabled yes --cluster-config-file 7001.conf --protected-mode no --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
           redis-server --port 7002 --daemonize yes --cluster-enabled yes --cluster-config-file 7002.conf --protected-mode no --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so
 
-      - name: Cluster setup: Overwrite redis cluster env vars
+      - name: Overwrite redis cluster env vars
         run: |
          echo "SSDB=127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002" >> $GITHUB_ENV &&
          echo "SMARTREDIS_TEST_CLUSTER=True" >> $GITHUB_ENV
 
-      - name: Cluster setup: Start redis cluster
+      - name: Start redis cluster
         run: redis-cli --cluster create $(echo $SSDB | tr "," " ") --cluster-yes
 
       - name: Run testing with redis cluster

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -152,5 +152,5 @@ jobs:
         run: redis-cli --cluster create $(echo $SSDB | tr "," " ") --cluster-yes
 
       - name: Run testing with redis cluster
-        run: PYTHONFAULTHANDLER=1 python -m pytest --ignore ./tests/docker -vv -s ./tests # make test-verbose without rebuilding tests
+        run: make test-verbose
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -128,7 +128,7 @@ jobs:
           echo  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
           sudo apt-get update && \
-          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server
+          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server=6:6.2.6-3rl1~focal1
 
       - name: Copy redisai from docker image
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - redis-cluster-testing # [DEBUG]
   pull_request:
     branches:
       - master
@@ -42,7 +41,7 @@ jobs:
       # Label used to access the service container
       redis:
         # Docker Hub image
-        image: redislabs/redisai:${{ matrix.rai_v }}-cpu-xenial
+        image: redislabs/redisai:${{ matrix.rai_v }}-cpu-bionic
 
         # Set health checks to wait until redis has started
         options: >-
@@ -109,7 +108,17 @@ jobs:
       - name: Run C++ coverage tests # unit tests already built
         run: bash ./build-scripts/build_cpp_cov.sh
 
-      - name: Install utility software
+      - name: Upload Python coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage.xml
+
+      - name: Upload C++ coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./tests/cpp/unit-tests/build/CMakeFiles/cpp_unit_tests.dir/coverage.info
+
+      - name: Cluster setup: Install docker and redis-server
         run: |
           sudo apt-get update && sudo apt-get -y install curl gnupg lsb-release software-properties-common ca-certificates && \
           # Add latest redis to apt sources
@@ -121,44 +130,27 @@ jobs:
           sudo apt-get update && \
           sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server
 
-      - name: Copy redisai from docker image
+      - name: Cluster setup: Copy redisai from docker image
         run: |
-          docker create --name redisai --rm redislabs/redisai:1.2.5-cpu-bionic && \
+          docker create --name redisai --rm redislabs/redisai:${{ matrix.rai_v }}-cpu-bionic && \
           docker cp redisai:/usr/lib/redis/modules/redisai.so $HOME &&
-          sudo mkdir -p /usr/lib/redis/modules/backends &&
-          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /home/runner/ &&
           sudo mkdir -p /usr/lib/redis/modules/ &&
           sudo docker cp redisai:/usr/lib/redis/modules/backends/ /usr/lib/redis/modules/
 
-      - name: setup local redis servers
+      - name: Cluster setup: Setup local redis servers
         run: |
-          redis-server --port 7000 --daemonize yes --cluster-enabled yes --cluster-config-file 7000.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
-          redis-server --port 7001 --daemonize yes --cluster-enabled yes --cluster-config-file 7001.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
-          redis-server --port 7002 --daemonize yes --cluster-enabled yes --cluster-config-file 7002.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so
+          redis-server --port 7000 --daemonize yes --cluster-enabled yes --cluster-config-file 7000.conf --protected-mode no --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
+          redis-server --port 7001 --daemonize yes --cluster-enabled yes --cluster-config-file 7001.conf --protected-mode no --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
+          redis-server --port 7002 --daemonize yes --cluster-enabled yes --cluster-config-file 7002.conf --protected-mode no --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so
 
-      - name: ping redis servers (for debugging)
-        run: |
-          redis-cli -p 7000 ping &&
-          redis-cli -p 7001 ping &&
-          redis-cli -p 7002 ping
-
-      - name: overwrite envs
+      - name: Cluster setup: Overwrite redis cluster env vars
         run: |
          echo "SSDB=127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002" >> $GITHUB_ENV &&
          echo "SMARTREDIS_TEST_CLUSTER=True" >> $GITHUB_ENV
 
-      - name: start redis cluster
+      - name: Cluster setup: Start redis cluster
         run: redis-cli --cluster create $(echo $SSDB | tr "," " ") --cluster-yes
 
-      - name: run cluster testing
+      - name: Run testing with redis cluster
         run: make test-verbose
 
-      - name: Upload Python coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          files: ./coverage.xml
-
-      - name: Upload C++ coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          files: ./tests/cpp/unit-tests/build/CMakeFiles/cpp_unit_tests.dir/coverage.info

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -128,7 +128,7 @@ jobs:
           echo  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
           sudo apt-get update && \
-          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server=6:6.2.6-3rl1~focal1
+          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server=6:6.2.5-1rl1~focal1
 
       - name: Copy redisai from docker image
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - develop
-      - redis-cluster-testing
+      - redis-cluster-testing # [DEBUG]
   pull_request:
     branches:
       - master
@@ -17,7 +17,6 @@ env:
   HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
   HOMEBREW_NO_GITHUB_API: "ON"
   HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-  TZ: "America/New_York" # for tzdata apt package
   DEBIAN_FRONTEND: "noninteractive" # disable interactive apt installs
   SSDB: "127.0.0.1:6379"
   SMARTREDIS_TEST_CLUSTER: False
@@ -32,7 +31,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
         compiler: [intel, 8, 9, 10, 11] # intel compiler, and versions of GNU compiler
-        rai_v: [1.2.4, 1.2.5] # verisons of RedisAI
+        rai_v: [1.2.4, 1.2.5] # versions of RedisAI
         py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
     env:
       FC: gfortran-${{ matrix.compiler }}
@@ -62,27 +61,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py_v }}
-
-      - name: Install utility software
-        run: |
-          sudo apt update && sudo apt-get -y install curl gnupg lsb-release software-properties-common ca-certificates && \
-          # Add latest redis to apt sources
-          echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list && \
-          curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
-          # Add latest docker to apt sources
-          echo  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-          sudo apt update && \
-          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server
-
-      - name: Copy redisai from docker image
-        run: |
-          docker create --name redisai --rm redislabs/redisai:1.2.5-cpu-bionic && \
-          docker cp redisai:/usr/lib/redis/modules/redisai.so $HOME &&
-          sudo mkdir -p /usr/lib/redis/modules/backends &&
-          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /home/runner/ &&
-          sudo mkdir -p /usr/lib/redis/modules/ &&
-          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /usr/lib/redis/modules/
 
       - name: Install GFortran Linux
         if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
@@ -131,6 +109,27 @@ jobs:
       - name: Run C++ coverage tests # unit tests already built
         run: bash ./build-scripts/build_cpp_cov.sh
 
+      - name: Install utility software
+        run: |
+          sudo apt-get update && sudo apt-get -y install curl gnupg lsb-release software-properties-common ca-certificates && \
+          # Add latest redis to apt sources
+          echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list && \
+          curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
+          # Add latest docker to apt sources
+          echo  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+          sudo apt-get update && \
+          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server
+
+      - name: Copy redisai from docker image
+        run: |
+          docker create --name redisai --rm redislabs/redisai:1.2.5-cpu-bionic && \
+          docker cp redisai:/usr/lib/redis/modules/redisai.so $HOME &&
+          sudo mkdir -p /usr/lib/redis/modules/backends &&
+          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /home/runner/ &&
+          sudo mkdir -p /usr/lib/redis/modules/ &&
+          sudo docker cp redisai:/usr/lib/redis/modules/backends/ /usr/lib/redis/modules/
+
       - name: setup local redis servers
         run: |
           redis-server --port 7000 --daemonize yes --cluster-enabled yes --cluster-config-file 7000.conf --protected-mode no --cluster-node-timeout 30000 --loadmodule $HOME/redisai.so TF /usr/lib/redis/modules/backends/redisai_tensorflow/redisai_tensorflow.so TORCH /usr/lib/redis/modules/backends/redisai_torch/redisai_torch.so  &
@@ -145,8 +144,8 @@ jobs:
 
       - name: overwrite envs
         run: |
-         echo "SSDB=127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002" > $GITHUB_ENV &&
-         echo "SMARTREDIS_TEST_CLUSTER=True" > $GITHUB_ENV
+         echo "SSDB=127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002" >> $GITHUB_ENV &&
+         echo "SMARTREDIS_TEST_CLUSTER=True" >> $GITHUB_ENV
 
       - name: start redis cluster
         run: redis-cli --cluster create $(echo $SSDB | tr "," " ") --cluster-yes

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -128,7 +128,7 @@ jobs:
           echo  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
           sudo apt-get update && \
-          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-server=6:6.2.5-1rl1~focal1
+          sudo apt-get -y install iputils-ping docker-ce docker-ce-cli containerd.io redis-tools=6:6.2.5-1rl1~focal1 redis-server=6:6.2.5-1rl1~focal1
 
       - name: Copy redisai from docker image
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -152,5 +152,5 @@ jobs:
         run: redis-cli --cluster create $(echo $SSDB | tr "," " ") --cluster-yes
 
       - name: Run testing with redis cluster
-        run: make test-verbose
+        run: PYTHONFAULTHANDLER=1 python -m pytest --ignore ./tests/docker -vv -s ./tests # make test-verbose without rebuilding tests
 


### PR DESCRIPTION
This PR appends Redis cluster testing to the existing `run_tests` suite, such that the full test suite gets run with a redis cluster across the full test matrix.

The setup involves:

- Installing some additional dependencies
    - docker and redis-server (6.2.5, same version that redisai image uses)
- Installing redisai by copying it out of the docker container into `$HOME`
- Creating a local redis cluster with 3 daemonized redis servers
- Overwriting the `SSDB` and `SMARTREDIS_TEST_CLUSTER` environment variables

Also in this PR:

- updated the redisai service container to use a more recent ubuntu version (bionic, 18.0.4 instead of xenial, 16.0.4) for the image, to keep the images we use consistent.