### PR TITLE
Run examples on commit

### DIFF
--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -148,7 +148,6 @@ jobs:
         if: "!contains( matrix.compiler, 'intel' )" # if using GNU compiler
         run: make test-examples SR_FORTRAN=ON SR_PYTHON=ON \
             SR_TEST_PORT=7000 SR_TEST_REDISAI_VER=v${{ matrix.rai_v }}
-            
       - name: Test static build -- intel compilers
         if: contains(matrix.compiler, 'intel')
         run: make build-example-serial SR_FORTRAN=ON

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -26,16 +26,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-name: run_post_merge_tests
-
-# This file is for tests that are to be run rarely, once on each merge.
+name: run_static_and_examples
 
 on:
   push:
     branches:
       - master
       - develop
-
+  pull_request:
+    branches:
+      - master
+      - develop
 env:
   HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker
   HOMEBREW_NO_AUTO_UPDATE: "ON"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,7 +21,7 @@ Description
 
 Detailed Notes
 
-- Moved testing of examples to on-commit testing in CI/CD pipeline (PR411_)
+- Moved testing of examples to on-commit testing in CI/CD pipeline (PR412_)
 - Updated RedisAI version used in post-commit check-in testing in Github pipeline to a version that supports fetch of model chunking size (PR408_)
 - Allow users to pass single keys for the inputs and outputs parameters as a string for Python run_script and run_script_multigpu
 - Exposed access to the Redis.AI MINBATCHTIMEOUT parameter, which limits the delay in model execution when trying to accumulate multiple executions in a batch (PR406_)
@@ -31,7 +31,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
-.. _PR411: https://github.com/CrayLabs/SmartRedis/pull/411
+.. _PR412: https://github.com/CrayLabs/SmartRedis/pull/412
 .. _PR408: https://github.com/CrayLabs/SmartRedis/pull/408
 .. _PR407: https://github.com/CrayLabs/SmartRedis/pull/407
 .. _PR406: https://github.com/CrayLabs/SmartRedis/pull/406

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Moved testing of examples to on-commit testing in CI/CD pipeline
 - Updated RedisAI version used in post-commit check-in testing in Github pipeline
 - Allow strings in Python interface for Client.run_script, Client.run_script_multiGPU
 - Improved support for model execution batching
@@ -20,6 +21,7 @@ Description
 
 Detailed Notes
 
+- Moved testing of examples to on-commit testing in CI/CD pipeline (PR411_)
 - Updated RedisAI version used in post-commit check-in testing in Github pipeline to a version that supports fetch of model chunking size (PR408_)
 - Allow users to pass single keys for the inputs and outputs parameters as a string for Python run_script and run_script_multigpu
 - Exposed access to the Redis.AI MINBATCHTIMEOUT parameter, which limits the delay in model execution when trying to accumulate multiple executions in a batch (PR406_)
@@ -29,6 +31,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
+.. _PR411: https://github.com/CrayLabs/SmartRedis/pull/411
 .. _PR408: https://github.com/CrayLabs/SmartRedis/pull/408
 .. _PR407: https://github.com/CrayLabs/SmartRedis/pull/407
 .. _PR406: https://github.com/CrayLabs/SmartRedis/pull/406

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -61,7 +61,6 @@ def test_example(test, build, sr_fortran, link):
         cmd = [test]
         print(f"Running test: {osp.basename(test)}")
         print(f"Test command {' '.join(cmd)}")
-        print(f"Using cluster: {use_cluster}")
         execute_cmd(cmd, test_subdir)
         time.sleep(1)
     else:


### PR DESCRIPTION
Fix bug with running examples introduced in multiDB PR.
Move test of static builds and examples to on-commit, not post-merge