### PR TITLE
Update RedisAI version in post commit checking

### DIFF
--- a/.github/workflows/run_post_merge_tests.yml
+++ b/.github/workflows/run_post_merge_tests.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04] # cannot test on macOS as docker isn't supported on Mac
         compiler: [intel, 8, 9, 10, 11] # intel compiler, and versions of GNU compiler
-        rai_v: [1.2.4, 1.2.5] # versions of RedisAI
+        rai_v: [1.2.7] # version(s) of RedisAI
         py_v: ['3.7.x', '3.8.x', '3.9.x', '3.10.x'] # versions of Python
     env:
       FC: gfortran-${{ matrix.compiler }}
@@ -149,6 +149,7 @@ jobs:
         if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
         run: make test-examples SR_FORTRAN=ON SR_PYTHON=ON \
             SR_TEST_PORT=7000 SR_TEST_REDISAI_VER=v${{ matrix.rai_v }}
+            
       - name: Test static build -- intel compilers
         if: contains(matrix.compiler, 'intel')
         run: make build-example-serial SR_FORTRAN=ON

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,11 +82,6 @@ jobs:
           sudo rm -rf /opt/ghc &&
           sudo rm -rf "/usr/local/share/boost"
 
-      # sudo rm -rf /usr/share/dotnet &&
-      # sudo rm -rf /opt/ghc &&
-      # sudo rm -rf "/usr/local/share/boost" &&
-      # sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
       # Install compilers (Intel or GCC)
       - name: Install GCC
         if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Updated RedisAI version used in post-commit check-in testing in Github pipeline
 - Improved support for model execution batching
 - Added support for model chunking
 - Updated the third-party RedisAI component
@@ -16,12 +17,14 @@ Description
 
 Detailed Notes
 
+- Updated RedisAI version used in post-commit check-in testing in Github pipeline to a version that supports fetch of model chunking size (PR408_)
 - Exposed access to the Redis.AI MINBATCHTIMEOUT parameter, which limits the delay in model execution when trying to accumulate multiple executions in a batch (PR406_)
 - Models will now be automatically chunked when sent to/received from the backed database. This allows use of models greater than 511MB in size. (PR404_)
 - Updated from RedisAI v1.2.3 (test target)/v1.2.4 and v1.2.5 (CI/CD pipeline) to v1.2.7 (PR402_)
 - Updated lcov from version 1.15 to 2.0 (PR396_)
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 
+.. _PR408: https://github.com/CrayLabs/SmartRedis/pull/408
 .. _PR406: https://github.com/CrayLabs/SmartRedis/pull/406
 .. _PR404: https://github.com/CrayLabs/SmartRedis/pull/404
 .. _PR402: https://github.com/CrayLabs/SmartRedis/pull/402


### PR DESCRIPTION
Need to update post-commit checking RedisAI version to v1.2.7 to support fetch of model chunking size parameter