### PR TITLE
Initialize boolean before starting thread pool

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,18 +12,21 @@ This section details changes made in the development branch that have not yet be
 
 Description
 
+- A bug related to thread pool initialization was fixed.
 - This version adds new functionality in the form of support for Unix Domain Sockets.
 - Fortran client can now be optionally built with the rest of the library
 - Initial support for dataset conversions, specifically Xarray.
 
 Detailed Notes
 
+- Fix thread pool error (PR280_)
 - Update library linking instructions and update Fortran tester build process (PR277_)
 - Added `add_metadata_for_xarray` and `transform_to_xarray` methods in `DatasetConverter` class for initial support with Xarray (PR262_)
 - Change Dockerfile to use Ubuntu 20.04 LTS image (PR276_)
 - Implemented support for Unix Domain Sockets, including refactorization of server address code, test cases, and check-in tests. (PR252_)
 - A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (PR245_)
 
+.. _PR280: https://github.com/CrayLabs/SmartRedis/pull/280
 .. _PR277: https://github.com/CrayLabs/SmartRedis/pull/277
 .. _PR262: https://github.com/CrayLabs/SmartRedis/pull/262
 .. _PR276: https://github.com/CrayLabs/SmartRedis/pull/276

--- a/src/cpp/threadpool.cpp
+++ b/src/cpp/threadpool.cpp
@@ -20,8 +20,9 @@ using namespace std::chrono_literals;
 // Constructor
 ThreadPool::ThreadPool(unsigned int num_threads)
 {
-    // Flag that we're initializing
+    // Flags that we're initializing and not shutting down
     initialization_complete = false;
+    shutting_down = false;
 
     // By default, we'll make one thread for each hardware context
     if (num_threads == 0)
@@ -37,7 +38,6 @@ ThreadPool::ThreadPool(unsigned int num_threads)
     }
 
     // Announce that we're open for business
-    shutting_down = false;
     shutdown_complete = false;
     initialization_complete = true;
 }


### PR DESCRIPTION
This PR is a small fix that moves the thread pool ``shutting_down`` boolean to before the initialization of the thread pool.  Shutting down of threads was observed during thread pool creation because the variable was left uninitialized.  