### PR TITLE
Fix static Fortran build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,27 @@ include_directories(SYSTEM
     install/include
 )
 
+# Build the main SmartRedis library
+add_library(smartredis ${SMARTREDIS_LINK_MODE} ${CLIENT_SRC})
+set_target_properties(smartredis PROPERTIES
+    SUFFIX ${SMARTREDIS_LINK_LIBRARY_SUFFIX}
+)
+set_target_properties(smartredis PROPERTIES
+    OUTPUT_NAME ${SMARTREDIS_LIB}
+)
+target_link_libraries(smartredis PUBLIC ${EXT_CLIENT_LIBRARIES} PRIVATE Threads::Threads)
+
+# Install SmartRedis header files
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/"
+        DESTINATION "include"
+        FILES_MATCHING
+        PATTERN "*.h" PATTERN "*.tcc" PATTERN "*.inc"
+)
+
+# Install dynamic library and headers
+install(TARGETS smartredis
+     	LIBRARY DESTINATION lib)
+
 # Build the Fortran library
 if (SR_FORTRAN)
     set(FORTRAN_SRC
@@ -151,28 +172,6 @@ if (SR_FORTRAN)
     install(TARGETS smartredis-fortran
     	LIBRARY DESTINATION lib)
 endif()
-
-
-# Build the main SmartRedis library
-add_library(smartredis ${SMARTREDIS_LINK_MODE} ${CLIENT_SRC})
-set_target_properties(smartredis PROPERTIES
-    SUFFIX ${SMARTREDIS_LINK_LIBRARY_SUFFIX}
-)
-set_target_properties(smartredis PROPERTIES
-    OUTPUT_NAME ${SMARTREDIS_LIB}
-)
-target_link_libraries(smartredis PUBLIC ${EXT_CLIENT_LIBRARIES} PRIVATE Threads::Threads)
-
-# Install SmartRedis header files
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/"
-        DESTINATION "include"
-        FILES_MATCHING
-        PATTERN "*.h" PATTERN "*.tcc" PATTERN "*.inc"
-)
-
-# Install dynamic library and headers
-install(TARGETS smartredis
-     	LIBRARY DESTINATION lib)
 
 # Build the Python library for SmartRedis
 if(SR_PYTHON)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -16,10 +16,10 @@ Description
 
 Detailed Notes
 
-- The Fortran client will no longer statically link to the SmartRedis library generated from the previous compilation attempt (PR372_)
+- The Fortran client will no longer statically link to the SmartRedis library generated from the previous compilation attempt (PR374_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
-.. _PR372: https://github.com/CrayLabs/SmartRedis/pull/372
+.. _PR372: https://github.com/CrayLabs/SmartRedis/pull/374
 .. _PR364: https://github.com/CrayLabs/SmartRedis/pull/364
 
 0.4.1

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+Changelog
+=========
+
+Development branch
+------------------
+
+To be released at some future point in time
+
+Description
+
+- Improved clustered redis initialization
+
+Detailed Notes
+
+- Reuse existing redis connection when mapping the Redis cluster (PR364_)
+
+.. _PR364: https://github.com/CrayLabs/SmartRedis/pull/364
+
 0.4.1
 -----
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,12 +11,15 @@ To be released at some future point in time
 
 Description
 
+- Fix static linkage for Fortran client
 - Improved clustered redis initialization
 
 Detailed Notes
 
+- The Fortran client will no longer statically link to the SmartRedis library generated from the previous compilation attempt (PR372_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
+.. _PR372: https://github.com/CrayLabs/SmartRedis/pull/372
 .. _PR364: https://github.com/CrayLabs/SmartRedis/pull/364
 
 0.4.1

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -1080,8 +1080,7 @@ inline void RedisCluster::_map_cluster()
     cmd << "CLUSTER" << "SLOTS";
 
     // Run it
-    CommandReply reply(_redis_cluster->
-                 command(cmd.begin(), cmd.end()));
+    CommandReply reply = run(cmd);
     if (reply.has_error() > 0) {
         throw SRRuntimeException("CLUSTER SLOTS command failed");
     }


### PR DESCRIPTION
We were actually statically linking to whatever the came out of the previous compilation command rather than the current compilation command. This usually worked out ok, but for a clean installation there was no previous command so no previous library and the build would fail