### PR TITLE
Downgrade F2018 requirement to F2003 (NVHPC support)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -63,11 +63,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
-        # rai_v: [1.2.4, 1.2.5] # versions of RedisAI
-        # py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
-        rai_v: [1.2.5]
-        py_v: ['3.9.x']
-        compiler: [nvhpc-23-5] # nvidia, intel compiler, and versions of GNU compiler
+        rai_v: [1.2.4, 1.2.5] # versions of RedisAI
+        py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
+        compiler: [intel, 8, 9, 10, 11] # intel compiler, and versions of GNU compiler
     env:
       FC: gfortran-${{ matrix.compiler }}
       GCC_V: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
@@ -83,7 +81,7 @@ jobs:
 
       # Install compilers (Intel or GCC)
       - name: Install GCC
-        if: "!contains( matrix.compiler, 'intel' ) && !contains( matrix.compiler, 'nvidia')" # if using GNU compiler
+        if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
         run: |
           sudo apt-get -y update &&
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test &&
@@ -113,25 +111,6 @@ jobs:
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&
           echo "FC=ifort" >> $GITHUB_ENV
-
-      - name: Install nvidia compiler
-        if: "contains( matrix.compiler, 'nvhpc-23-5' )" # if using intel compiler
-        uses:
-        run: |
-          curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
-          echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
-          sudo apt-get update -y
-          sudo apt-get install -y nvhpc-23-5-cuda-multi
-          echo "NVARCH=`uname -s`_`uname -m`" >> $GITHUB_ENV &&
-          echo "NVCOMPILERS=/opt/nvidia/hpc_sdk" >> $GITHUB_ENV &&
-          echo "MANPATH=$MANPATH:$NVCOMPILERS/$NVARCH/23.5/compilers/man" >> $GITHUB_ENV &&
-          echo "PATH=$NVCOMPILERS/$NVARCH/23.5/compilers/bin:$PATH" >> $GITHUB_ENV &&
-          echo "PATH=$NVCOMPILERS/$NVARCH/23.5/comm_libs/mpi/bin:$PATH" >> $GITHUB_ENV &&
-          echo "MANPATH=$MANPATH:$NVCOMPILERS/$NVARCH/23.5/comm_libs/mpi/man" >> $GITHUB_ENV &&
-          echo "CC=nvc" >> $GITHUB_ENV &&
-          echo "CXX=nvcc" >> $GITHUB_ENV &&
-          echo "FC=nvfortran" >> $GITHUB_ENV
-
 
       # Install additional dependencies
       - name: Install Cmake Linux

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -63,9 +63,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
-        rai_v: [1.2.4, 1.2.5] # versions of RedisAI
-        py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
-        compiler: [intel, 8, 9, 10, 11] # intel compiler, and versions of GNU compiler
+        # rai_v: [1.2.4, 1.2.5] # versions of RedisAI
+        # py_v: ['3.7.x', '3.8.x', '3.9.x'] # versions of Python
+        rai_v: [1.2.5]
+        py_v: ['3.9.x']
+        compiler: [nvhpc-23-5] # nvidia, intel compiler, and versions of GNU compiler
     env:
       FC: gfortran-${{ matrix.compiler }}
       GCC_V: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
@@ -81,7 +83,7 @@ jobs:
 
       # Install compilers (Intel or GCC)
       - name: Install GCC
-        if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
+        if: "!contains( matrix.compiler, 'intel' ) && !contains( matrix.compiler, 'nvidia')" # if using GNU compiler
         run: |
           sudo apt-get -y update &&
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test &&
@@ -111,6 +113,25 @@ jobs:
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&
           echo "FC=ifort" >> $GITHUB_ENV
+
+      - name: Install nvidia compiler
+        if: "contains( matrix.compiler, 'nvhpc-23-5' )" # if using intel compiler
+        uses:
+        run: |
+          curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+          sudo apt-get update -y
+          sudo apt-get install -y nvhpc-23-5-cuda-multi
+          echo "NVARCH=`uname -s`_`uname -m`" >> $GITHUB_ENV &&
+          echo "NVCOMPILERS=/opt/nvidia/hpc_sdk" >> $GITHUB_ENV &&
+          echo "MANPATH=$MANPATH:$NVCOMPILERS/$NVARCH/23.5/compilers/man" >> $GITHUB_ENV &&
+          echo "PATH=$NVCOMPILERS/$NVARCH/23.5/compilers/bin:$PATH" >> $GITHUB_ENV &&
+          echo "PATH=$NVCOMPILERS/$NVARCH/23.5/comm_libs/mpi/bin:$PATH" >> $GITHUB_ENV &&
+          echo "MANPATH=$MANPATH:$NVCOMPILERS/$NVARCH/23.5/comm_libs/mpi/man" >> $GITHUB_ENV &&
+          echo "CC=nvc" >> $GITHUB_ENV &&
+          echo "CXX=nvcc" >> $GITHUB_ENV &&
+          echo "FC=nvfortran" >> $GITHUB_ENV
+
 
       # Install additional dependencies
       - name: Install Cmake Linux

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,7 @@ install/lib/libredis++.a:
 	cmake -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_TEST=OFF \
 		-DREDIS_PLUS_PLUS_BUILD_SHARED=OFF -DCMAKE_PREFIX_PATH="../../../install/lib/" \
 		-DCMAKE_INSTALL_PREFIX="../../../install" -DCMAKE_CXX_STANDARD=17 \
-		-DCMAKE_INSTALL_LIBDIR="lib" .. && \
+		-DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. && \
 	CC=gcc CXX=g++ make -j $(NPROC) && \
 	CC=gcc CXX=g++ make install && \
 	echo "Finished installing Redis-plus-plus"

--- a/Makefile
+++ b/Makefile
@@ -386,10 +386,10 @@ install/lib/libredis++.a:
 	@cd third-party/redis-plus-plus && \
 	mkdir -p compile && \
 	cd compile && \
-	cmake -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_TEST=OFF \
+	(cmake -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_TEST=OFF \
 		-DREDIS_PLUS_PLUS_BUILD_SHARED=OFF -DCMAKE_PREFIX_PATH="../../../install/lib/" \
 		-DCMAKE_INSTALL_PREFIX="../../../install" -DCMAKE_CXX_STANDARD=17 \
-		-DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. && \
+		-DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. )&& \
 	CC=gcc CXX=g++ make -j $(NPROC) && \
 	CC=gcc CXX=g++ make install && \
 	echo "Finished installing Redis-plus-plus"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,7 +8,8 @@ To be released at some future point in time
 
 Description
 
-- Major revamo of build and test systems for SmartRedis
+- Major revamp of build and test systems for SmartRedis
+- Downgrade requirement for F2018 to F2003 (experimental support for Nvidia toolchain)
 - Refactor Fortran methods to return default logical kind
 - Update CI/CD tests to use a modern version of MacOS
 - Fix the spelling of the Dataset destructor's C interface (now DeallocateDataSet)
@@ -20,6 +21,11 @@ Description
 Detailed Notes
 
 - Rework the build and test system to improve maintainability of the library. There have been several significant changes, including that Python and Fortran clients are no longer built by defaults and that there are Make variables that customize the build process. Please review the build documentation and ``make help`` to see all that has changed. (PR341_)
+- Replaces the assumed rank feature of F2018 used in the Fortran client with assumed
+shape arrays. Compilers need only be compliant with the F2003 standard now. While
+this means that it is possible to compile SmartRedis with the Nvidia toolchain,
+users should consider this only experimental support until we can incorporate
+Nvidia compilers into our CI. (PR346_)
 - Many Fortran  routines were returning logical kind = c_bool which turns out not to be
 the same default kind of most Fortran compilers. These have now been refactored so that
 users need not import `iso_c_binding` in their own applications (PR340_)
@@ -31,6 +37,7 @@ users need not import `iso_c_binding` in their own applications (PR340_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
 .. _PR341: https://github.com/CrayLabs/SmartRedis/pull/341
+.. _PR346: https://github.com/CrayLabs/SmartRedis/pull/346
 .. _PR340: https://github.com/CrayLabs/SmartRedis/pull/340
 .. _PR339: https://github.com/CrayLabs/SmartRedis/pull/339
 .. _PR338: https://github.com/CrayLabs/SmartRedis/pull/338

--- a/doc/clients/fortran.rst
+++ b/doc/clients/fortran.rst
@@ -105,9 +105,9 @@ Fortran compilers need to support the following features
 
 * Object-oriented programming support (Fortran 2003)
 * Fortran-C interoperability, ``iso_c_binding`` (Fortran 2003)
-* Assumed rank (``dimension(..)``) arrays (Fortran 2018)
 
-These language features are supported by Intel 19, GNU 9, and Cray 8.6 and later versions.
+These language features are supported by Intel 19, GNU 9, and Cray 8.6 and later versions. Nvidia compilers
+have been shown to work, but should be considered a fragile feature for now
 
 .. _unsupported_smartredis_features:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -54,4 +54,4 @@ below summarizes the language standards for each client.
    * - C
      - C99
    * - Fortran
-     - Fortran 2018
+     - Fortran 2003

--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -460,7 +460,7 @@ end function poll_key
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
 function put_tensor_i8(self, name, data, dims) result(code)
-  integer(kind=c_int8_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int8_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -476,7 +476,7 @@ end function put_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
 function put_tensor_i16(self, name, data, dims) result(code)
-  integer(kind=c_int16_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int16_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -492,7 +492,7 @@ end function put_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
 function put_tensor_i32(self, name, data, dims) result(code)
-  integer(kind=c_int32_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int32_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -508,7 +508,7 @@ end function put_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
 function put_tensor_i64(self, name, data, dims) result(code)
-  integer(kind=c_int64_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int64_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -524,7 +524,7 @@ end function put_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
 function put_tensor_float(self, name, data, dims) result(code)
-  real(kind=c_float), dimension(..), target, intent(in) :: data !< Data to be sent
+  real(kind=c_float), dimension(*), target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -540,7 +540,7 @@ end function put_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
 function put_tensor_double(self, name, data, dims) result(code)
-  real(kind=c_double), dimension(..), target, intent(in) :: data !< Data to be sent
+  real(kind=c_double), dimension(*), target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -556,7 +556,7 @@ end function put_tensor_double
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
 function unpack_tensor_i8(self, name, result, dims) result(code)
-  integer(kind=c_int8_t), dimension(..), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int8_t), dimension(*), target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -572,7 +572,7 @@ end function unpack_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
 function unpack_tensor_i16(self, name, result, dims) result(code)
-  integer(kind=c_int16_t), dimension(..), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int16_t), dimension(*), target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -588,7 +588,7 @@ end function unpack_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
 function unpack_tensor_i32(self, name, result, dims) result(code)
-  integer(kind=c_int32_t), dimension(..), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int32_t), dimension(*), target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -604,7 +604,7 @@ end function unpack_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
 function unpack_tensor_i64(self, name, result, dims) result(code)
-  integer(kind=c_int64_t), dimension(..), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int64_t), dimension(*), target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -620,7 +620,7 @@ end function unpack_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
 function unpack_tensor_float(self, name, result, dims) result(code)
-  real(kind=c_float), dimension(..), target, intent(out) :: result !< Data to be sent
+  real(kind=c_float), dimension(*), target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -636,7 +636,7 @@ end function unpack_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
 function unpack_tensor_double(self, name, result, dims) result(code)
-  real(kind=c_double), dimension(..), target, intent(out) :: result !< Data to be sent
+  real(kind=c_double), dimension(*), target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor

--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -24,10 +24,13 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+! Note the below macros are here to allow compilation with Nvidia drivers
+! While assumed size should be sufficient, this does not seem to work with
+! Intel and GNU (however those have support for assumed rank)
 #ifdef __NVCOMPILER
-#define DIM_DEF dimension(*)
+#define DIM_RANK_SPEC dimension(*)
 #else
-#define DIM_DEF dimension(..)
+#define DIM_RANK_SPEC dimension(..)
 #endif
 
 module smartredis_client
@@ -466,7 +469,7 @@ end function poll_key
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
 function put_tensor_i8(self, name, data, dims) result(code)
-  integer(kind=c_int8_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int8_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -482,7 +485,7 @@ end function put_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
 function put_tensor_i16(self, name, data, dims) result(code)
-  integer(kind=c_int16_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int16_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -498,7 +501,7 @@ end function put_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
 function put_tensor_i32(self, name, data, dims) result(code)
-  integer(kind=c_int32_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int32_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -514,7 +517,7 @@ end function put_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
 function put_tensor_i64(self, name, data, dims) result(code)
-  integer(kind=c_int64_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int64_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -530,7 +533,7 @@ end function put_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
 function put_tensor_float(self, name, data, dims) result(code)
-  real(kind=c_float), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  real(kind=c_float), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -546,7 +549,7 @@ end function put_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
 function put_tensor_double(self, name, data, dims) result(code)
-  real(kind=c_double), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  real(kind=c_double), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -562,7 +565,7 @@ end function put_tensor_double
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
 function unpack_tensor_i8(self, name, result, dims) result(code)
-  integer(kind=c_int8_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int8_t), DIM_RANK_SPEC, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -578,7 +581,7 @@ end function unpack_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
 function unpack_tensor_i16(self, name, result, dims) result(code)
-  integer(kind=c_int16_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int16_t), DIM_RANK_SPEC, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -594,7 +597,7 @@ end function unpack_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
 function unpack_tensor_i32(self, name, result, dims) result(code)
-  integer(kind=c_int32_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int32_t), DIM_RANK_SPEC, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -610,7 +613,7 @@ end function unpack_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
 function unpack_tensor_i64(self, name, result, dims) result(code)
-  integer(kind=c_int64_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int64_t), DIM_RANK_SPEC, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -626,7 +629,7 @@ end function unpack_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
 function unpack_tensor_float(self, name, result, dims) result(code)
-  real(kind=c_float), DIM_DEF, target, intent(out) :: result !< Data to be sent
+  real(kind=c_float), DIM_RANK_SPEC, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -642,7 +645,7 @@ end function unpack_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
 function unpack_tensor_double(self, name, result, dims) result(code)
-  real(kind=c_double), DIM_DEF, target, intent(out) :: result !< Data to be sent
+  real(kind=c_double), DIM_RANK_SPEC, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor

--- a/src/fortran/client.F90
+++ b/src/fortran/client.F90
@@ -24,6 +24,12 @@
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#ifdef __NVCOMPILER
+#define DIM_DEF dimension(*)
+#else
+#define DIM_DEF dimension(..)
+#endif
+
 module smartredis_client
 
 use iso_c_binding, only : c_ptr, c_bool, c_null_ptr, c_char, c_int
@@ -460,7 +466,7 @@ end function poll_key
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
 function put_tensor_i8(self, name, data, dims) result(code)
-  integer(kind=c_int8_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int8_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -476,7 +482,7 @@ end function put_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
 function put_tensor_i16(self, name, data, dims) result(code)
-  integer(kind=c_int16_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int16_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -492,7 +498,7 @@ end function put_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
 function put_tensor_i32(self, name, data, dims) result(code)
-  integer(kind=c_int32_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int32_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -508,7 +514,7 @@ end function put_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
 function put_tensor_i64(self, name, data, dims) result(code)
-  integer(kind=c_int64_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int64_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -524,7 +530,7 @@ end function put_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
 function put_tensor_float(self, name, data, dims) result(code)
-  real(kind=c_float), dimension(*), target, intent(in) :: data !< Data to be sent
+  real(kind=c_float), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -540,7 +546,7 @@ end function put_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
 function put_tensor_double(self, name, data, dims) result(code)
-  real(kind=c_double), dimension(*), target, intent(in) :: data !< Data to be sent
+  real(kind=c_double), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(client_type),                    intent(in) :: self !< Fortran SmartRedis client
   character(len=*),                      intent(in) :: name !< The unique name used to store in the database
   integer, dimension(:),                 intent(in) :: dims !< The length of each dimension
@@ -556,7 +562,7 @@ end function put_tensor_double
 
 !> Put a tensor whose Fortran type is the equivalent 'int8' C-type
 function unpack_tensor_i8(self, name, result, dims) result(code)
-  integer(kind=c_int8_t), dimension(*), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int8_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -572,7 +578,7 @@ end function unpack_tensor_i8
 
 !> Put a tensor whose Fortran type is the equivalent 'int16' C-type
 function unpack_tensor_i16(self, name, result, dims) result(code)
-  integer(kind=c_int16_t), dimension(*), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int16_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -588,7 +594,7 @@ end function unpack_tensor_i16
 
 !> Put a tensor whose Fortran type is the equivalent 'int32' C-type
 function unpack_tensor_i32(self, name, result, dims) result(code)
-  integer(kind=c_int32_t), dimension(*), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int32_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -604,7 +610,7 @@ end function unpack_tensor_i32
 
 !> Put a tensor whose Fortran type is the equivalent 'int64' C-type
 function unpack_tensor_i64(self, name, result, dims) result(code)
-  integer(kind=c_int64_t), dimension(*), target, intent(out) :: result !< Data to be sent
+  integer(kind=c_int64_t), DIM_DEF, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -620,7 +626,7 @@ end function unpack_tensor_i64
 
 !> Put a tensor whose Fortran type is the equivalent 'float' C-type
 function unpack_tensor_float(self, name, result, dims) result(code)
-  real(kind=c_float), dimension(*), target, intent(out) :: result !< Data to be sent
+  real(kind=c_float), DIM_DEF, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor
@@ -636,7 +642,7 @@ end function unpack_tensor_float
 
 !> Put a tensor whose Fortran type is the equivalent 'double' C-type
 function unpack_tensor_double(self, name, result, dims) result(code)
-  real(kind=c_double), dimension(*), target, intent(out) :: result !< Data to be sent
+  real(kind=c_double), DIM_DEF, target, intent(out) :: result !< Data to be sent
   class(client_type),                   intent(in) :: self  !< Pointer to the initialized client
   character(len=*),                     intent(in) :: name  !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims  !< Length along each dimension of the tensor

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -23,10 +23,14 @@
 ! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+! Note the below macros are here to allow compilation with Nvidia drivers
+! While assumed size should be sufficient, this does not seem to work with
+! Intel and GNU (however those have support for assumed rank)
 #ifdef __NVCOMPILER
-#define DIM_DEF dimension(*)
+#define DIM_RANK_SPEC dimension(*)
 #else
-#define DIM_DEF dimension(..)
+#define DIM_RANK_SPEC dimension(..)
 #endif
 
 module smartredis_dataset
@@ -149,7 +153,7 @@ end function get_c_pointer
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int8' C-type
 function add_tensor_i8(self, name, data, dims) result(code)
-  integer(kind=c_int8_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int8_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -165,7 +169,7 @@ end function add_tensor_i8
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int16' C-type
 function add_tensor_i16(self, name, data, dims) result(code)
-  integer(kind=c_int16_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int16_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -181,7 +185,7 @@ end function add_tensor_i16
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int32' C-type
 function add_tensor_i32(self, name, data, dims) result(code)
-  integer(kind=c_int32_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int32_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -197,7 +201,7 @@ end function add_tensor_i32
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int64' C-type
 function add_tensor_i64(self, name, data, dims) result(code)
-  integer(kind=c_int64_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int64_t), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -213,7 +217,7 @@ end function add_tensor_i64
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'float' C-type
 function add_tensor_float(self, name, data, dims) result(code)
-  real(kind=c_float), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  real(kind=c_float), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -229,7 +233,7 @@ end function add_tensor_float
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'double' C-type
 function add_tensor_double(self, name, data, dims) result(code)
-  real(kind=c_double), DIM_DEF, target, intent(in) :: data !< Data to be sent
+  real(kind=c_double), DIM_RANK_SPEC, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -246,7 +250,7 @@ end function add_tensor_double
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int8' C-type
 function unpack_dataset_tensor_i8(self, name, result, dims) result(code)
-  integer(kind=c_int8_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int8_t), DIM_RANK_SPEC, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -262,7 +266,7 @@ end function unpack_dataset_tensor_i8
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int16' C-type
 function unpack_dataset_tensor_i16(self, name, result, dims) result(code)
-  integer(kind=c_int16_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int16_t), DIM_RANK_SPEC, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -278,7 +282,7 @@ end function unpack_dataset_tensor_i16
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int32' C-type
 function unpack_dataset_tensor_i32(self, name, result, dims) result(code)
-  integer(kind=c_int32_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int32_t), DIM_RANK_SPEC, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -294,7 +298,7 @@ end function unpack_dataset_tensor_i32
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int64' C-type
 function unpack_dataset_tensor_i64(self, name, result, dims) result(code)
-  integer(kind=c_int64_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int64_t), DIM_RANK_SPEC, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -310,7 +314,7 @@ end function unpack_dataset_tensor_i64
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'float' C-type
 function unpack_dataset_tensor_float(self, name, result, dims) result(code)
-  real(kind=c_float), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
+  real(kind=c_float), DIM_RANK_SPEC, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -326,7 +330,7 @@ end function unpack_dataset_tensor_float
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'double' C-type
 function unpack_dataset_tensor_double(self, name, result, dims) result(code)
-  real(kind=c_double), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
+  real(kind=c_double), DIM_RANK_SPEC, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -144,7 +144,7 @@ end function get_c_pointer
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int8' C-type
 function add_tensor_i8(self, name, data, dims) result(code)
-  integer(kind=c_int8_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int8_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -160,7 +160,7 @@ end function add_tensor_i8
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int16' C-type
 function add_tensor_i16(self, name, data, dims) result(code)
-  integer(kind=c_int16_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int16_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -176,7 +176,7 @@ end function add_tensor_i16
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int32' C-type
 function add_tensor_i32(self, name, data, dims) result(code)
-  integer(kind=c_int32_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int32_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -192,7 +192,7 @@ end function add_tensor_i32
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int64' C-type
 function add_tensor_i64(self, name, data, dims) result(code)
-  integer(kind=c_int64_t), dimension(..), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int64_t), dimension(*), target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -208,7 +208,7 @@ end function add_tensor_i64
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'float' C-type
 function add_tensor_float(self, name, data, dims) result(code)
-  real(kind=c_float), dimension(..), target, intent(in) :: data !< Data to be sent
+  real(kind=c_float), dimension(*), target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -224,7 +224,7 @@ end function add_tensor_float
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'double' C-type
 function add_tensor_double(self, name, data, dims) result(code)
-  real(kind=c_double), dimension(..), target, intent(in) :: data !< Data to be sent
+  real(kind=c_double), dimension(*), target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -241,7 +241,7 @@ end function add_tensor_double
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int8' C-type
 function unpack_dataset_tensor_i8(self, name, result, dims) result(code)
-  integer(kind=c_int8_t), dimension(..), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int8_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -257,7 +257,7 @@ end function unpack_dataset_tensor_i8
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int16' C-type
 function unpack_dataset_tensor_i16(self, name, result, dims) result(code)
-  integer(kind=c_int16_t), dimension(..), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int16_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -273,7 +273,7 @@ end function unpack_dataset_tensor_i16
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int32' C-type
 function unpack_dataset_tensor_i32(self, name, result, dims) result(code)
-  integer(kind=c_int32_t), dimension(..), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int32_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -289,7 +289,7 @@ end function unpack_dataset_tensor_i32
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int64' C-type
 function unpack_dataset_tensor_i64(self, name, result, dims) result(code)
-  integer(kind=c_int64_t), dimension(..), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int64_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -305,7 +305,7 @@ end function unpack_dataset_tensor_i64
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'float' C-type
 function unpack_dataset_tensor_float(self, name, result, dims) result(code)
-  real(kind=c_float), dimension(..), target, intent(out) :: result !< Array to be populated with data
+  real(kind=c_float), dimension(*), target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -321,7 +321,7 @@ end function unpack_dataset_tensor_float
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'double' C-type
 function unpack_dataset_tensor_double(self, name, result, dims) result(code)
-  real(kind=c_double), dimension(..), target, intent(out) :: result !< Array to be populated with data
+  real(kind=c_double), dimension(*), target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -23,6 +23,11 @@
 ! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 ! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#ifdef __NVCOMPILER
+#define DIM_DEF dimension(*)
+#else
+#define DIM_DEF dimension(..)
+#endif
 
 module smartredis_dataset
 
@@ -144,7 +149,7 @@ end function get_c_pointer
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int8' C-type
 function add_tensor_i8(self, name, data, dims) result(code)
-  integer(kind=c_int8_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int8_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -160,7 +165,7 @@ end function add_tensor_i8
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int16' C-type
 function add_tensor_i16(self, name, data, dims) result(code)
-  integer(kind=c_int16_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int16_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -176,7 +181,7 @@ end function add_tensor_i16
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int32' C-type
 function add_tensor_i32(self, name, data, dims) result(code)
-  integer(kind=c_int32_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int32_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -192,7 +197,7 @@ end function add_tensor_i32
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'int64' C-type
 function add_tensor_i64(self, name, data, dims) result(code)
-  integer(kind=c_int64_t), dimension(*), target, intent(in) :: data !< Data to be sent
+  integer(kind=c_int64_t), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -208,7 +213,7 @@ end function add_tensor_i64
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'float' C-type
 function add_tensor_float(self, name, data, dims) result(code)
-  real(kind=c_float), dimension(*), target, intent(in) :: data !< Data to be sent
+  real(kind=c_float), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -224,7 +229,7 @@ end function add_tensor_float
 
 !> Add a tensor to a dataset whose Fortran type is the equivalent 'double' C-type
 function add_tensor_double(self, name, data, dims) result(code)
-  real(kind=c_double), dimension(*), target, intent(in) :: data !< Data to be sent
+  real(kind=c_double), DIM_DEF, target, intent(in) :: data !< Data to be sent
   class(dataset_type),   intent(in)  :: self !< Fortran SmartRedis dataset
   character(len=*),      intent(in)  :: name !< The unique name used to store in the database
   integer, dimension(:), intent(in)  :: dims !< The length of each dimension
@@ -241,7 +246,7 @@ end function add_tensor_double
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int8' C-type
 function unpack_dataset_tensor_i8(self, name, result, dims) result(code)
-  integer(kind=c_int8_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int8_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -257,7 +262,7 @@ end function unpack_dataset_tensor_i8
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int16' C-type
 function unpack_dataset_tensor_i16(self, name, result, dims) result(code)
-  integer(kind=c_int16_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int16_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -273,7 +278,7 @@ end function unpack_dataset_tensor_i16
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int32' C-type
 function unpack_dataset_tensor_i32(self, name, result, dims) result(code)
-  integer(kind=c_int32_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int32_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -289,7 +294,7 @@ end function unpack_dataset_tensor_i32
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'int64' C-type
 function unpack_dataset_tensor_i64(self, name, result, dims) result(code)
-  integer(kind=c_int64_t), dimension(*), target, intent(out) :: result !< Array to be populated with data
+  integer(kind=c_int64_t), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -305,7 +310,7 @@ end function unpack_dataset_tensor_i64
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'float' C-type
 function unpack_dataset_tensor_float(self, name, result, dims) result(code)
-  real(kind=c_float), dimension(*), target, intent(out) :: result !< Array to be populated with data
+  real(kind=c_float), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor
@@ -321,7 +326,7 @@ end function unpack_dataset_tensor_float
 
 !> Unpack a tensor into already allocated memory whose Fortran type is the equivalent 'double' C-type
 function unpack_dataset_tensor_double(self, name, result, dims) result(code)
-  real(kind=c_double), dimension(*), target, intent(out) :: result !< Array to be populated with data
+  real(kind=c_double), DIM_DEF, target, intent(out) :: result !< Array to be populated with data
   class(dataset_type),                  intent(in) :: self !< Pointer to the initialized dataset
   character(len=*),                     intent(in) :: name !< The name to use to place the tensor
   integer, dimension(:),                intent(in) :: dims !< Length along each dimension of the tensor


### PR DESCRIPTION
Replaces the assumed rank feature of F2018 used in the Fortran client with assumed
shape arrays. Compilers need only be compliant with the F2003 standard now. While
this means that it is possible to compile SmartRedis with the Nvidia toolchain,
users should consider this only experimental support until we can incorporate
Nvidia compilers into our CI. 