### PR TITLE
Switch CI/CD pipeline to use MacOS 12 instead of 10.15

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-12]
         gcc_v: [8] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-12]
         gcc_v: [8] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,14 +17,14 @@ Description
 
 Detailed Notes
 
-- Update MacOS version in CI/CD tests from 10.15 to 12.0 (PR341_)
+- Update MacOS version in CI/CD tests from 10.15 to 12.0 (PR339_)
 - Correct the spelling of the C DataSet destruction interface from DeallocateeDataSet to DeallocateDataSet (PR338_)
 - Updated the version of Redis++ to v1.3.8 to pull in a change that ensures the redis++.pc file properly points to the generated libraries (PR334_)
 - Third-party software dependency installation is now handled in the Makefile instead of separate scripts
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
-.. _PR341: https://github.com/CrayLabs/SmartRedis/pull/341
+.. _PR339: https://github.com/CrayLabs/SmartRedis/pull/339
 .. _PR338: https://github.com/CrayLabs/SmartRedis/pull/338
 .. _PR334: https://github.com/CrayLabs/SmartRedis/pull/334
 .. _PR331: https://github.com/CrayLabs/SmartRedis/pull/331

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Update CI/CD tests to use a modern version of MacOS
 - Fix the spelling of the Dataset destructor's C interface (now DeallocateDataSet)
 - Update Redis++ version to 1.3.8
 - Refactor third-party software dependency installation
@@ -16,13 +17,15 @@ Description
 
 Detailed Notes
 
+- Update MacOS version in CI/CD tests from 10.15 to 12.0 (PR341_)
 - Correct the spelling of the C DataSet destruction interface from DeallocateeDataSet to DeallocateDataSet (PR338_)
 - Updated the version of Redis++ to v1.3.8 to pull in a change that ensures the redis++.pc file properly points to the generated libraries (PR334_)
 - Third-party software dependency installation is now handled in the Makefile instead of separate scripts
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
-.. _PR335: https://github.com/CrayLabs/SmartRedis/pull/338
+.. _PR341: https://github.com/CrayLabs/SmartRedis/pull/341
+.. _PR338: https://github.com/CrayLabs/SmartRedis/pull/338
 .. _PR334: https://github.com/CrayLabs/SmartRedis/pull/334
 .. _PR331: https://github.com/CrayLabs/SmartRedis/pull/331
 .. _PR330: https://github.com/CrayLabs/SmartRedis/pull/330


### PR DESCRIPTION
The MacOS 10.15 runner has been deprecated for a while and is now kaput