### PR TITLE
Make testing more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ define run_smartredis_tests_with_uds_server
 		$(SKIP_DOCKER) $(SKIP_PYTHON) $(SKIP_FORTRAN) \
 		--build $(SR_BUILD) --sr_fortran $(SR_FORTRAN) $(1) ; \
 	(testresult=$$?; \
-	echo "Shutting down standalone Redis server with Unix Domain Socket support" &&
+	echo "Shutting down standalone Redis server with Unix Domain Socket support" && \
 	python utils/launch_redis.py --port $(SR_TEST_PORT) --nodes 1 \
 		--udsport $(SR_TEST_UDS_FILE) --stop; \
 	exit $$testresult) && \

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ define run_smartredis_tests_with_standalone_server
 	(testresult=$$?; \
 	echo "Shutting down standalone Redis server" && \
 	python utils/launch_redis.py --port $(SR_TEST_PORT) --nodes 1 --stop && \
-	exit $$testresult) && \
+	test $$testresult -eq 0 || echo "Standalone tests failed"; exit $$testresult) && \
 	echo "Standalone tests complete"
 endef
 
@@ -346,7 +346,7 @@ define run_smartredis_tests_with_clustered_server
 	echo "Shutting down clustered Redis server" && \
 	python utils/launch_redis.py --port $(SR_TEST_PORT) \
 		--nodes $(SR_TEST_NODES) --stop; \
-	exit $$testresult) && \
+	test $$testresult -eq 0 || echo "Clustered tests failed"; exit $$testresult) && \
 	echo "Clustered tests complete"
 endef
 
@@ -370,7 +370,7 @@ define run_smartredis_tests_with_uds_server
 	echo "Shutting down standalone Redis server with Unix Domain Socket support" && \
 	python utils/launch_redis.py --port $(SR_TEST_PORT) --nodes 1 \
 		--udsport $(SR_TEST_UDS_FILE) --stop; \
-	exit $$testresult) && \
+	test $$testresult -eq 0 || echo "UDS tests failed"; exit $$testresult) && \
 	echo "UDS tests complete"
 endef
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,12 +15,12 @@ Description
 
 Detailed Notes
 
-- Preserve the shell output of test runs while making sure that server shutdown happens unconditionally (PR380_)
+- Preserve the shell output of test runs while making sure that server shutdown happens unconditionally (PR381_)
 - Update language support matrix in documentation to reflect updates from the last release (PR379_)
 - Deleted obsolete build and testing files that are no longer needed with the new build and test system (PR366_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
-.. _PR380: https://github.com/CrayLabs/SmartRedis/pull/380
+.. _PR381: https://github.com/CrayLabs/SmartRedis/pull/381
 .. _PR379: https://github.com/CrayLabs/SmartRedis/pull/379
 .. _PR366: https://github.com/CrayLabs/SmartRedis/pull/366
 .. _PR364: https://github.com/CrayLabs/SmartRedis/pull/364

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,16 +8,19 @@ To be released at some future point in time
 
 Description
 
+- Improve robustness of test runs
 - Update supported languages documentation
 - Removed obsolete files
 - Improved clustered redis initialization
 
 Detailed Notes
 
+- Preserve the shell output of test runs while making sure that server shutdown happens unconditionally (PR380_)
 - Update language support matrix in documentation to reflect updates from the last release (PR379_)
 - Deleted obsolete build and testing files that are no longer needed with the new build and test system (PR366_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
+.. _PR380: https://github.com/CrayLabs/SmartRedis/pull/380
 .. _PR379: https://github.com/CrayLabs/SmartRedis/pull/379
 .. _PR366: https://github.com/CrayLabs/SmartRedis/pull/366
 .. _PR364: https://github.com/CrayLabs/SmartRedis/pull/364

--- a/tests/cpp/client_test_mnist.cpp
+++ b/tests/cpp/client_test_mnist.cpp
@@ -96,5 +96,5 @@ int main(int argc, char* argv[]) {
 
   std::cout<<"Finished MNIST test."<<std::endl;
 
-  return ;
+  return 0;
 }

--- a/tests/cpp/client_test_mnist.cpp
+++ b/tests/cpp/client_test_mnist.cpp
@@ -96,5 +96,5 @@ int main(int argc, char* argv[]) {
 
   std::cout<<"Finished MNIST test."<<std::endl;
 
-  return 0;
+  return ;
 }


### PR DESCRIPTION
Make sure to shut down Redis server even if tests fail. 
Do so while still reporting the result of testing