### PR TITLE
Remove debug statement

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Remove debug output in pybind layer
 - Enable parallel build for the SmartRedis examples
 - Experimental support for Nvidia toolchain
 - Major revamp of build and test systems for SmartRedis
@@ -21,6 +22,7 @@ Description
 
 Detailed Notes
 
+- Remove debug output in pybind layer associated with put_dataset (PR352_)
 - Enable parallel build for the SmartRedis examples by moving utility Fortran code
 into a small static library (PR349_)
 - For the NVidia toolchain only: Replaces the assumed rank feature of F2018 used
@@ -40,6 +42,7 @@ users need not import `iso_c_binding` in their own applications (PR340_)
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
+.. _PR352: https://github.com/CrayLabs/SmartRedis/pull/352
 .. _PR349: https://github.com/CrayLabs/SmartRedis/pull/349
 .. _PR346: https://github.com/CrayLabs/SmartRedis/pull/346
 .. _PR341: https://github.com/CrayLabs/SmartRedis/pull/341

--- a/src/python/src/pyclient.cpp
+++ b/src/python/src/pyclient.cpp
@@ -192,7 +192,6 @@ void PyClient::rename_tensor(const std::string& old_name,
 void PyClient::put_dataset(PyDataset& dataset)
 {
     MAKE_CLIENT_API({
-        std::cout << "Got the dataset" << std::endl;
         _client->put_dataset(*(dataset.get()));
     });
 }


### PR DESCRIPTION
This PR removes a debug statement that was left in the pybind layer.  This statement is surfaced whenever the user invokes ``put_dataset``.