### PR TITLE
Change Docker container image to 20.04 LTS

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,10 +18,12 @@ Description
 Detailed Notes
 
 - Implemented support for Unix Domain Sockets, including refactorization of server address code, test cases, and check-in tests. (PR252_)
-- A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against
+- A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (245_)
+- Change Dockerfile to use Ubuntu 20.04 LTS image (PR276_)
 
 .. _PR252: https://github.com/CrayLabs/SmartRedis/pull/252
 .. _PR245: https://github.com/CrayLabs/SmartRedis/pull/245
+.. _PR276: https://github.com/CrayLabs/SmartRedis/pull/276
 
 0.3.1
 -----

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -27,7 +27,7 @@
 #
 
 ## Builder image
-FROM ubuntu:21.04 as builder
+FROM ubuntu:20.04 as builder
 
 # Install tooling
 RUN apt-get update && \


### PR DESCRIPTION
Github Actions fail due to the docker build step relying on
Ubuntu 21.04. This version of Ubuntu has reached end of life and
so the package install step of the workflow was failing. The rest
of the testing for SmartRedis points to 20.04 and so both the
tests and Dockerfile is synced.

Closes #274 