### PR TITLE
Add timing info for the beginning of each test case in CPP unit tests

### DIFF
--- a/tests/cpp/dataset_test_utils.h
+++ b/tests/cpp/dataset_test_utils.h
@@ -246,8 +246,6 @@ void check_meta_field(SmartRedis::DataSet& dataset,
                                 " was retrieved.");
         }
     }
-
-    std::cout<<"Correct fetched metadata field "<<field_name<<std::endl;
 }
 
 /*!
@@ -276,7 +274,6 @@ void check_tensor_names(SmartRedis::DataSet& dataset,
                                      "does not match the retrieved "\
                                      "value of " + names[i]);
     }
-    std::cout<<"Correctly fetched metadata tensor names."<<std::endl;
 }
 
 
@@ -348,8 +345,6 @@ void check_dataset_metadata(SmartRedis::DataSet& dataset)
     if(str_meta_3.compare(str_meta_field_2[0])!=0)
         throw std::runtime_error("The retrieved value for "\
                                 "str_meta_3 is incorrect.");
-
-    std::cout<<"Correctly fetched string type metadata"<<std::endl;
 }
 
 };  //Namespace DATASET_TEST_UTILS

--- a/tests/cpp/unit-tests/main.cpp
+++ b/tests/cpp/unit-tests/main.cpp
@@ -29,3 +29,20 @@
 #define CATCH_CONFIG_MAIN
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "srexception.h"
+#include <ctime>
+
+std::time_t start_time;
+bool initialized = false;
+
+time_t get_start_time() {
+    if (initialized)
+        return start_time;
+    start_time = std::time(NULL);
+    initialized = true;
+    return start_time;
+}
+
+unsigned long get_time_offset() {
+    std::time_t now = std::time(NULL);
+    return (unsigned long)((unsigned long)now - (unsigned long)get_start_time());
+}

--- a/tests/cpp/unit-tests/test_addressanycommand.cpp
+++ b/tests/cpp/unit-tests/test_addressanycommand.cpp
@@ -30,11 +30,13 @@
 #include "addressanycommand.h"
 #include "redisserver.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Testing assignment operator for AddressAnyCommand", "[AddressAnyCommand]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing assignment operator for AddressAnyCommand" << std::endl;
     GIVEN("An AddressAnyCommand object")
     {
         AddressAnyCommand cmd;
@@ -102,7 +104,7 @@ SCENARIO("Testing assignment operator for AddressAnyCommand", "[AddressAnyComman
 
 SCENARIO("Testing AddressAnyCommand member variables", "[AddressAnyCommand]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing AddressAnyCommand member variables" << std::endl;
     GIVEN("An AddressAnyCommand object and a db node address and port")
     {
         AddressAnyCommand cmd;

--- a/tests/cpp/unit-tests/test_addressatcommand.cpp
+++ b/tests/cpp/unit-tests/test_addressatcommand.cpp
@@ -29,10 +29,13 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "addressatcommand.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Ensuring the iterators for an AddressAtCommand are correct", "[AddressAtCommand]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Ensuring the iterators for an AddressAtCommand are correct" << std::endl;
     GIVEN("An AddressAtCommand with a single field")
     {
         AddressAtCommand cmd;
@@ -60,6 +63,7 @@ SCENARIO("Ensuring the iterators for an AddressAtCommand are correct", "[Address
 
 SCENARIO("Testing assignment operator for AddressAtCommand on heap", "[AddressAtCommand]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Testing assignment operator for AddressAtCommand on heap" << std::endl;
     GIVEN("An AddressAtCommand object on the heap")
     {
         AddressAtCommand* cmd = new AddressAtCommand;
@@ -130,7 +134,7 @@ SCENARIO("Testing assignment operator for AddressAtCommand on heap", "[AddressAt
 
 SCENARIO("Testing AddressAtCommand member variables", "[AddressAtCommand]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing AddressAnyCommand member variables" << std::endl;
     GIVEN("An AddressAtCommand object")
     {
         AddressAtCommand* cmd = new AddressAtCommand;

--- a/tests/cpp/unit-tests/test_aggregation_list.cpp
+++ b/tests/cpp/unit-tests/test_aggregation_list.cpp
@@ -34,6 +34,8 @@
 #include "srexception.h"
 #include <sstream>
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 // helper function that determines whether two
@@ -143,6 +145,7 @@ bool is_same_dataset(DataSet& dataset_1, DataSet& dataset_2)
 
 SCENARIO("Testing Dataset aggregation via our client", "[List]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Testing Dataset aggregation via our client" << std::endl;
     GIVEN("A Client object and vector of DataSet objects")
     {
         Client client(use_cluster());

--- a/tests/cpp/unit-tests/test_client.cpp
+++ b/tests/cpp/unit-tests/test_client.cpp
@@ -33,6 +33,8 @@
 #include "srexception.h"
 #include <sstream>
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 // helper function that determines whether two
@@ -92,7 +94,7 @@ void check_all_data(size_t length, std::vector<void*>& original_datas,
 
 SCENARIO("Testing Dataset Functions on Client Object", "[Client]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing Dataset Functions on Client Object" << std::endl;
     GIVEN("A Client object")
     {
         Client client(use_cluster());
@@ -188,7 +190,7 @@ SCENARIO("Testing Dataset Functions on Client Object", "[Client]")
 
 SCENARIO("Testing Tensor Functions on Client Object", "[Client]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing Tensor Functions on Client Object" << std::endl;
     GIVEN("A Client object")
     {
         Client client(use_cluster());
@@ -468,7 +470,7 @@ SCENARIO("Testing Tensor Functions on Client Object", "[Client]")
 
 SCENARIO("Testing INFO Functions on Client Object", "[Client]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing INFO Functions on Client Object" << std::endl;
     GIVEN("A Client object")
     {
         Client client(use_cluster());
@@ -517,6 +519,7 @@ SCENARIO("Testing INFO Functions on Client Object", "[Client]")
 
 SCENARIO("Testing AI.INFO Functions on Client Object", "[Client]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Testing AI.INFO Functions on Client Object" << std::endl;
     GIVEN("A Client object")
     {
         Client client(use_cluster());
@@ -565,7 +568,7 @@ SCENARIO("Testing AI.INFO Functions on Client Object", "[Client]")
 
 SCENARIO("Testing FLUSHDB on empty Client Object", "[Client][FLUSHDB]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing FLUSHDB on empty Client Object" << std::endl;
     GIVEN("An empty non-cluster Client object")
     {
         Client client(use_cluster());
@@ -600,7 +603,7 @@ SCENARIO("Testing FLUSHDB on empty Client Object", "[Client][FLUSHDB]")
 
 SCENARIO("Testing FLUSHDB on Client Object", "[Client][FLUSHDB]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing FLUSHDB on Client Object" << std::endl;
     GIVEN("A non-cluster Client object")
     {
         // From within the testing framework, there is no way of knowing
@@ -641,7 +644,7 @@ SCENARIO("Testing FLUSHDB on Client Object", "[Client][FLUSHDB]")
 
 SCENARIO("Testing CONFIG GET and CONFIG SET on Client Object", "[Client]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing CONFIG GET and CONFIG SET on Client Object" << std::endl;
     GIVEN("A Client object")
     {
         Client client(use_cluster());
@@ -686,6 +689,7 @@ SCENARIO("Testing CONFIG GET and CONFIG SET on Client Object", "[Client]")
 
 SCENARIO("Test CONFIG GET on an unsupported command", "[Client]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Test CONFIG GET on an unsupported command" << std::endl;
     GIVEN("A client object")
     {
         Client client(use_cluster());
@@ -706,6 +710,7 @@ SCENARIO("Test CONFIG GET on an unsupported command", "[Client]")
 
 SCENARIO("Test CONFIG SET on an unsupported command", "[Client]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Test CONFIG SET on an unsupported command" << std::endl;
     GIVEN("A client object")
     {
         Client client(use_cluster());
@@ -726,7 +731,7 @@ SCENARIO("Test CONFIG SET on an unsupported command", "[Client]")
 
 SCENARIO("Testing SAVE command on Client Object", "[!mayfail][Client][SAVE]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing SAVE command on Client Object" << std::endl;
     GIVEN("A client object and some data")
     {
         Client client(use_cluster());
@@ -766,7 +771,7 @@ SCENARIO("Testing SAVE command on Client Object", "[!mayfail][Client][SAVE]")
 
 SCENARIO("Test that prefixing covers all hash slots of a cluster", "[Client]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test that prefixing covers all hash slots of a cluster" << std::endl;
     if(use_cluster()==false)
         return;
 
@@ -805,6 +810,7 @@ SCENARIO("Test that prefixing covers all hash slots of a cluster", "[Client]")
 
 SCENARIO("Testing Multi-GPU Function error cases", "[Client]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Testing Multi-GPU Function error cases" << std::endl;
     GIVEN("A Client object, a script, and a model")
     {
         Client client(use_cluster());

--- a/tests/cpp/unit-tests/test_client_ensemble.cpp
+++ b/tests/cpp/unit-tests/test_client_ensemble.cpp
@@ -31,6 +31,8 @@
 #include "dataset.h"
 #include "../client_test_utils.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 // helper function for resetting environment
@@ -87,7 +89,7 @@ void load_mnist_image_to_array(float**** img)
 
 SCENARIO("Testing Client ensemble using a producer/consumer paradigm")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing Client ensemble using a producer/consumer paradigm" << std::endl;
     GIVEN("Variables that will be used by the producer and consumer")
     {
         const char* old_keyin = std::getenv("SSKEYIN");

--- a/tests/cpp/unit-tests/test_clusterinfocommand.cpp
+++ b/tests/cpp/unit-tests/test_clusterinfocommand.cpp
@@ -29,10 +29,13 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "clusterinfocommand.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Parsing an empty string for cluster info")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Parsing an empty string for cluster info" << std::endl;
     GIVEN("A ClusterInfoCommand and an empty string")
     {
         ClusterInfoCommand cmd;

--- a/tests/cpp/unit-tests/test_commandlist.cpp
+++ b/tests/cpp/unit-tests/test_commandlist.cpp
@@ -35,11 +35,13 @@
 #include "addressanycommand.h"
 #include "client.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Testing CommandList object", "[CommandList]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing CommandList objectinfo" << std::endl;
     GIVEN("A CommandList object")
     {
         CommandList cmd_lst;
@@ -287,7 +289,7 @@ SCENARIO("Testing CommandList object", "[CommandList]")
 
 SCENARIO("Testing CommandList object on heap", "[CommandList]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing CommandList object on heap" << std::endl;
     GIVEN("A CommandList object on the heap with three Commands")
     {
         CommandList* cmd_lst = new CommandList;

--- a/tests/cpp/unit-tests/test_commandreply.cpp
+++ b/tests/cpp/unit-tests/test_commandreply.cpp
@@ -30,6 +30,8 @@
 #include "commandreply.h"
 #include "srexception.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 /*
@@ -101,7 +103,7 @@ void fill_reply_array(redisReply*& reply, int num_of_children)
 
 SCENARIO("Testing CommandReply object", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing CommandReply object" << std::endl;
     GIVEN("A CommandReply object with type REDIS_REPLY_INTEGER")
     {
         redisReply* reply = new redisReply;
@@ -162,7 +164,7 @@ SCENARIO("Testing CommandReply object", "[CommandReply]")
 SCENARIO("Test CommandReply copy assignment operator and copy "
          "constructor on simple REDIS_REPLY_TYPES", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test CommandReply copy assignment operator and copy" << std::endl;
     GIVEN("A CommandReply")
     {
         redisReply* reply = new redisReply;
@@ -207,7 +209,7 @@ SCENARIO("Test CommandReply copy assignment operator and copy "
 
 SCENARIO("Test CommandReply::has_error", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test CommandReply::has_error" << std::endl;
     GIVEN("A parent and child redisReply")
     {
         char const* str = "ERR";
@@ -234,7 +236,7 @@ SCENARIO("Test CommandReply::has_error", "[CommandReply]")
 SCENARIO("CommandReply copy assignment operator preserves the state of the "
          "rvalue and the lvalue when one of the objects are deleted", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": CommandReply copy assignment operator preserves the state of the" << std::endl;
     GIVEN("Two dynamically allocated CommandReply. One with a complex "
           "redisReply, and the other with a simple redisReply")
     {
@@ -322,7 +324,7 @@ SCENARIO("CommandReply copy assignment operator preserves the state of the "
 
 SCENARIO("Simple tests on CommandReply constructors that use redisReply*", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Simple tests on CommandReply constructors that use redisReply*" << std::endl;
     GIVEN("A redisReply")
     {
         char const* str = "100.0";
@@ -368,7 +370,7 @@ SCENARIO("Simple tests on CommandReply constructors that use redisReply*", "[Com
 
 SCENARIO("Test CommandReply copy constructor with an inconsistent redisReply", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test CommandReply copy constructor with an inconsistent redisReply" << std::endl;
     GIVEN("An inconsistent redisReply where its 'elements' doesn't "\
           "correspond to its 'element'")
     {
@@ -394,7 +396,7 @@ SCENARIO("Test CommandReply copy constructor with an inconsistent redisReply", "
 
 SCENARIO("Test CommandReply's redisReply deep copy on a shallow copy", "[CommandReply]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test CommandReply's redisReply deep copy on a shallow copy" << std::endl;
     GIVEN("A CommandReply with redisReply type REDIS_REPLY_ARRAY")
     {
         char const* strs[] = {"zero", "one"};
@@ -433,6 +435,7 @@ SCENARIO("Test CommandReply's redisReply deep copy on a shallow copy", "[Command
 
 SCENARIO("Test CommandReply string retrieval for non REDIS_REPLY_STRING", "[CommandReply]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Test CommandReply string retrieval for non REDIS_REPLY_STRING" << std::endl;
     char const* strs[] = {"OK", "42.5", "99999999999999999999", "Verbatim string"};
     int lens[] = {3, 5, 21, 16};
     int types[] = {REDIS_REPLY_STATUS, REDIS_REPLY_DOUBLE, REDIS_REPLY_BIGNUM, REDIS_REPLY_VERB};
@@ -471,6 +474,7 @@ SCENARIO("Test CommandReply string retrieval for non REDIS_REPLY_STRING", "[Comm
 
 SCENARIO("Test REDIS_REPLY_ERROR retrieval from a CommandReply", "[CommandReply]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Test REDIS_REPLY_ERROR retrieval from a CommandReply" << std::endl;
     /*
             CommanReply (ARRAY)     LEVEL 0
             /    |    \

--- a/tests/cpp/unit-tests/test_compoundcommand.cpp
+++ b/tests/cpp/unit-tests/test_compoundcommand.cpp
@@ -29,11 +29,13 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "compoundcommand.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Testing copy constructor and deep copy operator for CompoundCommand", "[CompoundCommand]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing copy constructor and deep copy operator for CompoundCommand" << std::endl;
     GIVEN("A CompoundCommand object")
     {
         CompoundCommand cmd;

--- a/tests/cpp/unit-tests/test_dataset.cpp
+++ b/tests/cpp/unit-tests/test_dataset.cpp
@@ -31,6 +31,8 @@
 #include "srexception.h"
 #include <cxxabi.h>
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 const char *currentExceptionTypeName() {
@@ -41,7 +43,7 @@ const char *currentExceptionTypeName() {
 
 SCENARIO("Testing DataSet object", "[DataSet]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing DataSet object" << std::endl;
     GIVEN("A DataSet object")
     {
         std::string dataset_name;

--- a/tests/cpp/unit-tests/test_dbinfocommand.cpp
+++ b/tests/cpp/unit-tests/test_dbinfocommand.cpp
@@ -29,10 +29,13 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "dbinfocommand.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Parsing an empty string for db info")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Parsing an empty string for db info" << std::endl;
     GIVEN("A DBInfoCommand and an empty string")
     {
         DBInfoCommand cmd;

--- a/tests/cpp/unit-tests/test_dbnode.cpp
+++ b/tests/cpp/unit-tests/test_dbnode.cpp
@@ -26,14 +26,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "dbnode.h"
+
+unsigned long get_time_offset();
 
 using namespace SmartRedis;
 
 SCENARIO("Testing DBNode object", "[DBNode]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing DBNode object" << std::endl;
     GIVEN("Two DBNode objects created with the default contructor")
     {
         DBNode node_1;

--- a/tests/cpp/unit-tests/test_metadata.cpp
+++ b/tests/cpp/unit-tests/test_metadata.cpp
@@ -30,6 +30,8 @@
 #include "metadata.h"
 #include "srexception.h"
 
+unsigned long get_time_offset();
+
 // helper function for checking if the MetaData object was copied correctly
 void check_metadata_copied_correctly(MetaData metadata, MetaData metadata_cpy)
 {
@@ -128,7 +130,7 @@ void check_metadata_copied_correctly(MetaData metadata, MetaData metadata_cpy)
 
 SCENARIO("Test MetaData", "[MetaData]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test MetaData" << std::endl;
     GIVEN("A MetaData object")
     {
         MetaData metadata;

--- a/tests/cpp/unit-tests/test_multikeycommand.cpp
+++ b/tests/cpp/unit-tests/test_multikeycommand.cpp
@@ -29,12 +29,13 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "multikeycommand.h"
 
+unsigned long get_time_offset();
 
 using namespace SmartRedis;
 
 SCENARIO("Adding fields of different types", "[MultiKeyCommand]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Adding fields of different types" << std::endl;
     GIVEN("A MultiKeyCommand object")
     {
         MultiKeyCommand cmd;

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -36,6 +36,8 @@
 #include "redis.h"
 #include "srexception.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 /*  Derived objects for Redis and RedisCluster are defined to access
@@ -127,6 +129,7 @@ void check_all_defaults(T& server)
 
 SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Test runtime settings are initialized correctly" << std::endl;
     GIVEN("A Redis derived object created with all environment variables unset")
     {
         unset_all_env_vars();

--- a/tests/cpp/unit-tests/test_singlekeycommand.cpp
+++ b/tests/cpp/unit-tests/test_singlekeycommand.cpp
@@ -30,12 +30,13 @@
 #include "singlekeycommand.h"
 #include "srexception.h"
 
+unsigned long get_time_offset();
 
 using namespace SmartRedis;
 
 SCENARIO("Retrieve field to empty SingleKeyCommand", "[SingleKeyCommand]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Retrieve field to empty SingleKeyCommand" << std::endl;
     GIVEN("An empty SingleKeyCommand object")
     {
         SingleKeyCommand cmd;
@@ -54,6 +55,7 @@ SCENARIO("Retrieve field to empty SingleKeyCommand", "[SingleKeyCommand]")
 
 SCENARIO("Testing copy constructor for SingleKeyCommand on heap", "[SingleKeyCommand]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Testing copy constructor for SingleKeyCommand on heap" << std::endl;
     GIVEN("A SingleKeyCommand object on the heap")
     {
         SingleKeyCommand* cmd = new SingleKeyCommand;

--- a/tests/cpp/unit-tests/test_ssdb.cpp
+++ b/tests/cpp/unit-tests/test_ssdb.cpp
@@ -29,6 +29,8 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "redis.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 // Helper class used for accessing protected members of RedisServer
@@ -54,7 +56,7 @@ void setenv_ssdb(const char* ssdb)
 
 SCENARIO("Additional Testing for various SSDBs", "[SSDB]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Additional Testing for various SSDBs" << std::endl;
     GIVEN("A TestSSDB object")
     {
         const char* old_ssdb = std::getenv("SSDB");

--- a/tests/cpp/unit-tests/test_stringfield.cpp
+++ b/tests/cpp/unit-tests/test_stringfield.cpp
@@ -29,9 +29,11 @@
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "stringfield.h"
 
+unsigned long get_time_offset();
+
 SCENARIO("Test StringField", "[StringField]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Test StringField" << std::endl;
     GIVEN("A StringField object constructed with the string field name")
     {
         std::string name_1 = "stringfield_name_1";

--- a/tests/cpp/unit-tests/test_tensor.cpp
+++ b/tests/cpp/unit-tests/test_tensor.cpp
@@ -26,14 +26,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "tensor.h"
+
+unsigned long get_time_offset();
 
 using namespace SmartRedis;
 
 SCENARIO("Testing Tensor", "[Tensor]")
 {
-
+    std::cout << std::to_string(get_time_offset()) << ": Testing Tensor" << std::endl;
     GIVEN("Two Tensors")
     {
         // Create first tensor

--- a/tests/cpp/unit-tests/test_tensorbase.cpp
+++ b/tests/cpp/unit-tests/test_tensorbase.cpp
@@ -26,15 +26,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <iostream>
 #include "../../../third-party/catch/single_include/catch2/catch.hpp"
 #include "tensorbase.h"
 #include "tensorpack.h"
 #include "srexception.h"
 
+unsigned long get_time_offset();
+
 using namespace SmartRedis;
 
 SCENARIO("Testing TensorBase through TensorPack", "[TensorBase]")
 {
+    std::cout << std::to_string(get_time_offset()) << ": Testing TensorBase through TensorPack" << std::endl;
     SRTensorType tensor_type = GENERATE(SRTensorTypeDouble, SRTensorTypeFloat,
                                         SRTensorTypeInt64, SRTensorTypeInt32,
                                         SRTensorTypeInt16, SRTensorTypeInt8,


### PR DESCRIPTION
Enables identification of which tests are taking a really long time in check-in testing