### PR TITLE
Change dependency for build-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build-test-fortran: test-lib-with-fortran
 
 # help: build-examples                 - build all examples (serial, parallel)
 .PHONY: build-examples
-build-examples: lib
+build-examples: lib-with-fortran
 	./build-scripts/build_serial_examples.sh
 	./build-scripts/build_parallel_examples.sh
 


### PR DESCRIPTION
`build-examples` was pointing to the `lib` target which does not build the Fortran client library. This causes the post-merge tests to fail. Updating this to `lib-with-fortran` allows compilation of the example codes to succeed.