### PR TITLE
Parallelize build of examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ deps:
 lib: deps
 lib:
 	@cmake -S . -B build/$(SR_BUILD) -DSR_BUILD=$(SR_BUILD) -DSR_LINK=$(SR_LINK) \
-	-DSR_PEDANTIC=$(SR_PEDANTIC) -DSR_FORTRAN=$(SR_FORTRAN) -DSR_PYTHON=$(SR_PYTHON)
+		-DSR_PEDANTIC=$(SR_PEDANTIC) -DSR_FORTRAN=$(SR_FORTRAN) -DSR_PYTHON=$(SR_PYTHON)
 	@cmake --build build/$(SR_BUILD) -- -j $(NPROC)
 	@cmake --install build/$(SR_BUILD)
 
@@ -173,7 +173,7 @@ build-test-fortran: test-lib
 build-examples: lib
 	@cmake -S examples -B build/$(SR_BUILD)/examples -DSR_BUILD=$(SR_BUILD) \
 		-DSR_LINK=$(SR_LINK) -DSR_FORTRAN=$(SR_FORTRAN)
-	@cmake --build build/$(SR_BUILD)/examples
+	@cmake --build build/$(SR_BUILD)/examples -- -j $(NPROC)
 
 
 # help: build-example-serial           - buld serial examples

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,7 +8,8 @@ To be released at some future point in time
 
 Description
 
-- Major revamo of build and test systems for SmartRedis
+- Enable parallel build for the SmartRedis examples
+- Major revamp of build and test systems for SmartRedis
 - Refactor Fortran methods to return default logical kind
 - Update CI/CD tests to use a modern version of MacOS
 - Fix the spelling of the Dataset destructor's C interface (now DeallocateDataSet)
@@ -19,6 +20,7 @@ Description
 
 Detailed Notes
 
+- Enable parallel build for the SmartRedis examples by moving utility Fortran code into a small static library (PR342_)
 - Rework the build and test system to improve maintainability of the library. There have been several significant changes, including that Python and Fortran clients are no longer built by defaults and that there are Make variables that customize the build process. Please review the build documentation and ``make help`` to see all that has changed. (PR341_)
 - Many Fortran  routines were returning logical kind = c_bool which turns out not to be
 the same default kind of most Fortran compilers. These have now been refactored so that
@@ -30,6 +32,7 @@ users need not import `iso_c_binding` in their own applications (PR340_)
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
+.. _PR342: https://github.com/CrayLabs/SmartRedis/pull/342
 .. _PR341: https://github.com/CrayLabs/SmartRedis/pull/341
 .. _PR340: https://github.com/CrayLabs/SmartRedis/pull/340
 .. _PR339: https://github.com/CrayLabs/SmartRedis/pull/339

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,7 +20,7 @@ Description
 
 Detailed Notes
 
-- Enable parallel build for the SmartRedis examples by moving utility Fortran code into a small static library (PR342_)
+- Enable parallel build for the SmartRedis examples by moving utility Fortran code into a small static library (PR349_)
 - Rework the build and test system to improve maintainability of the library. There have been several significant changes, including that Python and Fortran clients are no longer built by defaults and that there are Make variables that customize the build process. Please review the build documentation and ``make help`` to see all that has changed. (PR341_)
 - Many Fortran  routines were returning logical kind = c_bool which turns out not to be
 the same default kind of most Fortran compilers. These have now been refactored so that
@@ -32,7 +32,7 @@ users need not import `iso_c_binding` in their own applications (PR340_)
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
-.. _PR342: https://github.com/CrayLabs/SmartRedis/pull/342
+.. _PR349: https://github.com/CrayLabs/SmartRedis/pull/349
 .. _PR341: https://github.com/CrayLabs/SmartRedis/pull/341
 .. _PR340: https://github.com/CrayLabs/SmartRedis/pull/340
 .. _PR339: https://github.com/CrayLabs/SmartRedis/pull/339

--- a/examples/parallel/fortran/CMakeLists.txt
+++ b/examples/parallel/fortran/CMakeLists.txt
@@ -68,6 +68,9 @@ include_directories(SYSTEM
     ${SMARTREDIS_INSTALL_PATH}/include
 )
 
+# Stuff the example_utils into a library to enable parallel builds
+add_library(example_utils STATIC example_utils.F90)
+
 # Define all the examples to be built
 list(APPEND EXECUTABLES
 	 smartredis_dataset
@@ -79,7 +82,6 @@ list(APPEND EXECUTABLES
 foreach(EXECUTABLE ${EXECUTABLES})
 	add_executable(${EXECUTABLE}_fortran_parallel
 		${EXECUTABLE}.F90
-		example_utils.F90
 	)
 	set_target_properties(${EXECUTABLE}_fortran_parallel PROPERTIES
 		OUTPUT_NAME ${EXECUTABLE}
@@ -87,5 +89,6 @@ foreach(EXECUTABLE ${EXECUTABLES})
 	target_link_libraries(${EXECUTABLE}_fortran_parallel
 		${SMARTREDIS_LIBRARIES}
 		MPI::MPI_Fortran
+		example_utils
 	)
 endforeach()


### PR DESCRIPTION
Enable parallel build of examples by putting Fortran utility files into a mini-library