### PR TITLE
Fix bad kwarg when launching server via UDS

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,10 +15,12 @@ Description
 Detailed Notes
 
 - Update language support matrix in documentation to reflect updates from the last release (PR379_)
+- Fix typo causing startup failure in utility script for unit tests (PR378_)
 - Deleted obsolete build and testing files that are no longer needed with the new build and test system (PR366_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
 .. _PR379: https://github.com/CrayLabs/SmartRedis/pull/379
+.. _PR378: https://github.com/CrayLabs/SmartRedis/pull/378
 .. _PR366: https://github.com/CrayLabs/SmartRedis/pull/366
 .. _PR364: https://github.com/CrayLabs/SmartRedis/pull/364
 

--- a/utils/launch_redis.py
+++ b/utils/launch_redis.py
@@ -29,6 +29,7 @@ from time import sleep
 import argparse
 import os
 import pathlib
+import typing as t
 
 def check_availability(n_nodes, port, udsport):
     """Repeat a command until it is successful
@@ -126,7 +127,7 @@ def prepare_uds_socket(udsport):
         return # Silently bail
     uds_abs = pathlib.Path(udsport).resolve()
     basedir = uds_abs.parent
-    basedir.mkdir(exists_okay=True)
+    basedir.mkdir(exist_ok=True)
     uds_abs.touch()
     uds_abs.chmod(0o777)
 

--- a/utils/launch_redis.py
+++ b/utils/launch_redis.py
@@ -29,7 +29,6 @@ from time import sleep
 import argparse
 import os
 import pathlib
-import typing as t
 
 def check_availability(n_nodes, port, udsport):
     """Repeat a command until it is successful


### PR DESCRIPTION
When launching a server with UDS enabled, a keyword arg typo causes an error to occur.

The current code contains:

````
def prepare_uds_socket(udsport):
    """Sets up the UDS socket"""
    if udsport is None:
        return # Silently bail
    uds_abs = pathlib.Path(udsport).resolve()
    basedir = uds_abs.parent
    basedir.mkdir(exists_okay=True)
    ...
````

The defect is in the line `basedir.mkdir(exists_okay=True)` - the keyword should be `exist_ok`. See [pathlib docs](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir)