### PR TITLE
Add 'where' information to Python exceptions

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ This section details changes made in the development branch that have not yet be
 
 Description
 
+- Python error messages from SmartRedis contain more information
 - A bug related to thread pool initialization was fixed.
 - This version adds new functionality in the form of support for Unix Domain Sockets.
 - Fortran client can now be optionally built with the rest of the library
@@ -19,6 +20,7 @@ Description
 
 Detailed Notes
 
+- Add exception location information from CPP code to Python exceptions (PR283_)
 - Fix thread pool error (PR280_)
 - Update library linking instructions and update Fortran tester build process (PR277_)
 - Added `add_metadata_for_xarray` and `transform_to_xarray` methods in `DatasetConverter` class for initial support with Xarray (PR262_)

--- a/include/srexception.h
+++ b/include/srexception.h
@@ -50,6 +50,11 @@ typedef enum {
     SRTypeError      = 9  // Type mismatch
 } SRError;
 
+#ifdef __cplusplus
+namespace SmartRedis {
+class Exception;
+}
+#endif // __cplusplus
 
 /*!
 *   \brief Return the last error encountered
@@ -60,9 +65,27 @@ extern "C"
 #endif
 const char* SRGetLastError();
 
+/*!
+*   \brief Return the location for the last error encountered
+*   \return The text data for the last error's location
+*/
+#ifdef __cplusplus
+extern "C"
+#endif
+const char* SRGetLastErrorLocation();
+
 #ifdef __cplusplus
 #include <string>
 namespace SmartRedis {
+
+/*!
+*   \brief Store the last error encountered in a global variable. Not
+*          currently thread-safe
+*   \param last_error Exception to be stored as the last error encountered
+*/
+extern "C"
+void SRSetLastError(const Exception& last_error);
+
 
 /*!
 *   \brief  Smart error: custom exception class for the SmartRedis library
@@ -75,9 +98,9 @@ class Exception: public std::exception
     *   \param what_arg The message for the exception
     */
     Exception(const char* what_arg)
-      : _msg(what_arg)
+      : _msg(what_arg), _loc("unavailable")
     {
-        // NOP
+        SRSetLastError(*this);
     }
 
     /*!
@@ -87,9 +110,10 @@ class Exception: public std::exception
     *   \param line The line number from which the exception was thrown
     */
     Exception(const char* what_arg, const char* file, int line)
-      : _msg(what_arg), _loc(file + std::string(":") + std::to_string(line))
+      : _msg(what_arg),
+        _loc(std::string("\"") + file + std::string("\", line ") + std::to_string(line))
     {
-        // NOP
+        SRSetLastError(*this);
     }
 
     /*!
@@ -99,9 +123,10 @@ class Exception: public std::exception
     *   \param line The line number from which the exception was thrown
     */
     Exception(const std::string& what_arg, const char* file, int line)
-      : _msg(what_arg), _loc(file + std::string(":") + std::to_string(line))
+      : _msg(what_arg),
+        _loc(std::string("\"") + file + std::string("\", line ") + std::to_string(line))
     {
-        // NOP
+        SRSetLastError(*this);
     }
 
     /*!
@@ -366,14 +391,6 @@ class TypeException: public Exception
 *   \brief Instantiate a TypeException with message
 */
 #define SRTypeException(txt) TypeException(txt, __FILE__, __LINE__)
-
-/*!
-*   \brief Store the last error encountered in a global variable. Not
-*          currently thread-safe
-*   \param last_error Exception to be stored as the last error encountered
-*/
-extern "C"
-void SRSetLastError(const Exception& last_error);
 
 } // namespace SmartRedis
 

--- a/src/c/c_error.cpp
+++ b/src/c/c_error.cpp
@@ -66,3 +66,9 @@ extern "C"
 const char* SRGetLastError()  {
   return __lastError.what();
 }
+
+// Return the location for the last error encountered
+extern "C"
+const char* SRGetLastErrorLocation()  {
+  return __lastError.where();
+}

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -108,6 +108,9 @@ PYBIND11_MODULE(smartredisPy, m) {
         .def("get_meta_strings", &PyDataset::get_meta_strings)
         .def("get_name", &PyDataset::get_name);
 
+    // Error management routines
+    m.def("c_get_last_error_location", &SRGetLastErrorLocation);
+
     // Python exception classes
     static py::exception<SmartRedis::Exception>         exception_handler(m,          "RedisReplyError");
     static py::exception<SmartRedis::RuntimeException>  runtime_exception_handler(m,  "RedisRuntimeError",  exception_handler.ptr());


### PR DESCRIPTION
Update Python exceptions raised from the SmartRedis C++ library to include "where" location, such as the following:

```python
>>> c.rename_tensor("vanilla", "chocolate")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/scherer/sandbox/smartredis/src/python/module/smartredis/util.py", line 105, in smartredis_api_wrapper
    raise globals()[exception_name](cpp_error_str, method_name) from None
smartredis.error.RedisRuntimeError: Client.rename_tensor execution failed
File "/Users/scherer/sandbox/smartredis/src/cpp/rediscluster.cpp", line 963, in SmartRedis library
Redis error when executing command: ERR tensor key is empty or in a different shard
```

This PR adds the second-to-last line (beginning "File "/Users/scherer") to the error output 