### PR TITLE
Fix copy/paste error in to_str methods in C interface

### DIFF
--- a/src/c/c_client.cpp
+++ b/src/c/c_client.cpp
@@ -1431,7 +1431,6 @@ const char* client_to_string(void* c_client)
   catch (...) {
     result = "Unknown exception occurred";
     SRSetLastError(SRInternalException(result));
-    result = SRInternalError;
   }
 
   return result.c_str();

--- a/src/c/c_dataset.cpp
+++ b/src/c/c_dataset.cpp
@@ -353,7 +353,6 @@ const char* dataset_to_string(void* dataset)
   catch (...) {
     result = "Unknown exception occurred";
     SRSetLastError(SRInternalException(result));
-    result = SRInternalError;
   }
 
   return result.c_str();


### PR DESCRIPTION
boilerplate cloning issue