### PR TITLE
Prevent codecov status checks from failing

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,10 @@ coverage:
   status:
     project:
       default:
-        target: 60%
-        threshold: 2%
+        target: 0%
+    patch:
+      default:
+        target: 0%
 
 parsers:
   gcov:
@@ -19,6 +21,6 @@ parsers:
 comment:
   layout: "reach,diff,flags,files"
   behavior: default # update comment if already exists, otherwise post new
-  require_changes: no
-  require_base: no
+  require_changes: yes
+  require_base: yes
   require_head: yes

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ This section details changes made in the development branch that have not yet be
 
 Description
 
+- Disable codecov CI tests
 - Streamlined PyBind interface layer
 - Updated Python API documentation
 - Streamlined C interface layer
@@ -43,6 +44,7 @@ Description
 
 Detailed Notes
 
+- Remove codecov thresholds to avoid commits being marked as 'failed' due to coverage variance (PR317_)
 - Streamlined PyBind interface layer to reduce repetitive boilerplate code (PR315_)
 - Updated Python API summary table to include new methods (PR313_)
 - Streamlined C interface layer to reduce repetitive boilerplate code (PR312_)
@@ -76,6 +78,7 @@ Detailed Notes
 - Implemented support for Unix Domain Sockets, including refactorization of server address code, test cases, and check-in tests. (PR252_)
 - A new make target `make lib-with-fortran` now compiles the Fortran client and dataset into its own library which applications can link against (PR245_)
 
+.. _PR317: https://github.com/CrayLabs/SmartRedis/pull/317
 .. _PR315: https://github.com/CrayLabs/SmartRedis/pull/315
 .. _PR313: https://github.com/CrayLabs/SmartRedis/pull/313
 .. _PR312: https://github.com/CrayLabs/SmartRedis/pull/312


### PR DESCRIPTION
We have wide variability of our total coverage reports even for non-substantive commits. We suspect that this is because we are compiling unit tests and the SmartRedis library in cmake's Release mode which enables -O3 and may, at worse, skip the execution of some tests and at least confuses the tracer that marks which lines have been run.

As a workaround for now, we are lowering the target thresholds to 0% so that commits are not marked with the dreaded 'X' due to the variance that results in code coverage.