### PR TITLE
Add a contributing reference to SmartRedis pointing to SmartSim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+SmartRedis and SmartSim share the same contributor guidelines. Please refer to
+[CONTRIBUTING.rst](https://github.com/CrayLabs/SmartSim/blob/develop/CONTRIBUTING.rst)
+in the SmartSim repo or at CrayLabs[https://www.craylabs.org/docs/contributing.html]

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,14 +10,17 @@ Description
 
 - Updated the third-party RedisAI component
 - Updated the third-party lcov component
+- Add link to contributing guidelines
 
 Detailed Notes
 
 - Updated from RedisAI v1.2.3 (test target)/v1.2.4 and v1.2.5 (CI/CD pipeline) to v1.2.7 (PR402_)
 - Updated lcov from version 1.15 to 2.0 (PR396_)
+- Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 
 .. _PR402: https://github.com/CrayLabs/SmartRedis/pull/402
 .. _PR396: https://github.com/CrayLabs/SmartRedis/pull/396
+.. _PR394: https://github.com/CrayLabs/SmartRedis/pull/395
 
 0.4.2
 -----


### PR DESCRIPTION
Puts links to the contribution guidelines in the SmartSim Github repo and on the CrayLabs documentation. Note: these links will not work correctly yet.
- The SmartSim link will work after the PR is merged
- CrayLabs documentation will be updated on next release