### PR TITLE
Add logging context for direct testing of Redis, RedisCluster objects

### DIFF
--- a/include/redis.h
+++ b/include/redis.h
@@ -33,7 +33,7 @@
 
 namespace SmartRedis {
 
-class Client;
+class SRObject;
 
 ///@file
 
@@ -46,18 +46,18 @@ class Redis : public RedisServer
     public:
         /*!
         *   \brief Redis constructor.
-        *   \param client The owning Client
+        *   \param context The owning context
         */
-        Redis(const Client* client);
+        Redis(const SRObject* context);
 
         /*!
         *   \brief Redis constructor.
         *          Uses address provided to constructor instead
         *          of environment variables.
-        *   \param client The owning Client
+        *   \param context The owning context
         *   \param addr_spec The TCP or UDS server address
         */
-        Redis(const Client* client, std::string addr_spec);
+        Redis(const SRObject* context, std::string addr_spec);
 
         /*!
         *   \brief Redis copy constructor is not allowed

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -43,7 +43,7 @@ namespace SmartRedis {
 
 ///@file
 
-class Client;
+class SRObject;
 
 /*!
 *   \brief  The RedisCluster class executes RedisServer
@@ -55,18 +55,18 @@ class RedisCluster : public RedisServer
 
         /*!
         *   \brief RedisCluster constructor.
-        *   \param client The owning Client
+        *   \param context The owning context
         */
-        RedisCluster(const Client* client);
+        RedisCluster(const SRObject* context);
 
         /*!
         *   \brief RedisCluster constructor.
         *          Uses address provided to constructor instead
         *          of environment variables.
-        *   \param client The owning Client
+        *   \param context The owning context
         *   \param address_spec The TCP or UDS address of the server
         */
-        RedisCluster(const Client* client, std::string address_spec);
+        RedisCluster(const SRObject* context, std::string address_spec);
 
         /*!
         *   \brief RedisCluster copy constructor is not allowed

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -60,7 +60,7 @@
 
 namespace SmartRedis {
 
-class Client;
+class SRObject;
 
 /*!
 *   \brief Abstract class that defines interface for
@@ -72,9 +72,9 @@ class RedisServer {
 
         /*!
         *   \brief Default constructor
-        *   \param client The owning Client
+        *   \param context The owning context
         */
-        RedisServer(const Client* client);
+        RedisServer(const SRObject* context);
 
         /*!
         *   \brief Destructor
@@ -563,9 +563,9 @@ class RedisServer {
         static constexpr int _DEFAULT_THREAD_COUNT = 4;
 
         /*!
-        *   \brief The owning Client
+        *   \brief The owning context
         */
-        const Client* _client;
+        const SRObject* _context;
 
         /*!
         *   \brief Seeding for the random number engine

--- a/include/threadpool.h
+++ b/include/threadpool.h
@@ -11,7 +11,7 @@
 #define SMARTREDIS_THREADPOOL_H
 namespace SmartRedis {
 
-class Client;
+class SRObject;
 
 /*!
 *   \brief  A thread pool for concurrent execution of parallel jobs
@@ -21,11 +21,11 @@ class ThreadPool
   public:
     /*!
     *   \brief ThreadPool constructor
-    *   \param client The owning client
+    *   \param context The owning context
     *   \param num_threads The number of threads to create in the pool,
     *          or 0 to use one thread per hardware context
     */
-    ThreadPool(const Client* client, unsigned int num_threads=0);
+    ThreadPool(const SRObject* context, unsigned int num_threads=0);
 
     /*!
     *   \brief ThreadPool destructor
@@ -88,7 +88,7 @@ class ThreadPool
     /*!
     *   \brief Owning client object
     */
-    const Client* _client;
+    const SRObject* _context;
 };
 
 } // namespace SmartRedis

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -29,13 +29,13 @@
 #include "redis.h"
 #include "srexception.h"
 #include "utility.h"
-#include "client.h"
+#include "srobject.h"
 
 using namespace SmartRedis;
 
 // Redis constructor.
-Redis::Redis(const Client* client)
-    : RedisServer(client)
+Redis::Redis(const SRObject* context)
+    : RedisServer(context)
 {
     SRAddress db_address(_get_ssdb());
     // Remember whether it's a unix domain socket for later
@@ -45,8 +45,8 @@ Redis::Redis(const Client* client)
 }
 
 // Redis constructor. Uses address provided to constructor instead of environment variables
-Redis::Redis(const Client* client, std::string addr_spec)
-    : RedisServer(client)
+Redis::Redis(const SRObject* context, std::string addr_spec)
+    : RedisServer(context)
 {
     SRAddress db_address(addr_spec);
     _add_to_address_map(db_address);

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -31,13 +31,13 @@
 #include "keyedcommand.h"
 #include "srexception.h"
 #include "utility.h"
-#include "client.h"
+#include "srobject.h"
 
 using namespace SmartRedis;
 
 // RedisCluster constructor
-RedisCluster::RedisCluster(const Client* client)
-    : RedisServer(client)
+RedisCluster::RedisCluster(const SRObject* context)
+    : RedisServer(context)
 {
     SRAddress db_address(_get_ssdb());
     if (!db_address._is_tcp) {
@@ -55,8 +55,8 @@ RedisCluster::RedisCluster(const Client* client)
 
 // RedisCluster constructor. Uses address provided to constructor instead of
 // environment variables
-RedisCluster::RedisCluster(const Client* client, std::string address_spec)
-    : RedisServer(client)
+RedisCluster::RedisCluster(const SRObject* context, std::string address_spec)
+    : RedisServer(context)
 {
     SRAddress db_address(address_spec);
     _connect(db_address);

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -30,13 +30,13 @@
 #include "redisserver.h"
 #include "srexception.h"
 #include "utility.h"
-#include "client.h"
+#include "srobject.h"
 
 using namespace SmartRedis;
 
 // RedisServer constructor
-RedisServer::RedisServer(const Client* client)
-    : _client(client), _gen(_rd())
+RedisServer::RedisServer(const SRObject* context)
+    : _context(context), _gen(_rd())
 {
     get_config_integer(_connection_timeout, _CONN_TIMEOUT_ENV_VAR,
                          _DEFAULT_CONN_TIMEOUT);
@@ -57,7 +57,7 @@ RedisServer::RedisServer(const Client* client)
     _command_attempts = (_command_timeout * 1000) /
                          _command_interval + 1;
 
-    _tp = new ThreadPool(_client, _thread_count);
+    _tp = new ThreadPool(_context, _thread_count);
 }
 
 // RedisServer destructor

--- a/tests/cpp/client_test_utils.h
+++ b/tests/cpp/client_test_utils.h
@@ -33,13 +33,15 @@
 #include <random>
 
 #include "rediscluster.h"
+#include "srobject.h"
 
 using namespace SmartRedis;
 
 class RedisClusterTestObject : public RedisCluster
 {
     public:
-        RedisClusterTestObject() : RedisCluster(NULL) {};
+        RedisClusterTestObject(const SRObject* context)
+         : RedisCluster(context) {};
 
         std::string get_crc16_prefix(uint64_t hash_slot) {
             return _get_crc16_prefix(hash_slot);

--- a/tests/cpp/unit-tests/test_client.cpp
+++ b/tests/cpp/unit-tests/test_client.cpp
@@ -33,6 +33,7 @@
 #include "srexception.h"
 #include <sstream>
 #include "logger.h"
+#include "logcontext.h"
 
 unsigned long get_time_offset();
 
@@ -817,7 +818,8 @@ SCENARIO("Test that prefixing covers all hash slots of a cluster", "[Client]")
 
     GIVEN("A test RedisCluster test object")
     {
-        RedisClusterTestObject redis_cluster;
+        LogContext context("test_client");
+        RedisClusterTestObject redis_cluster(&context);
 
         WHEN("A prefix is requested for a hash slot between 0 and 16384")
         {

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -36,7 +36,8 @@
 #include "redis.h"
 #include "srexception.h"
 #include "logger.h"
-#include "client.h"
+#include "srobject.h"
+#include "logcontext.h"
 
 unsigned long get_time_offset();
 
@@ -56,7 +57,7 @@ using namespace SmartRedis;
 class RedisTest : public Redis
 {
     public:
-        RedisTest(Client* c) : Redis(c) {}
+        RedisTest(SRObject* c) : Redis(c) {}
         int get_connection_timeout() {return _connection_timeout;}
         int get_connection_interval() {return _connection_interval;}
         int get_command_timeout() {return _command_timeout;}
@@ -72,7 +73,7 @@ class RedisTest : public Redis
 class RedisClusterTest : public RedisCluster
 {
     public:
-        RedisClusterTest(Client* c) : RedisCluster(c) {}
+        RedisClusterTest(SRObject* c) : RedisCluster(c) {}
         int get_connection_timeout() {return _connection_timeout;}
         int get_connection_interval() {return _connection_interval;}
         int get_command_timeout() {return _command_timeout;}
@@ -96,11 +97,12 @@ const char* CMD_INTERVAL_ENV_VAR = "SR_CMD_INTERVAL";
 // error to be thrown
 void invoke_constructor()
 {
+    LogContext context("test_redisserver");
     if (use_cluster()) {
-        RedisClusterTest cluster_obj(NULL);
+        RedisClusterTest cluster_obj(&context);
     }
     else {
-        RedisTest non_cluster_obj(NULL);
+        RedisTest non_cluster_obj(&context);
     }
 }
 
@@ -174,6 +176,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     std::cout << std::to_string(get_time_offset()) << ": Test runtime settings are initialized correctly" << std::endl;
     std::string context("test_redisserver");
     log_data(context, LLDebug, "***Beginning RedisServer testing***");
+    LogContext lc("test_redisserver");
 
     char* __conn_timeout;
     char* __conn_interval;
@@ -185,14 +188,14 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     {
         unset_all_env_vars();
         if (use_cluster()) {
-            RedisClusterTest redis_server(NULL);
+            RedisClusterTest redis_server(&lc);
             THEN("Default member variable values are used")
             {
                 check_all_defaults(redis_server);
             }
         }
         else {
-            RedisTest redis_server(NULL);
+            RedisTest redis_server(&lc);
             THEN("Default member variable values are used")
             {
                 check_all_defaults(redis_server);
@@ -208,14 +211,14 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CMD_INTERVAL_ENV_VAR, "", true);
 
         if (use_cluster()) {
-            RedisClusterTest redis_server(NULL);
+            RedisClusterTest redis_server(&lc);
             THEN("Default member variable values are used")
             {
                 check_all_defaults(redis_server);
             }
         }
         else {
-            RedisTest redis_server(NULL);
+            RedisTest redis_server(&lc);
             THEN("Default member variable values are used")
             {
                 check_all_defaults(redis_server);
@@ -238,7 +241,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CMD_INTERVAL_ENV_VAR, std::to_string(cmd_interval).c_str(), true);
 
         if (use_cluster()) {
-            RedisClusterTest redis_server(NULL);
+            RedisClusterTest redis_server(&lc);
             THEN("Environment variables are used for member variables")
             {
                 CHECK(redis_server.get_connection_timeout() ==
@@ -257,7 +260,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
             }
         }
         else {
-            RedisTest redis_server(NULL);
+            RedisTest redis_server(&lc);
             THEN("Environment variables are used for member variables")
             {
                 CHECK(redis_server.get_connection_timeout() ==

--- a/tests/cpp/unit-tests/test_ssdb.cpp
+++ b/tests/cpp/unit-tests/test_ssdb.cpp
@@ -31,6 +31,8 @@
 #include "client.h"
 #include "address.h"
 #include "logger.h"
+#include "logcontext.h"
+#include "srobject.h"
 
 unsigned long get_time_offset();
 
@@ -40,7 +42,7 @@ using namespace SmartRedis;
 class TestSSDB : public Redis
 {
     public:
-        TestSSDB() : Redis(NULL) {}
+        TestSSDB(const SRObject* c) : Redis(c) {}
 
         SRAddress get_ssdb()
         {
@@ -62,6 +64,7 @@ SCENARIO("Additional Testing for various SSDBs", "[SSDB]")
     std::cout << std::to_string(get_time_offset()) << ": Additional Testing for various SSDBs" << std::endl;
     std::string context("test_ssdb");
     log_data(context, LLDebug, "***Beginning SSDB testing***");
+    LogContext lc("test_ssdb");
 
     GIVEN("A TestSSDB object")
     {
@@ -71,7 +74,7 @@ SCENARIO("Additional Testing for various SSDBs", "[SSDB]")
             "port before running this test.");
         REQUIRE(old_ssdb != NULL);
 
-        TestSSDB test_ssdb;
+        TestSSDB test_ssdb(&lc);
         Client* c = NULL;
 
         THEN("SSDB environment variable must exist "


### PR DESCRIPTION
Add logging context to direct instantiation of Redis and RedisCluster objects in the CPP testing code so that subsequent additions of logging code to these objects won't cause spontaneous test failures