### PR TITLE
Python Client constructor update

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,7 +27,7 @@ Description
 
 Detailed Notes
 
-- Improved robustness of Python client construction by adding detection of invalid kwargs (PR417_)
+- Improved robustness of Python client construction by adding detection of invalid kwargs (PR419_)
 - Updated the Client and Dataset API documentation to clarify which interacts with the backend db (PR416_)
 - The SSDB address can now include '-' and '_' as special characters in the name. This gives users more options for naming the UDS socket file (PR415_)
 - Added tests to increase Python code coverage
@@ -43,7 +43,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
-.. _PR417: https://github.com/CrayLabs/SmartRedis/pull/417
+.. _PR419: https://github.com/CrayLabs/SmartRedis/pull/419
 .. _PR416: https://github.com/CrayLabs/SmartRedis/pull/416
 .. _PR415: https://github.com/CrayLabs/SmartRedis/pull/415
 .. _PR414: https://github.com/CrayLabs/SmartRedis/pull/414

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Improved robustness of Python client construction
 - Updated Client and Dataset documentation
 - Expanded list of allowed characters in the SSDB address
 - Added coverage to SmartRedis Python API functions
@@ -26,6 +27,7 @@ Description
 
 Detailed Notes
 
+- Improved robustness of Python client construction by adding detection of invalid kwargs (PR417_)
 - Updated the Client and Dataset API documentation to clarify which interacts with the backend db (PR416_)
 - The SSDB address can now include '-' and '_' as special characters in the name. This gives users more options for naming the UDS socket file (PR415_)
 - Added tests to increase Python code coverage
@@ -41,6 +43,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
+.. _PR417: https://github.com/CrayLabs/SmartRedis/pull/417
 .. _PR416: https://github.com/CrayLabs/SmartRedis/pull/416
 .. _PR415: https://github.com/CrayLabs/SmartRedis/pull/415
 .. _PR414: https://github.com/CrayLabs/SmartRedis/pull/414

--- a/doc/clients/python.rst
+++ b/doc/clients/python.rst
@@ -3,23 +3,24 @@ Python APIs
 ***********
 
 The following page provides a comprehensive overview of the SmartRedis Python
-Client, DataSet and Logging APIs. 
+Client, DataSet and Logging APIs.
 Further explanation and details of each are presented below.
 
 Client API
 ==========
 
-The Client API is purpose-built for interaction with the backend database, 
-which extends the capabilities of the Redis in-memory data store. 
-It's important to note that the SmartRedis Client API is the exclusive 
-means for altering, transmitting, and receiving data within the backend 
-database. More specifically, the Client API is responsible for both 
-creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`, 
-:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor:>`.  
-It also handles the transmission and reception of 
-the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>` 
-data structure. Creating and modifying the ``DataSet`` object 
-is confined to local operation by the DataSet API.
+The Client API is purpose-built for interaction with the backend database,
+which extends the capabilities of the Redis in-memory data store.
+It's important to note that the SmartRedis Client API is the exclusive
+means for altering, transmitting, and receiving data within the backend
+database. More specifically, the Client API is responsible for both
+creating and modifying data structures, which encompass
+:ref:`Models <data-structures-model>`, :ref:`Scripts <data-structures-script>`,
+and :ref:`Tensors <data-structures-tensor:>`.
+It also handles the transmission and reception of the aforementioned data
+structures in addition to :ref:`Dataset <data-structures-dataset>` data
+structure. Creating and modifying the ``DataSet`` object is confined to local
+operation by the DataSet API.
 
 Client Class Method Overview
 ----------------------------
@@ -102,11 +103,11 @@ Client Class Method Detailed View
 DataSet API
 ===========
 
-The Python DataSet API enables a user to manage a group of tensors 
-and associated metadata within a datastructure called a ``DataSet`` object. 
-The DataSet API operates independently of the database and solely 
-maintains the dataset object **in-memory**. The actual interaction with the Redis database, 
-where a snapshot of the DataSet object is sent, is handled by the Client API. For more 
+The Python DataSet API enables a user to manage a group of tensors
+and associated metadata within a datastructure called a ``DataSet`` object.
+The DataSet API operates independently of the database and solely
+maintains the dataset object **in-memory**. The actual interaction with the Redis database,
+where a snapshot of the DataSet object is sent, is handled by the Client API. For more
 information on the ``DataSet`` object, click :ref:`here <data-structures-dataset>`.
 
 Dataset Class Method Overview

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -90,7 +90,12 @@ class Client(SRObject):
                 pyclient = self.__standard_construction(*a, **kw)
         super().__init__(pyclient)
 
-    def __address_construction(self, cluster, address=None, logger_name="Default"):
+    def __address_construction(
+        self,
+        cluster: bool,
+        address: t.Optional[str] = None,
+        logger_name: str = "Default"
+    ) -> PyClient:
         """Initialize a SmartRedis client
 
         This construction method is primarily intended for use by driver
@@ -121,7 +126,11 @@ class Client(SRObject):
         except (PybindRedisReplyError, RuntimeError) as e:
             raise RedisConnectionError(str(e)) from None
 
-    def __standard_construction(self, config_options=None, logger_name="Default"):  # pylint: disable=no-self-use
+    @staticmethod
+    def __standard_construction(
+        config_options: t.Optional[ConfigOptions] = None,
+        logger_name: str = "Default"
+    ) -> PyClient:
         """Initialize a RedisAI client
 
         The address of the Redis database is expected to be found in the

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -94,7 +94,8 @@ class Client(SRObject):
         """Initialize a SmartRedis client
 
         This construction method is primarily intended for use by driver
-        scripts. It is preferred to set up config
+        scripts. It is preferred to set up configuration via environment
+        variables.
 
         For clusters, the address can be a single tcp/ip address and port
         of a database node. The rest of the cluster will be discovered

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -54,12 +54,12 @@ class Client(SRObject):
         SmartRedis library.
 
             Client(config_options: ConfigOptions=None,
-                   logger_name: str="Default")
+                   config_options: str="Default")
             Client(cluster: bool, address: optional(str)=None,
                    logger_name: str="Default") <= Deprecated!
 
         For detailed information on the first signature, please refer
-        to the __new_construction() method below.
+        to the __standard_construction() method below.
 
         For detailed information on the second signature, please refer
         to the __deprecated_construction() method below.
@@ -74,14 +74,31 @@ class Client(SRObject):
         """
         if a:
             if isinstance(a[0], bool):
+                for arg in kw:
+                    if arg not in ["cluster", "address"]:
+                        raise TypeError(
+                            f"__init__() got an unexpected keyword argument '{arg}'"
+                        )
                 pyclient = self.__deprecated_construction(*a, **kw)
             elif isinstance(a[0], ConfigOptions) or a[0] is None:
-                pyclient = self.__new_construction(*a, **kw)
+                config_object = kw.get("config_object", None)
+                logger_name = kw.get("logger_name", "default")
+                for arg in kw:
+                    if arg not in ["config_object", "logger_name"]:
+                        raise TypeError(
+                            f"__init__() got an unexpected keyword argument '{arg}'"
+                        )
+                pyclient = self.__standard_construction(*a, **kw)
             else:
                 raise TypeError(f"Invalid type for argument 0: {type(a[0])}")
         else:
             config_object = kw.get("config_object", None)
             logger_name = kw.get("logger_name", "default")
+            for arg in kw:
+                if arg not in ["config_object", "logger_name"]:
+                    raise TypeError(
+                        f"__init__() got an unexpected keyword argument '{arg}'"
+                    )
             pyclient = self.__new_construction(config_object, logger_name)
         super().__init__(pyclient)
 
@@ -121,7 +138,7 @@ class Client(SRObject):
         except (PybindRedisReplyError, RuntimeError) as e:
             raise RedisConnectionError(str(e)) from None
 
-    def __new_construction(self, config_options=None, logger_name="Default"):  # pylint: disable=no-self-use
+    def __standard_construction(self, config_options=None, logger_name="Default"):  # pylint: disable=no-self-use
         """Initialize a RedisAI client
 
         The address of the Redis database is expected to be found in the

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -42,15 +42,14 @@ from .util import Dtypes, exception_handler, init_default, typecheck
 
 class Client(SRObject):
     def __init__(self, *a: t.Any, **kw: t.Any):
-        """Initialize a RedisAI client
+        """Initialize a SmartRedis client
 
         At this time, the Client can be initialized with one of two
         signatures. The first version is preferred, though the second is
-        still supported. Note that the order was swapped for first two
-        parameters in the second signature relative to previous releases
-        of SmartRedis; this was necessary to remove ambiguity. Support for
-        the second signature will be removed in a future version of the
-        SmartRedis library.
+        supported (primarily for use in driver scripts). Note that the
+        order was swapped for first two parameters in the second signature
+        relative to previous releases of SmartRedis; this was necessary to
+        remove ambiguity.
 
             Client(config_options: ConfigOptions=None,
                    config_options: str="Default")
@@ -63,11 +62,11 @@ class Client(SRObject):
         For detailed information on the second signature, please refer
         to the __address_construction() method below.
 
-        :param a: The positional arguments supplied to this method; see above for
-                  valid options
+        :param a: The positional arguments supplied to this method;
+                  see above for valid options
         :type a: tuple[any]; see above for valid options
-        :param kw: Keyword arguments supplied to this method; see above for
-                   valid options
+        :param kw: Keyword arguments supplied to this method;
+                   see above for valid options
         :type kw: dict[string, any]; see above for valid options
         :raises RedisConnectionError: if connection initialization fails
         """
@@ -92,7 +91,10 @@ class Client(SRObject):
         super().__init__(pyclient)
 
     def __address_construction(self, cluster, address=None, logger_name="Default"):
-        """Initialize a RedisAI client (Deprecated)
+        """Initialize a SmartRedis client
+
+        This construction method is primarily intended for use by driver
+        scripts. It is preferred to set up config
 
         For clusters, the address can be a single tcp/ip address and port
         of a database node. The rest of the cluster will be discovered

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -52,9 +52,9 @@ class Client(SRObject):
         remove ambiguity.
 
             Client(config_options: ConfigOptions=None,
-                   config_options: str="Default")
+                   logger_name: str="Default")
             Client(cluster: bool, address: optional(str)=None,
-                   logger_name: str="Default") <= Deprecated!
+                   logger_name: str="Default")
 
         For detailed information on the first signature, please refer
         to the __standard_construction() method below.

--- a/tests/python/test_prefixing.py
+++ b/tests/python/test_prefixing.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import os
 
 from smartredis import Client, Dataset
 
@@ -34,11 +35,11 @@ def test_prefixing(context, monkeypatch):
     monkeypatch.setenv("SSKEYIN", "prefix_test,prefix_ignore")
 
     # Set up client
-    c = Client(address=None, logger_name=context)
+    c = Client(logger_name=context)
     c.use_dataset_ensemble_prefix(True)
     c.use_tensor_ensemble_prefix(True)
     c.set_data_source("prefix_test")
-    
+
     # Create Dataset
     d = Dataset("test_dataset")
     data = np.uint16([1, 2, 3, 4])
@@ -53,7 +54,6 @@ def test_prefixing(context, monkeypatch):
     assert c.tensor_exists("test_tensor")
     assert c.key_exists("prefix_test.test_tensor")
     assert not c.key_exists("test_tensor")
-    
 
 def test_model_prefixing(mock_model, context, monkeypatch):
     # configure prefix variables
@@ -61,10 +61,10 @@ def test_model_prefixing(mock_model, context, monkeypatch):
     monkeypatch.setenv("SSKEYIN", "prefix_test,prefix_ignore")
 
     # Set up client
-    c = Client(address=None, logger_name=context)
+    c = Client(logger_name=context)
     c.use_model_ensemble_prefix(True)
     c.set_data_source("prefix_test")
-    
+
     # Create model
     model = mock_model.create_torch_cnn()
     c.set_model("simple_cnn", model, "TORCH", "CPU")
@@ -80,27 +80,27 @@ def test_list_prefixing(context, monkeypatch):
     monkeypatch.setenv("SSKEYIN", "prefix_test,prefix_ignore")
 
     # Set up client
-    c = Client(address=None, logger_name=context)
+    c = Client(logger_name=context)
     c.use_list_ensemble_prefix(True)
     c.set_data_source("prefix_test")
 
     # Build datasets
     num_datasets = 4
     original_datasets = [create_dataset(f"dataset_{i}") for i in range(num_datasets)]
-    
+
     # Make sure the list is cleared
     list_name = "dataset_test_list"
     c.delete_list(list_name)
-    
+
     # Put datasets into the list
     for i in range(num_datasets):
         c.put_dataset(original_datasets[i])
         c.append_to_list(list_name, original_datasets[i])
-    
+
     # Validate keys to see whether prefixing was applied properly
     assert c.key_exists("prefix_test.dataset_test_list")
     assert not c.key_exists("dataset_test_list")
-    
+
 # ------------ helper functions ---------------------------------
 
 def create_dataset(name):


### PR DESCRIPTION
Clean up Python Client constructor to detect invalid kwargs and remove deprecation warning for construction method that will be used primarily for driver scripts. Rename internal construction methods to reflect new expected usage patterns. Update test cases to remove invalid construction requests. Update docs.