### PR TITLE
Mitigate protected-access error by encapsulating factory checks

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Reduced number of suppressed lint errors
 - Expanded documentation of aggregation lists
 - Updated third-party software dependencies to current versions
 - Updated post-merge tests in CI/CD to work with new test system
@@ -21,6 +22,7 @@ Description
 
 Detailed Notes
 
+- Refactor factory for ConfigOptions to avoid using protected member outside an instance (PR393_)
 - Added a new advanced topics documentation page with a section on aggregation lists (PR390_)
 - Updated pybind (2.10.3 => 2.11.1), hiredis (1.1.0 => 1.2.0), and redis++ (1.3.5 => 1.3.10) dependencies to current versions (PR389_)
 - Post-merge tests in CI/CD have been updated to interface cleanly with the new test system that was deployed in the previous release (PR388_)
@@ -33,6 +35,7 @@ Detailed Notes
 - Deleted obsolete build and testing files that are no longer needed with the new build and test system (PR366_)
 - Reuse existing redis connection when mapping the Redis cluster (PR364_)
 
+.. _PR393: https://github.com/CrayLabs/SmartRedis/pull/393
 .. _PR390: https://github.com/CrayLabs/SmartRedis/pull/390
 .. _PR389: https://github.com/CrayLabs/SmartRedis/pull/389
 .. _PR388: https://github.com/CrayLabs/SmartRedis/pull/388

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -39,9 +39,16 @@ class _Managed:
 
 def create_config_options(base: t.Type[t.Any]) -> t.Any:
     """Factory method for creating managed instances"""
+    def get_dynamic_class_name(bases: t.Tuple[t.Type]) -> str:
+        """Create a name for the new type by concatenating base names. Appends a
+        unique suffix to avoid confusion if dynamic type comparisons occur"""
+        unique_key = str(uuid4()).split("-", 1)[0]
+        class_name = "".join(base.__name__ for base in bases) + unique_key
+        return class_name
+
+    # Create a subtype that includes the _Managed marker
     bases = (_Managed, base)
-    unique_key = str(uuid4()).split("-", 1)[0]
-    class_name = "".join(base.__name__ for base in bases) + unique_key
+    class_name = get_dynamic_class_name(bases)
     managed_class = type(class_name, bases, {})
     return managed_class()
 

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -37,7 +37,7 @@ class _Managed:
     """Marker class identifying factory-created objects"""
 
 
-def create_config_options(base: t.Type[t.Any]) -> t.Any:
+def create_managed_instance(base: t.Type[t.Any]) -> t.Any:
     """Factory method for creating managed instances"""
     def get_dynamic_class_name(bases: t.Tuple[t.Type]) -> str:
         """Create a name for the new type by concatenating base names. Appends a
@@ -87,7 +87,7 @@ class ConfigOptions:
         :rtype: ConfigOptions
         """
         typecheck(configoptions, "configoptions", PyConfigOptions)
-        opts: ConfigOptions = create_config_options(ConfigOptions)
+        opts: ConfigOptions = create_managed_instance(ConfigOptions)
         opts.set_configoptions(configoptions)
         return opts
 
@@ -119,7 +119,7 @@ class ConfigOptions:
         """
         typecheck(db_prefix, "db_prefix", str)
         configoptions = PyConfigOptions.create_from_environment(db_prefix)
-        opts: ConfigOptions = create_config_options(ConfigOptions)
+        opts: ConfigOptions = create_managed_instance(ConfigOptions)
         opts.set_configoptions(configoptions)
         return opts
 

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -38,7 +38,8 @@ class _Managed:
 
 
 def create_managed_instance(base: t.Type[t.Any]) -> t.Any:
-    """Factory method for creating managed instances"""
+    """Instantiate a managed instance of the class, enabling the use of type 
+    checking to detect if an instance is managed"""
     def get_dynamic_class_name(bases: t.Tuple[t.Type]) -> str:
         """Create a name for the new type by concatenating base names. Appends a
         unique suffix to avoid confusion if dynamic type comparisons occur"""

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -37,7 +37,7 @@ class _Managed:
     """Marker class identifying factory-created objects"""
 
 
-def create_config_options(mcs, base: t.Type[t.Any]) -> t.Any:
+def create_config_options(base: t.Type[t.Any]) -> t.Any:
     """Factory method for creating managed instances"""
     bases = (_Managed, base)
     unique_key = str(uuid4()).split("-", 1)[0]

--- a/tests/python/test_errors.py
+++ b/tests/python/test_errors.py
@@ -941,7 +941,7 @@ def test_is_configured_wrong_type(cfg_opts: ConfigOptions):
     with pytest.raises(TypeError):
         _ = cfg_opts.is_configured(42)
 
-def test_override_integer_option_wrong_type(cfg_opts: ConfigOptions, key: str, value: str):
+def test_override_integer_option_wrong_type(cfg_opts: ConfigOptions):
     """Ensure override_integer_option raises an exception on an invalid key type
     and when an invalid value for the target storage type is encountered"""
     key = 42

--- a/tests/python/test_errors.py
+++ b/tests/python/test_errors.py
@@ -941,29 +941,30 @@ def test_is_configured_wrong_type(cfg_opts: ConfigOptions):
     with pytest.raises(TypeError):
         _ = cfg_opts.is_configured(42)
 
-@pytest.mark.parametrize(
-        "key,value",
-        [
-            pytest.param(42, 42, id="Invalid key type"),
-            pytest.param("key", "stringval", id="Invalid value type"),
-        ]
-)
 def test_override_integer_option_wrong_type(cfg_opts: ConfigOptions, key: str, value: str):
     """Ensure override_integer_option raises an exception on an invalid key type
     and when an invalid value for the target storage type is encountered"""
+    key = 42
+    value = 42
     with pytest.raises(TypeError):
         _ = cfg_opts.override_integer_option(key, value)
 
-@pytest.mark.parametrize(
-        "key,value",
-        [
-            pytest.param(42, "stringval", id="Invalid key type"),
-            pytest.param("stringval", 42, id="Invalid value type"),
-        ]
-)
-def test_override_string_option_wrong_type(cfg_opts: ConfigOptions, key: str, value: str):
+    key = "key"
+    value = "stringval"
+    with pytest.raises(TypeError):
+        _ = cfg_opts.override_integer_option(key, value)
+
+def test_override_string_option_wrong_type(cfg_opts: ConfigOptions):
     """Ensure override_string_option raises an exception on an invalid key type
     and when an invalid value for the target storage type is encountered"""
+
+    key = 42
+    value = "stringval"
+    with pytest.raises(TypeError):
+        _ = cfg_opts.override_string_option(key, value)
+
+    key = "stringkey"
+    value = 42
     with pytest.raises(TypeError):
         _ = cfg_opts.override_string_option(key, value)
 

--- a/tests/python/test_errors.py
+++ b/tests/python/test_errors.py
@@ -32,6 +32,12 @@ from smartredis import *
 from smartredis.error import *
 
 
+@pytest.fixture
+def cfg_opts() -> ConfigOptions:
+    opts = ConfigOptions.create_from_environment("")
+    return opts
+
+
 def test_SSDB_not_set(use_cluster, context):
     ssdb = os.environ["SSDB"]
     del os.environ["SSDB"]
@@ -913,43 +919,53 @@ def test_get_tensor_names_wrong_type():
 # Test type errors from bad parameter types to ConfigOptions API calls
 
 def test_create_from_environment_wrong_type():
+    """Ensure create_from_environment doesn't accept an invalid db_prefix param"""
     with pytest.raises(TypeError):
         _ = ConfigOptions.create_from_environment(42)
 
-def test_get_integer_option_wrong_type():
-    co = ConfigOptions()
-    key = "intval"
-    with pytest.raises(TypeError):
-        _ = co.get_integer_option(42)
+def test_get_integer_option_wrong_type(cfg_opts: ConfigOptions):
+    """Ensure get_integer_option raises an exception on an invalid key type"""
 
-def test_get_string_option_wrong_type():
-    co = ConfigOptions()
-    key = "stringval"
     with pytest.raises(TypeError):
-        _ = co.get_string_option(42)
+        _ = cfg_opts.get_integer_option(42)
 
-def test_is_configured_wrong_type():
-    co = ConfigOptions()
+def test_get_string_option_wrong_type(cfg_opts: ConfigOptions):
+    """Ensure get_string_option raises an exception on an invalid key type"""
+    
     with pytest.raises(TypeError):
-        _ = co.is_configured(42)
+        _ = cfg_opts.get_string_option(42)
 
-def test_override_integer_option_wrong_type():
-    co = ConfigOptions()
-    key = "intval"
-    value = 42
+def test_is_configured_wrong_type(cfg_opts: ConfigOptions):
+    """Ensure is_configured raises an exception on an invalid key type"""
+    
     with pytest.raises(TypeError):
-        _ = co.override_integer_option(42, value)
-    with pytest.raises(TypeError):
-        _ = co.override_integer_option(key, "not an integer")
+        _ = cfg_opts.is_configured(42)
 
-def test_override_string_option_wrong_type():
-    co = ConfigOptions()
-    key = "stringval"
-    value = "target_string_value"
+@pytest.mark.parametrize(
+        "key,value",
+        [
+            pytest.param(42, 42, id="Invalid key type"),
+            pytest.param("key", "stringval", id="Invalid value type"),
+        ]
+)
+def test_override_integer_option_wrong_type(cfg_opts: ConfigOptions, key: str, value: str):
+    """Ensure override_integer_option raises an exception on an invalid key type
+    and when an invalid value for the target storage type is encountered"""
     with pytest.raises(TypeError):
-        _ = co.override_string_option(42, value)
+        _ = cfg_opts.override_integer_option(key, value)
+
+@pytest.mark.parametrize(
+        "key,value",
+        [
+            pytest.param(42, "stringval", id="Invalid key type"),
+            pytest.param("stringval", 42, id="Invalid value type"),
+        ]
+)
+def test_override_string_option_wrong_type(cfg_opts: ConfigOptions, key: str, value: str):
+    """Ensure override_string_option raises an exception on an invalid key type
+    and when an invalid value for the target storage type is encountered"""
     with pytest.raises(TypeError):
-        _ = co.override_string_option(key, 42)
+        _ = cfg_opts.override_string_option(key, value)
 
 ####
 # Utility functions


### PR DESCRIPTION
Shift checks for a managed indicator into external code.