### PR TITLE
Add py3.10 to test matrix

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.4, 1.2.5] # versions of RedisAI
-        py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
+        py_v: ['3.7.x', '3.8.x', '3.9.x', '3.10.x'] # versions of Python
         compiler: [intel, 8, 9, 10, 11] # intel compiler, and versions of GNU compiler
     env:
       FC: gfortran-${{ matrix.compiler }}


### PR DESCRIPTION
Add testing for python 3.10 now that it is supported by smartsim