### PR TITLE
Add cluster to KW check in client constructor

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -29,7 +29,7 @@ Description
 Detailed Notes
 
 - Merged dependency lists from requirements.txt and requirements-dev.txt into setup.cfg to have only one set of dependencies going forward (PR420_)
-- Improved robustness of Python client construction by adding detection of invalid kwargs (PR419_)
+- Improved robustness of Python client construction by adding detection of invalid kwargs (PR419_), (PR421_)
 - Updated the Client and Dataset API documentation to clarify which interacts with the backend db (PR416_)
 - The SSDB address can now include '-' and '_' as special characters in the name. This gives users more options for naming the UDS socket file (PR415_)
 - Added tests to increase Python code coverage
@@ -45,6 +45,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
+.. _PR421: https://github.com/CrayLabs/SmartRedis/pull/421
 .. _PR420: https://github.com/CrayLabs/SmartRedis/pull/420
 .. _PR419: https://github.com/CrayLabs/SmartRedis/pull/419
 .. _PR416: https://github.com/CrayLabs/SmartRedis/pull/416

--- a/src/cpp/client.cpp
+++ b/src/cpp/client.cpp
@@ -107,17 +107,8 @@ void Client::_establish_server_connection()
 Client::Client(bool cluster, const std::string& logger_name)
     : SRObject(logger_name)
 {
-    std::cout << "In deprecated constructor" << std::endl;
     // Log that a new client has been instantiated
     log_data(LLDebug, "New client created");
-
-    // Log deprecation warning for this method
-    log_data(
-        LLInfo,
-        "Deprecation Notice: Client::Client(bool, std::string) constructor "
-        "should not be used. Please migrate your code to use the "
-        "Client::Client(ConfigOptions*) constructor and set the server type "
-        "in the SR_DB_TYPE environment variable.");
 
     // Create our ConfigOptions object (default = no suffixing)
     auto cfgopts = ConfigOptions::create_from_environment("");

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -84,7 +84,7 @@ class Client(SRObject):
                 raise TypeError(f"Invalid type for argument 0: {type(a[0])}")
         else:
             # Only kwargs in the call
-            if "address" in kw:
+            if "address" in kw or "cluster" in kw:
                 pyclient = self.__address_construction(*a, **kw)
             else:
                 pyclient = self.__standard_construction(*a, **kw)


### PR DESCRIPTION
This lets a call like `c = Client(cluster=False)` work as expected