### PR TITLE
object-based logging for Python

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ This section details changes made in the development branch that have not yet be
 
 Description
 
+- Add support for user-directed logging for Python clients, using Client, Dataset, or LogContext logging methods
 - Add support for user-directed logging for C and Fortran clients without a Client or Dataset context
 - Additional error reporting for connections to and commands run against Redis databases
 - Improved error reporting capabilities for Fortran clients
@@ -24,6 +25,7 @@ Description
 
 Detailed Notes
 
+- Added support for user-directed logging for Python clients via {Client, Dataset, LogContext}.{log_data, log_warning, log_error} methods (PR289_)
 - Added support for user-directed logging without a Client or Dataset context to C and Fortran clients via _string() methods (PR288_)
 - Added logging to capture transient errors that arise in the _run() and _connect() methods of the Redis and RedisCluster classes (PR287_)
 - Tweak direct testing of Redis and RedisCluster classes (PR286_)
@@ -38,6 +40,7 @@ Detailed Notes
 - Implemented support for Unix Domain Sockets, including refactorization of server address code, test cases, and check-in tests. (PR252_)
 - A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (PR245_)
 
+.. _PR288: https://github.com/CrayLabs/SmartRedis/pull/289
 .. _PR288: https://github.com/CrayLabs/SmartRedis/pull/288
 .. _PR287: https://github.com/CrayLabs/SmartRedis/pull/287
 .. _PR286: https://github.com/CrayLabs/SmartRedis/pull/286

--- a/include/pysrobject.h
+++ b/include/pysrobject.h
@@ -77,6 +77,32 @@ class PySRObject
         */
         SRObject* get();
 
+        /*!
+        *   \brief Conditionally log data if the logging level is high enough
+        *   \param level Minimum logging level for data to be logged
+        *   \param data Text of data to be logged
+        */
+        virtual void log_data(
+            SRLoggingLevel level, const std::string& data) const;
+
+        /*!
+        *   \brief Conditionally log warning data if the logging level is
+        *          high enough
+        *   \param level Minimum logging level for data to be logged
+        *   \param data Text of data to be logged
+        */
+        virtual void log_warning(
+            SRLoggingLevel level, const std::string& data) const;
+
+        /*!
+        *   \brief Conditionally log error data if the logging level is
+        *          high enough
+        *   \param level Minimum logging level for data to be logged
+        *   \param data Text of data to be logged
+        */
+        virtual void log_error(
+            SRLoggingLevel level, const std::string& data) const;
+
     private:
 
         SRObject* _srobject;

--- a/src/python/bindings/bind.cpp
+++ b/src/python/bindings/bind.cpp
@@ -44,7 +44,10 @@ PYBIND11_MODULE(smartredisPy, m) {
 
     // Python SRObject class
     py::class_<PySRObject>(m, "PySRObject")
-        .def(py::init<std::string&>());
+        .def(py::init<std::string&>())
+        .def("log_data", &PySRObject::log_data)
+        .def("log_warning", &PySRObject::log_warning)
+        .def("log_error", &PySRObject::log_error);
 
     // Python LogContext class
     py::class_<PyLogContext, PySRObject>(m, "PyLogContext")

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -57,18 +57,22 @@ class Client(SRObject):
         :type logger_name: str
         :raises RedisConnectionError: if connection initialization fails
         """
-        super().__init__(logger_name)
         if address:
             self.__set_address(address)
         if "SSDB" not in os.environ:
             raise RedisConnectionError("Could not connect to database. $SSDB not set")
         try:
-            self._client = PyClient(cluster, logger_name)
-            self._srobject = self._client
+            super().__init__(PyClient(cluster, logger_name))
         except PybindRedisReplyError as e:
             raise RedisConnectionError(str(e)) from None
         except RuntimeError as e:
             raise RedisConnectionError(str(e)) from None
+
+    @property
+    def _client(self):
+        """Alias _srobject to _client
+        """
+        return self._srobject
 
     @exception_handler
     def put_tensor(self, name, data):

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -32,13 +32,14 @@ import functools
 import numpy as np
 
 from .dataset import Dataset
+from .srobject import SRObject
 from .smartredisPy import PyClient
 from .util import Dtypes, init_default, exception_handler, typecheck
 
 from .error import *
 from .smartredisPy import RedisReplyError as PybindRedisReplyError
 
-class Client:
+class Client(SRObject):
     def __init__(self, address=None, cluster=False, logger_name="default"):
         """Initialize a RedisAI client
 
@@ -56,12 +57,14 @@ class Client:
         :type logger_name: str
         :raises RedisConnectionError: if connection initialization fails
         """
+        super().__init__(logger_name)
         if address:
             self.__set_address(address)
         if "SSDB" not in os.environ:
             raise RedisConnectionError("Could not connect to database. $SSDB not set")
         try:
             self._client = PyClient(cluster, logger_name)
+            self._srobject = self._client
         except PybindRedisReplyError as e:
             raise RedisConnectionError(str(e)) from None
         except RuntimeError as e:

--- a/src/python/module/smartredis/dataset.py
+++ b/src/python/module/smartredis/dataset.py
@@ -41,11 +41,14 @@ class Dataset(SRObject):
         :param name: name of dataset
         :type name: str
         """
-        super().__init__(name)
+        super().__init__(PyDataset(name))
         typecheck(name, "name", str)
-        self._data = PyDataset(name)
-        self._srobject = self._data
 
+    @property
+    def _data(self):
+        """Alias _srobject to _data
+        """
+        return self._srobject
 
     @staticmethod
     def from_pybind(dataset):
@@ -82,7 +85,7 @@ class Dataset(SRObject):
         :type dataset: PyDataset
         """
         typecheck(dataset, "dataset", PyDataset)
-        self._data = dataset
+        self._srobject = dataset
 
     @exception_handler
     def add_tensor(self, name, data):

--- a/src/python/module/smartredis/dataset.py
+++ b/src/python/module/smartredis/dataset.py
@@ -29,19 +29,22 @@ from numbers import Number
 import numpy as np
 
 from .smartredisPy import PyDataset
+from .srobject import SRObject
 from .util import Dtypes, exception_handler, typecheck
 
 from .error import *
 
-class Dataset:
+class Dataset(SRObject):
     def __init__(self, name):
         """Initialize a Dataset object
 
         :param name: name of dataset
         :type name: str
         """
+        super().__init__(name)
         typecheck(name, "name", str)
         self._data = PyDataset(name)
+        self._srobject = self._data
 
 
     @staticmethod

--- a/src/python/module/smartredis/logcontext.py
+++ b/src/python/module/smartredis/logcontext.py
@@ -25,20 +25,23 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from .smartredisPy import PyLogContext
+from .srobject import SRObject
 from .util import exception_handler, typecheck
 
 from .error import *
 
-class LogContext:
+class LogContext(SRObject):
     def __init__(self, context):
         """Initialize a LogContext object
 
         :param context: logging context
         :type name: str
         """
+        super().__init__(context)
         typecheck(context, "context", str)
         self._name = context
-        self._data = PyLogContext(context)
+        self._logcontext = PyLogContext(context)
+        self._srobject = self._logcontext
 
 
     @staticmethod
@@ -55,25 +58,25 @@ class LogContext:
         """
         typecheck(logcontext, "logcontext", PyLogContext)
         new_logcontext = LogContext(logcontext._name)
-        new_logcontext.set_data(logcontext)
+        new_logcontext.set_context(logcontext)
         return new_logcontext
 
     @exception_handler
-    def get_data(self):
+    def get_context(self):
         """Return the PyLogContext attribute
 
         :return: The PyLogContext attribute containing
                  the logcontext information
         :rtype: PyLogContext
         """
-        return self._data
+        return self._logcontext
 
     @exception_handler
-    def set_data(self, logcontext):
+    def set_context(self, logcontext):
         """Set the PyLogContext attribute
 
         :param logcontext: The PyLogContext object
         :type logcontext: PyLogContext
         """
         typecheck(logcontext, "logcontext", PyLogContext)
-        self._data = logcontext
+        self._logcontext = logcontext

--- a/src/python/module/smartredis/logcontext.py
+++ b/src/python/module/smartredis/logcontext.py
@@ -37,12 +37,15 @@ class LogContext(SRObject):
         :param context: logging context
         :type name: str
         """
-        super().__init__(context)
+        super().__init__(PyLogContext(context))
         typecheck(context, "context", str)
         self._name = context
-        self._logcontext = PyLogContext(context)
-        self._srobject = self._logcontext
 
+    @property
+    def _logcontext(self):
+        """Alias _srobject to _logcontext
+        """
+        return self._srobject
 
     @staticmethod
     def from_pybind(logcontext):
@@ -79,4 +82,4 @@ class LogContext(SRObject):
         :type logcontext: PyLogContext
         """
         typecheck(logcontext, "logcontext", PyLogContext)
-        self._logcontext = logcontext
+        self._srobject = logcontext

--- a/src/python/module/smartredis/srobject.py
+++ b/src/python/module/smartredis/srobject.py
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .smartredisPy import PySRObject
+from .smartredisPy import PySRObject, SRLoggingLevel
 from .util import exception_handler, typecheck
 
 from .error import *
@@ -38,7 +38,7 @@ class SRObject:
         """
         typecheck(context, "context", str)
         self._name = context
-        self._data = PySRObject(context)
+        self._srobject = PySRObject(context)
 
 
     @staticmethod
@@ -46,11 +46,9 @@ class SRObject:
         """Initialize a SRObject object from
         a PySRObject object
 
-        :param srobject: The pybind PySRObject object
-                           to use for construction
+        :param srobject: The pybind PySRObject object to use for construction
         :type srobject: PySRObject
-        :return: The newly constructor SRObject from
-                 the PySRObject
+        :return: The newly constructor SRObject from the PySRObject
         :rtype: SRObject
         """
         typecheck(srobject, "srobject", PySRObject)
@@ -59,21 +57,62 @@ class SRObject:
         return new_srobject
 
     @exception_handler
-    def get_data(self):
+    def get_srobject(self):
         """Return the PySRObject attribute
 
-        :return: The PySRObject attribute containing
-                 the srobject information
+        :return: The PySRObject attribute containing the srobject information
         :rtype: PySRObject
         """
-        return self._data
+        return self._srobject
 
     @exception_handler
-    def set_data(self, srobject):
+    def set_srobject(self, srobject):
         """Set the PySRObject attribute
 
         :param srobject: The PySRObject object
         :type srobject: PySRObject
         """
         typecheck(srobject, "srobject", PySRObject)
-        self._data = srobject
+        self._srobject = srobject
+
+    @exception_handler
+    def log_data(self, level, data):
+        """Conditionally log data if the logging level is high enough
+
+        :param level: Minimum logging level for data to be logged
+        :type name: enum
+        :param data: Text of data to be logged
+        :type name: str
+        :raises RedisReplyError: if logging fails
+        """
+        typecheck(level, "level", SRLoggingLevel)
+        typecheck(data, "data", str)
+        self._srobject.log_data(level, data)
+
+    @exception_handler
+    def log_warning(self, level, data):
+        """Conditionally log warning data if the logging level is high enough
+
+        :param level: Minimum logging level for data to be logged
+        :type name: enum
+        :param data: Text of data to be logged
+        :type name: str
+        :raises RedisReplyError: if logging fails
+        """
+        typecheck(level, "level", SRLoggingLevel)
+        typecheck(data, "data", str)
+        self._srobject.log_warning(level, data)
+
+    @exception_handler
+    def log_error(self, level, data):
+        """Conditionally log error data if the logging level is high enough
+
+        :param level: Minimum logging level for data to be logged
+        :type name: enum
+        :param data: Text of data to be logged
+        :type name: str
+        :raises RedisReplyError: if logging fails
+        """
+        typecheck(level, "level", SRLoggingLevel)
+        typecheck(data, "data", str)
+        self._srobject.log_error(level, data)

--- a/src/python/module/smartredis/srobject.py
+++ b/src/python/module/smartredis/srobject.py
@@ -36,10 +36,12 @@ class SRObject:
         :param context: logging context
         :type name: str
         """
-        typecheck(context, "context", str)
-        self._name = context
-        self._srobject = PySRObject(context)
-
+        typecheck(context, "context", (str, PySRObject))
+        if isinstance(context, str):
+            self._name = context
+            self._srobject = PySRObject(context)
+        else:
+            self._srobject = context
 
     @staticmethod
     def from_pybind(srobject):
@@ -48,7 +50,7 @@ class SRObject:
 
         :param srobject: The pybind PySRObject object to use for construction
         :type srobject: PySRObject
-        :return: The newly constructor SRObject from the PySRObject
+        :return: The newly constructed¸ SRObject from the PySRObject
         :rtype: SRObject
         """
         typecheck(srobject, "srobject", PySRObject)

--- a/src/python/src/pysrobject.cpp
+++ b/src/python/src/pysrobject.cpp
@@ -73,3 +73,66 @@ PySRObject::~PySRObject()
 SRObject* PySRObject::get() {
     return _srobject;
 }
+
+void PySRObject::log_data(
+    SRLoggingLevel level, const std::string& data) const
+{
+    try {
+        _srobject->log_data(level, data);
+    }
+    catch (Exception& e) {
+        // exception is already prepared for caller
+        throw;
+    }
+    catch (std::exception& e) {
+        // should never happen
+        throw SRInternalException(e.what());
+    }
+    catch (...) {
+        // should never happen
+        throw SRInternalException("A non-standard exception was encountered "\
+                                  "while executing log_data.");
+    }
+}
+
+void PySRObject::log_warning(
+    SRLoggingLevel level, const std::string& data) const
+{
+    try {
+        _srobject->log_warning(level, data);
+    }
+    catch (Exception& e) {
+        // exception is already prepared for caller
+        throw;
+    }
+    catch (std::exception& e) {
+        // should never happen
+        throw SRInternalException(e.what());
+    }
+    catch (...) {
+        // should never happen
+        throw SRInternalException("A non-standard exception was encountered "\
+                                  "while executing log_warning.");
+    }
+}
+
+void PySRObject::log_error(
+    SRLoggingLevel level, const std::string& data) const
+{
+    try {
+        _srobject->log_error(level, data);
+    }
+    catch (Exception& e) {
+        // exception is already prepared for caller
+        throw;
+    }
+    catch (std::exception& e) {
+        // should never happen
+        throw SRInternalException(e.what());
+    }
+    catch (...) {
+        // should never happen
+        throw SRInternalException("A non-standard exception was encountered "\
+                                  "while executing log_error.");
+    }
+}

--- a/tests/python/test_errors.py
+++ b/tests/python/test_errors.py
@@ -752,6 +752,51 @@ def test_bad_type_log_function(use_cluster, context, log_fn):
     with pytest.raises(TypeError):
         log_fn("test_bad_type_log_function", LLInfo, 42)
 
+def test_bad_type_client_log(use_cluster, context):
+    c = Client(None, use_cluster, logger_name=context)
+    with pytest.raises(TypeError):
+        c.log_data("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        c.log_warning("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        c.log_error("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        c.log_data(LLInfo, 42)
+    with pytest.raises(TypeError):
+        c.log_warning(LLInfo, 42)
+    with pytest.raises(TypeError):
+        c.log_error(LLInfo, 42)
+
+def test_bad_type_dataset_log(context):
+    d = Dataset(context)
+    with pytest.raises(TypeError):
+        d.log_data("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        d.log_warning("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        d.log_error("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        d.log_data(LLInfo, 42)
+    with pytest.raises(TypeError):
+        d.log_warning(LLInfo, 42)
+    with pytest.raises(TypeError):
+        d.log_error(LLInfo, 42)
+
+def test_bad_type_logcontext_log(context):
+    lc = LogContext(context)
+    with pytest.raises(TypeError):
+        lc.log_data("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        lc.log_warning("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        lc.log_error("Not a logging level", "Data to be logged")
+    with pytest.raises(TypeError):
+        lc.log_data(LLInfo, 42)
+    with pytest.raises(TypeError):
+        lc.log_warning(LLInfo, 42)
+    with pytest.raises(TypeError):
+        lc.log_error(LLInfo, 42)
+
 #####
 # Test type errors from bad parameter types to Dataset API calls
 

--- a/tests/python/test_logging.py
+++ b/tests/python/test_logging.py
@@ -31,9 +31,34 @@ import pytest
 @pytest.mark.parametrize("log_level", [
     LLQuiet, LLInfo, LLDebug, LLDeveloper
 ])
-def test_logging(use_cluster, context, log_level):
-    c = Client(None, use_cluster, logger_name=context)
-    log_data(context, log_level, f"This is data logging ({log_level.name})")
-    log_warning(context, log_level, f"This is a warning ({log_level.name})")
-    log_error(context, log_level, f"This is an error ({log_level.name})")
+def test_logging_string(use_cluster, context, log_level):
+    log_data(context, log_level, f"This is data logged from a string ({log_level.name})")
+    log_warning(context, log_level, f"This is a warning logged from a string ({log_level.name})")
+    log_error(context, log_level, f"This is an error logged from a string ({log_level.name})")
 
+@pytest.mark.parametrize("log_level", [
+    LLQuiet, LLInfo, LLDebug, LLDeveloper
+])
+def test_logging_client(use_cluster, context, log_level):
+    c = Client(None, use_cluster, logger_name=context)
+    c.log_data(log_level, f"This is data logged from a client ({log_level.name})")
+    c.log_warning(log_level, f"This is a warning logged from a client ({log_level.name})")
+    c.log_error(log_level, f"This is an error logged from a client ({log_level.name})")
+
+@pytest.mark.parametrize("log_level", [
+    LLQuiet, LLInfo, LLDebug, LLDeveloper
+])
+def test_logging_dataset(context, log_level):
+    d = Dataset(context)
+    d.log_data(log_level, f"This is data logged from a dataset ({log_level.name})")
+    d.log_warning(log_level, f"This is a warning logged from a dataset ({log_level.name})")
+    d.log_error(log_level, f"This is an error logged from a dataset ({log_level.name})")
+
+@pytest.mark.parametrize("log_level", [
+    LLQuiet, LLInfo, LLDebug, LLDeveloper
+])
+def test_logging_logcontext(context, log_level):
+    lc = LogContext(context)
+    lc.log_data(log_level, f"This is data logged from a logcontext ({log_level.name})")
+    lc.log_warning(log_level, f"This is a warning logged from a logcontext ({log_level.name})")
+    lc.log_error(log_level, f"This is an error logged from a logcontext ({log_level.name})")


### PR DESCRIPTION
Enable user-initiated logging from {client, dataset, logcontext}.{log_data, log_warning, log_error} methods for Python users