### PR TITLE
Update third-party software

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ SHELL:=/bin/bash
 
 # Params for third-party software
 HIREDIS_URL := https://github.com/redis/hiredis.git
-HIREDIS_VER := v1.1.0
+HIREDIS_VER := v1.2.0
 RPP_URL := https://github.com/sewenew/redis-plus-plus.git
-RPP_VER := 1.3.5
+RPP_VER := 1.3.10
 PYBIND_URL := https://github.com/pybind/pybind11.git
-PYBIND_VER := v2.10.3
+PYBIND_VER := v2.11.1
 REDIS_URL := https://github.com/redis/redis.git
 REDIS_VER := 6.0.8
 REDISAI_URL := https://github.com/RedisAI/RedisAI.git
@@ -42,7 +42,7 @@ REDISAI_URL := https://github.com/RedisAI/RedisAI.git
 CATCH2_URL := https://github.com/catchorg/Catch2.git
 CATCH2_VER := v2.13.6
 LCOV_URL := https://github.com/linux-test-project/lcov.git
-LCOV_VER := v1.15
+LCOV_VER := v2.0
 
 # Build variables
 NPROC := $(shell nproc 2>/dev/null || python -c "import multiprocessing as mp; print (mp.cpu_count())" 2>/dev/null || echo 4)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ REDISAI_URL := https://github.com/RedisAI/RedisAI.git
 CATCH2_URL := https://github.com/catchorg/Catch2.git
 CATCH2_VER := v2.13.6
 LCOV_URL := https://github.com/linux-test-project/lcov.git
-LCOV_VER := v2.0
+LCOV_VER := v1.15
 
 # Build variables
 NPROC := $(shell nproc 2>/dev/null || python -c "import multiprocessing as mp; print (mp.cpu_count())" 2>/dev/null || echo 4)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Updated third-party software dependencies to current versions
 - Updated post-merge tests in CI/CD to work with new test system
 - Enabled static builds of SmartRedis
 - Improve robustness of test runs
@@ -19,6 +20,7 @@ Description
 
 Detailed Notes
 
+- Updated lcov (1.15 => 2.0), pybind (2.10.3 => 2.11.1), hiredis (1.1.0 => 1.2.0), and redis++ (1.3.5 => 1.3.10) dependencies to current versions (PR389_)
 - Post-merge tests in CI/CD have been updated to interface cleanly with the new test system that was deployed in the previous release (PR388_)
 - Static builds of SmartRedis can now work with Linux platforms. Fortran is tested with GNU, PGI, Intel compilers (PR386_)
 - Preserve the shell output of test runs while making sure that server shutdown happens unconditionally (PR381_)
@@ -29,6 +31,7 @@ Detailed Notes
 - Deleted obsolete build and testing files that are no longer needed with the new build and test system (PR366_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
+.. _PR389: https://github.com/CrayLabs/SmartRedis/pull/389
 .. _PR388: https://github.com/CrayLabs/SmartRedis/pull/388
 .. _PR386: https://github.com/CrayLabs/SmartRedis/pull/386
 .. _PR381: https://github.com/CrayLabs/SmartRedis/pull/381

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,7 +20,7 @@ Description
 
 Detailed Notes
 
-- Updated lcov (1.15 => 2.0), pybind (2.10.3 => 2.11.1), hiredis (1.1.0 => 1.2.0), and redis++ (1.3.5 => 1.3.10) dependencies to current versions (PR389_)
+- Updated pybind (2.10.3 => 2.11.1), hiredis (1.1.0 => 1.2.0), and redis++ (1.3.5 => 1.3.10) dependencies to current versions (PR389_)
 - Post-merge tests in CI/CD have been updated to interface cleanly with the new test system that was deployed in the previous release (PR388_)
 - Static builds of SmartRedis can now work with Linux platforms. Fortran is tested with GNU, PGI, Intel compilers (PR386_)
 - Preserve the shell output of test runs while making sure that server shutdown happens unconditionally (PR381_)


### PR DESCRIPTION
Update lcov, pybind, hiredis, redis++ third-party dependencies to current versions.