### PR TITLE
Pipeline fixes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ This section details changes made in the development branch that have not yet be
 
 Description
 
+- Streamline pipelined execution of tasks for backend database
 - Fix a bug which resulted in wrong key prefixing when retrieving aggregation lists in ensembles
 - Correct assorted API documentation errors
 - Improve documentation of exception handling in Redis server classes
@@ -36,6 +37,7 @@ Description
 
 Detailed Notes
 
+- RedisCluster::_run_pipeline() will no longer unconditionally apply a retry wait before returning (PR307_)
 - An internal flag was set incorrectly, it resulted in wrong key prefixing when accessing (retrieving or querying) lists created in ensembles (PR306_)
 - Corrected a variety of Doxygen errors and omissions in the API documentation (PR305_)
 - Added throw documentation for exception handling in redis.h, redisserver.h, rediscluster.h (PR301_)
@@ -62,6 +64,8 @@ Detailed Notes
 - Implemented support for Unix Domain Sockets, including refactorization of server address code, test cases, and check-in tests. (PR252_)
 - A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (PR245_)
 
+
+.. _PR306: https://github.com/CrayLabs/SmartRedis/pull/307
 .. _PR306: https://github.com/CrayLabs/SmartRedis/pull/306
 .. _PR305: https://github.com/CrayLabs/SmartRedis/pull/305
 .. _PR301: https://github.com/CrayLabs/SmartRedis/pull/301

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -37,7 +37,7 @@ Description
 
 Detailed Notes
 
-- RedisCluster::_run_pipeline() will no longer unconditionally apply a retry wait before returning (PR307_)
+- RedisCluster::_run_pipeline() will no longer unconditionally apply a retry wait before returning (PR309_)
 - An internal flag was set incorrectly, it resulted in wrong key prefixing when accessing (retrieving or querying) lists created in ensembles (PR306_)
 - Corrected a variety of Doxygen errors and omissions in the API documentation (PR305_)
 - Added throw documentation for exception handling in redis.h, redisserver.h, rediscluster.h (PR301_)
@@ -65,7 +65,7 @@ Detailed Notes
 - A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (PR245_)
 
 
-.. _PR306: https://github.com/CrayLabs/SmartRedis/pull/307
+.. _PR306: https://github.com/CrayLabs/SmartRedis/pull/309
 .. _PR306: https://github.com/CrayLabs/SmartRedis/pull/306
 .. _PR305: https://github.com/CrayLabs/SmartRedis/pull/305
 .. _PR301: https://github.com/CrayLabs/SmartRedis/pull/301

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -1369,6 +1369,9 @@ RedisCluster::_run_pipeline(std::vector<Command*>& cmds,
             if (reply.has_error()) {
                 throw SRRuntimeException("Redis failed to execute the pipeline");
             }
+
+            // If we get here, it all worked
+            return reply;
         }
         catch (SmartRedis::Exception& e) {
             // Exception is already prepared, just propagate it
@@ -1412,16 +1415,10 @@ RedisCluster::_run_pipeline(std::vector<Command*>& cmds,
 
         // Sleep before the next attempt
         std::this_thread::sleep_for(std::chrono::milliseconds(_command_interval));
-
-        // Return the reply
-        return reply;
     }
 
     // If we get here, we've run out of retry attempts
     throw SRTimeoutException("Unable to execute pipeline");
-
-    // Return the reply
-    return reply;
 }
 
 // Create a string representation of the Redis connection


### PR DESCRIPTION
Fix pipeline execution to no longer apply a retry timeout before returning,  allow retries to actually occur in the event of a non-fatal error, and to eliminate an unreachable return statement