### PR TITLE
third-party software support in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ third-party/RedisAI/install-cpu/redisai.so:
 	@mkdir -p third-party
 	@cd third-party && \
 	GIT_LFS_SKIP_SMUDGE=1 git clone --recursive $(REDISAI_URL) RedisAI --branch $(REDISAI_VER) --depth=1
-	@cd third-party/RedisAI && \
+	-@cd third-party/RedisAI && \
 	CC=gcc CXX=g++ WITH_PT=1 WITH_TF=1 WITH_TFLITE=0 WITH_ORT=0 bash get_deps.sh $(SR_DEVICE) && \
 	CC=gcc CXX=g++ GPU=$(DEVICE_IS_GPU) WITH_PT=1 WITH_TF=1 WITH_TFLITE=0 WITH_ORT=0 WITH_UNIT_TESTS=0 make -j -C opt clean build && \
 	echo "Finished installing RedisAI"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,12 +8,15 @@ To be released at some future point in time
 
 Description
 
+- Refactor third-party software dependency installation
 - Add pip-install target to Makefile to automate this process going forward
 
 Detailed Notes
 
+- Third-party software dependency installation is now handled in the Makefile instead of separate scripts
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 
+.. _PR331: https://github.com/CrayLabs/SmartRedis/pull/331
 .. _PR330: https://github.com/CrayLabs/SmartRedis/pull/330
 
 0.4.0


### PR DESCRIPTION
Third-party software is now downloaded, built, and installed directly from the Makefile, and deps/test-deps are now properly listed as dependencies for lib and testing targets, respectively.

I've left the old scripts intact for now so that they are available for reference.

Two weirdnesses I noticed in testing:
1. `Make clean` nukes the installed versions of hiredis and redis++. I couldn't come up with a good way to stop that from happening. so as a stopgap, I nuke the third-party built versions before downloading, building, installing them
2. From an empty state (after `make clobber`) the sequence `make deps` => `make test-deps` reports a failure at the very end of installing RedisAI even though everything has successfully installed. Runing `make test-deps` again finishes the installation. This doesn't happen with any of the following sequences:

   - `make clobber` => `make test-deps` => `make deps`
   - `make clobber` => `make deps` => `make test` (which invokes `test-deps` first thing)

From a fresh clone, `make test` will now install everything and run the tests.