### PR TITLE
Add some missing error handling

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ This section details changes made in the development branch that have not yet be
 
 Description
 
+- Improve error handling for setting of scripts and models
 - Update to the latest version of PyBind
 - Change documentation theme to sphinx_book_theme and fix doc strings
 - Add print capability for Client and DataSet
@@ -29,6 +30,7 @@ Description
 
 Detailed Notes
 
+- Added error handling for a rare edge condition when setting scripts and models (PR300_)
 - Updated from PyBind v2.6.2 to v2.10.3 (PR295_)
 - Change documentation theme to sphinx_book_theme to match SmartSim documentation theme and fix Python API doc string errors (PR294_)
 - Added print capability for Client and DataSet to give details diagnostic information for debugging (PR293_)
@@ -48,6 +50,7 @@ Detailed Notes
 - Implemented support for Unix Domain Sockets, including refactorization of server address code, test cases, and check-in tests. (PR252_)
 - A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (PR245_)
 
+.. _PR300: https://github.com/CrayLabs/SmartRedis/pull/300
 .. _PR295: https://github.com/CrayLabs/SmartRedis/pull/295
 .. _PR294: https://github.com/CrayLabs/SmartRedis/pull/294
 .. _PR294: https://github.com/CrayLabs/SmartRedis/pull/293

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -591,9 +591,14 @@ void Client::set_model(const std::string& name,
     }
 
     std::string key = _build_model_key(name, false);
-    _redis_server->set_model(key, model, backend, device,
-                             batch_size, min_batch_size,
-                             tag, inputs, outputs);
+    auto response = _redis_server->set_model(
+        key, model, backend, device,
+        batch_size, min_batch_size,
+        tag, inputs, outputs);
+    if (response.has_error()) {
+        throw SRInternalException(
+            "An unknown error occurred while setting the model");
+    }
 }
 
 void Client::set_model_multigpu(const std::string& name,
@@ -730,7 +735,11 @@ void Client::set_script(const std::string& name,
     }
 
     std::string key = _build_model_key(name, false);
-    _redis_server->set_script(key, device, script);
+    auto response = _redis_server->set_script(key, device, script);
+    if (response.has_error()) {
+        throw SRInternalException(
+            "An unknown error occurred while setting the scriot");
+    }
 }
 
 // Set a script in the database for future execution in a multi-GPU system

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -738,7 +738,7 @@ void Client::set_script(const std::string& name,
     auto response = _redis_server->set_script(key, device, script);
     if (response.has_error()) {
         throw SRInternalException(
-            "An unknown error occurred while setting the scriot");
+            "An unknown error occurred while setting the script");
     }
 }
 


### PR DESCRIPTION
Check the CommandResponse objects returned from set_script() and set_model() calls and throw an internal error if they come back in bad state.