### PR TITLE
Fix list key prefix

### DIFF
--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -1461,7 +1461,7 @@ int Client::get_list_length(const std::string& list_name)
     LOG_API_FUNCTION();
 
     // Build the list key
-    std::string list_key = _build_list_key(list_name, false);
+    std::string list_key = _build_list_key(list_name, true);
 
     // Build the command
     SingleKeyCommand cmd;


### PR DESCRIPTION
An erroneous `on_db` flag is causing wrong behavior when lists are on the DB. This PR fixes it with a minimum set of changes.