### PR TITLE
Remove ParamSpec as Runtime Dep

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Improved compatibility of type hints with third-party software
 - Added type hints to the Python interface layer
 - Add support for Python 3.10
 - Updated setup.py to work with the new build system

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -29,6 +29,7 @@ Description
 
 Detailed Notes
 
+- Turn `ParamSpec` usage into forward references to not require `typing-extensions` at runtime (PR365_)
 - Added type hints to the Python interface layer (PR361_)
 - List Python 3.10 support and loosen PyTorch requirement to allow for versions support Python 3.10 (PR360_)
 - Streamlined setup.py to simplify Python install (PR359)
@@ -56,6 +57,7 @@ users need not import `iso_c_binding` in their own applications (PR340_)
 - New pip-install target in Makefile will be a dependency of the lib target going forward so that users don't have to manually pip install SmartRedis in the future (PR330_)
 - Added ConfigOptions class and API, which will form the backbone of multiDB support (PR303_)
 
+.. _PR365: https://github.com/CrayLabs/SmartRedis/pull/365
 .. _PR361: https://github.com/CrayLabs/SmartRedis/pull/361
 .. _PR360: https://github.com/CrayLabs/SmartRedis/pull/360
 .. _PR359: https://github.com/CrayLabs/SmartRedis/pull/359

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ setup_requires =
 include_package_data = True
 install_requires =
     numpy>=1.18.2
-    typing_extensions>=4.0.0
 python_requires = >=3.7,<3.11
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ setup_requires =
 include_package_data = True
 install_requires =
     numpy>=1.18.2
+    typing_extensions>=4.0.0
 python_requires = >=3.7,<3.11
 
 

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -28,7 +28,6 @@ from .smartredisPy import PyConfigOptions
 from .util import exception_handler, typecheck
 from .error import RedisRuntimeError
 import typing as t
-from typing_extensions import Self
 
 _notfactory = (
     "Method called on a ConfigOptions object not created from a factory method"

--- a/src/python/module/smartredis/dataset_utils.py
+++ b/src/python/module/smartredis/dataset_utils.py
@@ -27,21 +27,21 @@
 import functools
 import typing as t
 from typing import TYPE_CHECKING
-from typing_extensions import ParamSpec
 
 from .dataset import Dataset
 from .util import typecheck
 from itertools import permutations
 from .error import *
 
-# Type hint magic bits
-_PR = ParamSpec("_PR")
-_RT = t.TypeVar("_RT")
-
 
 if TYPE_CHECKING:  # pragma: no cover
     # Import optional deps for intellisense
     import xarray as xr
+
+    # Type hint magic bits
+    from typing_extensions import ParamSpec
+    _PR = ParamSpec("_PR")
+    _RT = t.TypeVar("_RT")
 else:
     # Leave optional deps as nullish
     xr = None
@@ -49,9 +49,9 @@ else:
 # ----helper decorators -----
 
 
-def _requires_xarray(fn: t.Callable[_PR, _RT]) -> t.Callable[_PR, _RT]:
+def _requires_xarray(fn: "t.Callable[_PR, _RT]") -> "t.Callable[_PR, _RT]":
     @functools.wraps(fn)
-    def _import_xarray(*args: _PR.args, **kwargs: _PR.kwargs) -> _RT:
+    def _import_xarray(*args: "_PR.args", **kwargs: "_PR.kwargs") -> "_RT":
         global xr
         try:
             import xarray as xr

--- a/src/python/module/smartredis/util.py
+++ b/src/python/module/smartredis/util.py
@@ -30,11 +30,12 @@ from .smartredisPy import RedisReplyError as PybindRedisReplyError
 from .smartredisPy import c_get_last_error_location
 import numpy as np
 import typing as t
-from typing_extensions import ParamSpec
 
-# Type hint magic bits
-_PR = ParamSpec("_PR")
-_RT = t.TypeVar("_RT")
+if t.TYPE_CHECKING:
+    # Type hint magic bits
+    from typing_extensions import ParamSpec
+    _PR = ParamSpec("_PR")
+    _RT = t.TypeVar("_RT")
 
 
 class Dtypes:
@@ -105,7 +106,7 @@ def init_default(
     return init_value
 
 
-def exception_handler(func: t.Callable[_PR, _RT]) -> t.Callable[_PR, _RT]:
+def exception_handler(func: "t.Callable[_PR, _RT]") -> "t.Callable[_PR, _RT]":
     """Route exceptions raised in processing SmartRedis API calls to our
     Python wrappers
 
@@ -120,7 +121,7 @@ def exception_handler(func: t.Callable[_PR, _RT]) -> t.Callable[_PR, _RT]:
     """
 
     @wraps(func)
-    def smartredis_api_wrapper(*args: _PR.args, **kwargs: _PR.kwargs) -> _RT:
+    def smartredis_api_wrapper(*args: "_PR.args", **kwargs: "_PR.kwargs") -> "_RT":
         try:
             return func(*args, **kwargs)
         # Catch RedisReplyErrors for additional processing (convert from


### PR DESCRIPTION
Does NOT add typing extensions to SR run deps
Remove unused import
Turn all ParamSpec usage into forward refs