### PR TITLE
Add links to RAI and TS docs

### DIFF
--- a/doc/advanced_topics.rst
+++ b/doc/advanced_topics.rst
@@ -125,7 +125,7 @@ lead to race conditions:
     // Delete an aggregation list
     void delete_list(const std::string& list_name);
 
-.. _advanced-topics-dataset-aggregation:
+.. _advanced-topics-multi-db:
 
 Multiple Database Support
 =========================

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Updated documentation
 - Added test cases for all Client construction parameter combinations
 - Centralized dependency tracking to setup.cfg
 - Improved robustness of Python client construction
@@ -29,6 +30,7 @@ Description
 
 Detailed Notes
 
+- Some broken links in the documentation were fixed, and the instructions to run the tests were updated (PR423_)
 - Added test cases for all Client construction parameter combinations (PR422_)
 - Merged dependency lists from requirements.txt and requirements-dev.txt into setup.cfg to have only one set of dependencies going forward (PR420_)
 - Improved robustness of Python client construction by adding detection of invalid kwargs (PR419_), (PR421_)
@@ -47,6 +49,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
+.. _PR423: https://github.com/CrayLabs/SmartRedis/pull/423
 .. _PR422: https://github.com/CrayLabs/SmartRedis/pull/422
 .. _PR421: https://github.com/CrayLabs/SmartRedis/pull/421
 .. _PR420: https://github.com/CrayLabs/SmartRedis/pull/420

--- a/doc/clients/c-plus.rst
+++ b/doc/clients/c-plus.rst
@@ -2,23 +2,23 @@
 C++ APIs
 ********
 
-The following page provides a comprehensive overview of the SmartRedis C++ 
-Client and Dataset APIs. 
+The following page provides a comprehensive overview of the SmartRedis C++
+Client and Dataset APIs.
 Further explanation and details of each are presented below.
 
 Client API
 ==========
 
-The Client API is purpose-built for interaction with the backend database, 
-which extends the capabilities of the Redis in-memory data store. 
-It's important to note that the SmartRedis Client API is the exclusive 
-means for altering, transmitting, and receiving data within the backend 
-database. More specifically, the Client API is responsible for both 
-creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`, 
-:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor:>`.  
-It also handles the transmission and reception of 
-the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>` 
-data structure. Creating and modifying the ``DataSet`` object 
+The Client API is purpose-built for interaction with the backend database,
+which extends the capabilities of the Redis in-memory data store.
+It's important to note that the SmartRedis Client API is the exclusive
+means for altering, transmitting, and receiving data within the backend
+database. More specifically, the Client API is responsible for both
+creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`,
+:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor>`.
+It also handles the transmission and reception of
+the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>`
+data structure. Creating and modifying the ``DataSet`` object
 is confined to local operation by the DataSet API.
 
 .. doxygenclass:: SmartRedis::Client
@@ -30,15 +30,14 @@ is confined to local operation by the DataSet API.
 Dataset API
 ===========
 
-The C++ DataSet API enables a user to manage a group of tensors 
-and associated metadata within a datastructure called a ``DataSet`` object. 
-The DataSet API operates independently of the database and solely 
-maintains the dataset object in-memory. The actual interaction with the Redis database, 
-where a snapshot of the DataSet object is sent, is handled by the Client API. For more 
+The C++ DataSet API enables a user to manage a group of tensors
+and associated metadata within a datastructure called a ``DataSet`` object.
+The DataSet API operates independently of the database and solely
+maintains the dataset object in-memory. The actual interaction with the Redis database,
+where a snapshot of the DataSet object is sent, is handled by the Client API. For more
 information on the ``DataSet`` object, click :ref:`here <data-structures-dataset>`.
 
 .. doxygenclass:: SmartRedis::DataSet
    :project: cpp_client
    :members:
    :undoc-members:
-

--- a/doc/clients/c.rst
+++ b/doc/clients/c.rst
@@ -2,23 +2,23 @@
 C APIs
 *******
 
-The following page provides a comprehensive overview of the SmartRedis C 
-Client and Dataset APIs. 
+The following page provides a comprehensive overview of the SmartRedis C
+Client and Dataset APIs.
 Further explanation and details of each are presented below.
 
 Client API
 ==========
 
-The Client API is purpose-built for interaction with the backend database, 
-which extends the capabilities of the Redis in-memory data store. 
-It's important to note that the SmartRedis Client API is the exclusive 
-means for altering, transmitting, and receiving data within the backend 
-database. More specifically, the Client API is responsible for both 
-creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`, 
-:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor:>`.  
-It also handles the transmission and reception of 
-the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>` 
-data structure. Creating and modifying the ``DataSet`` object 
+The Client API is purpose-built for interaction with the backend database,
+which extends the capabilities of the Redis in-memory data store.
+It's important to note that the SmartRedis Client API is the exclusive
+means for altering, transmitting, and receiving data within the backend
+database. More specifically, the Client API is responsible for both
+creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`,
+:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor>`.
+It also handles the transmission and reception of
+the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>`
+data structure. Creating and modifying the ``DataSet`` object
 is confined to local operation by the DataSet API.
 
 .. doxygenfile:: c_client.h
@@ -28,13 +28,12 @@ is confined to local operation by the DataSet API.
 Dataset API
 ===========
 
-The C DataSet API enables a user to manage a group of tensors 
-and associated metadata within a datastructure called a ``DataSet`` object. 
-The DataSet API operates independently of the database and solely 
-maintains the dataset object in-memory. The actual interaction with the Redis database, 
-where a snapshot of the DataSet object is sent, is handled by the Client API. For more 
+The C DataSet API enables a user to manage a group of tensors
+and associated metadata within a datastructure called a ``DataSet`` object.
+The DataSet API operates independently of the database and solely
+maintains the dataset object in-memory. The actual interaction with the Redis database,
+where a snapshot of the DataSet object is sent, is handled by the Client API. For more
 information on the ``DataSet`` object, click :ref:`here <data-structures-dataset>`.
 
 .. doxygenfile:: c_dataset.h
    :project: c_client
-

--- a/doc/clients/fortran.rst
+++ b/doc/clients/fortran.rst
@@ -2,23 +2,23 @@
 Fortran APIs
 ************
 
-The following page provides a comprehensive overview of the SmartRedis Fortran 
-Client and Dataset APIs. 
+The following page provides a comprehensive overview of the SmartRedis Fortran
+Client and Dataset APIs.
 Further explanation and details of each are presented below.
 
 Client API
 ==========
 
-The Client API is purpose-built for interaction with the backend database, 
-which extends the capabilities of the Redis in-memory data store. 
-It's important to note that the SmartRedis Client API is the exclusive 
-means for altering, transmitting, and receiving data within the backend 
-database. More specifically, the Client API is responsible for both 
-creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`, 
-:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor:>`.  
-It also handles the transmission and reception of 
-the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>` 
-data structure. Creating and modifying the ``DataSet`` object 
+The Client API is purpose-built for interaction with the backend database,
+which extends the capabilities of the Redis in-memory data store.
+It's important to note that the SmartRedis Client API is the exclusive
+means for altering, transmitting, and receiving data within the backend
+database. More specifically, the Client API is responsible for both
+creating and modifying data structures, which encompass :ref:`Models <data-structures-model>`,
+:ref:`Scripts <data-structures-script>`, and :ref:`Tensors <data-structures-tensor>`.
+It also handles the transmission and reception of
+the aforementioned data structures in addition to :ref:`Dataset <data-structures-dataset>`
+data structure. Creating and modifying the ``DataSet`` object
 is confined to local operation by the DataSet API.
 
 The following are overloaded interfaces which support
@@ -32,11 +32,11 @@ The following are overloaded interfaces which support
 Dataset API
 ===========
 
-The Fortran DataSet API enables a user to manage a group of tensors 
-and associated metadata within a datastructure called a ``DataSet`` object. 
-The DataSet API operates independently of the database and solely 
-maintains the dataset object in-memory. The actual interaction with the Redis database, 
-where a snapshot of the DataSet object is sent, is handled by the Client API. For more 
+The Fortran DataSet API enables a user to manage a group of tensors
+and associated metadata within a datastructure called a ``DataSet`` object.
+The DataSet API operates independently of the database and solely
+maintains the dataset object in-memory. The actual interaction with the Redis database,
+where a snapshot of the DataSet object is sent, is handled by the Client API. For more
 information on the ``DataSet`` object, click :ref:`here <data-structures-dataset>`.
 
 The following are overloaded interfaces which support

--- a/doc/clients/python.rst
+++ b/doc/clients/python.rst
@@ -16,7 +16,7 @@ means for altering, transmitting, and receiving data within the backend
 database. More specifically, the Client API is responsible for both
 creating and modifying data structures, which encompass
 :ref:`Models <data-structures-model>`, :ref:`Scripts <data-structures-script>`,
-and :ref:`Tensors <data-structures-tensor:>`.
+and :ref:`Tensors <data-structures-tensor>`.
 It also handles the transmission and reception of the aforementioned data
 structures in addition to :ref:`Dataset <data-structures-dataset>` data
 structure. Creating and modifying the ``DataSet`` object is confined to local

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,7 +13,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+# pylint: skip-file
 
 # -- Project information -----------------------------------------------------
 

--- a/doc/data_structures.rst
+++ b/doc/data_structures.rst
@@ -2,22 +2,22 @@
 Data Structures
 ***************
 
-SmartSim defines primary three data structures designed for use within backend databases: 
+SmartSim defines primary three data structures designed for use within backend databases:
 
 * ``Tensor`` : represents an n-dimensional array of values.
 * ``Model`` : represents a computational ML model for one of the supported backend frameworks.
 * ``Script`` : represents a TorchScript program.
 
 In addition, SmartRedis defines a data
-structure named ``DataSet`` that enables a user to manage a group of tensors 
-and associated metadata in-memory. In this section, we will provide an explanation 
-of the SmartRedis API used to interact with these four data structures, 
+structure named ``DataSet`` that enables a user to manage a group of tensors
+and associated metadata in-memory. In this section, we will provide an explanation
+of the SmartRedis API used to interact with these four data structures,
 along with relevant insights on performance and best practices.
 
-We illustrate concepts and capabilities of the Python 
-and C++ SmartRedis APIs. The C and Fortran function signatures closely 
-mirror the C++ API, and for brevity, we won't delve 
-into them. For full discussion of the C and Fortran APIs, 
+We illustrate concepts and capabilities of the Python
+and C++ SmartRedis APIs. The C and Fortran function signatures closely
+mirror the C++ API, and for brevity, we won't delve
+into them. For full discussion of the C and Fortran APIs,
 please refer to their respective documentation pages.
 
 
@@ -178,14 +178,14 @@ SmartSim ensemble capabilities.
 Dataset
 =======
 
-When dealing with multi-modal data or complex data sets, 
-one may have different types of tensors (e.g., images, text embeddings, 
-numerical data) and metadata for each data point. Grouping them into a 
+When dealing with multi-modal data or complex data sets,
+one may have different types of tensors (e.g., images, text embeddings,
+numerical data) and metadata for each data point. Grouping them into a
 collection represents each data point as a cohesive unit.
 The ``DataSet`` data structure provides this functionality to stage tensors and metadata
-in-memory via the ``DataSet API``. After the creation of a 
-``DataSet`` object, the grouped data can be efficiently stored in the backend database 
-by the ``Client API`` and subsequently retrieved using the assigned ``DataSet`` name. 
+in-memory via the ``DataSet API``. After the creation of a
+``DataSet`` object, the grouped data can be efficiently stored in the backend database
+by the ``Client API`` and subsequently retrieved using the assigned ``DataSet`` name.
 In the upcoming sections, we outline the process of building, sending, and retrieving a ``DataSet``.
 
 Listed below are the supported tensor and metadata types.
@@ -237,31 +237,31 @@ Build and Send a DataSet
 
 When building a ``DataSet`` object in-memory,
 a user can group various combinations of tensors and metadata that
-constrain to the supported data types in the table above. To illustrate, 
-tensors can be inserted into a ``dataset`` object via the ``Dataset.add_tensor()`` method. 
-The SmartRedis DataSet API functions 
-are available in C, C++, Python, and Fortran. The ``DataSet.add_tensor()`` function, 
-operates independently of the database and solely 
-maintains the dataset object. Storing the dataset in the backend 
+constrain to the supported data types in the table above. To illustrate,
+tensors can be inserted into a ``dataset`` object via the ``Dataset.add_tensor()`` method.
+The SmartRedis DataSet API functions
+are available in C, C++, Python, and Fortran. The ``DataSet.add_tensor()`` function,
+operates independently of the database and solely
+maintains the dataset object. Storing the dataset in the backend
 database is done via the Client API ``put_dataset()`` method.
 
 .. note::
-    The ``DataSet.add_tensor()`` function copies user-provided 
-    tensor data; this prevents potential issues arising from the user's 
-    data being cleared or deallocated. Any additional memory allocated 
+    The ``DataSet.add_tensor()`` function copies user-provided
+    tensor data; this prevents potential issues arising from the user's
+    data being cleared or deallocated. Any additional memory allocated
     for this purpose will be released when the DataSet object is destroyed.
 
 Metadata can be added to an in-memory ``DataSet`` object with the
 ``DataSet.add_meta_scalar()`` and ``DataSet.add_meta_string()``
-functions. Methods exist for adding scalar metadata (e.g., double) and string metadata. 
+functions. Methods exist for adding scalar metadata (e.g., double) and string metadata.
 For both functions, the first input
-parameter is the name of the metadata field. 
-The field name serves as an internal identifier within the ``DataSet`` 
-for grouped metadata values. It's used to retrieve metadata in the future. 
-Since it's an internal identifier, users don't need to be concerned 
-about conflicts with keys in the database. In other words, multiple 
-``DataSet`` objects can use the same metadata field names without causing 
-issues because these names are managed within the ``DataSet`` and won't 
+parameter is the name of the metadata field.
+The field name serves as an internal identifier within the ``DataSet``
+for grouped metadata values. It's used to retrieve metadata in the future.
+Since it's an internal identifier, users don't need to be concerned
+about conflicts with keys in the database. In other words, multiple
+``DataSet`` objects can use the same metadata field names without causing
+issues because these names are managed within the ``DataSet`` and won't
 interfere with external database keys. The C++ interface for adding
 metadata is shown below:
 
@@ -280,13 +280,13 @@ metadata is shown below:
 When adding a scalar or string metadata value, the value
 is copied by the ``DataSet``, and as a result, the user
 does not need to ensure that the metadata values provided
-are still in-memory. In other words, 
-the ``DataSet`` handles the memory management of these metadata values, 
-and you don't need to retain or manage the original copies separately 
+are still in-memory. In other words,
+the ``DataSet`` handles the memory management of these metadata values,
+and you don't need to retain or manage the original copies separately
 once they have been included in the ``DataSet`` object.
 Additionally, multiple metadata values can be added to a
 single field name, and the default behavior is to append the value to the
-field name (creating the field if not already present). This behavior allows the ``DataSet`` metadata 
+field name (creating the field if not already present). This behavior allows the ``DataSet`` metadata
 to function like one-dimensional arrays.
 
 Also, note that in the above C++ example,
@@ -296,7 +296,7 @@ requirements exist for C and Fortran ``DataSet`` implementations.
 
 Finally, the ``DataSet`` object is sent to the database using the
 ``Client.put_dataset()`` function, which is uniform across all clients.
-To emphasize once more, all interactions with the backend database are handle by 
+To emphasize once more, all interactions with the backend database are handle by
 the Client API, not the DataSet API.
 
 
@@ -320,11 +320,11 @@ the previous section for details on tensor retrieve
 function calls.
 
 There are four functions for retrieving metadata information from a ``DataSet`` object in-memory:
-``get_meta_scalars()``, ``get_meta_strings()``, ``get_metadata_field_names()`` 
+``get_meta_scalars()``, ``get_meta_strings()``, ``get_metadata_field_names()``
 and ``get_metadata_field_type()``. As the names suggest, the ``get_meta_scalars()`` function
 is used for retrieving numerical metadata values, while the ``get_meta_strings()`` function
-is for retrieving metadata string values. The ``get_metadata_field_names()`` function 
-retrieves a list of all metadata field names in the ``DataSet`` object. Lastly, 
+is for retrieving metadata string values. The ``get_metadata_field_names()`` function
+retrieves a list of all metadata field names in the ``DataSet`` object. Lastly,
 the ``get_metadata_field_type()`` function returns the type (scalar or string) of the metadata
 attached to the specified field name. The metadata retrieval function prototypes
 vary across the clients based on programming language constraints,
@@ -339,8 +339,7 @@ Aggregating
 -----------
 
 SmartRedis also supports an advanced API for working with aggregate
-lists of DataSets; details may be found
-:ref:`here <advanced-topics-dataset-aggregation>`.
+lists of DataSets; details may be found :ref:`here <advanced-topics-dataset-aggregation>`.
 
 .. _data-structures-model:
 

--- a/doc/developer/testing.rst
+++ b/doc/developer/testing.rst
@@ -7,6 +7,7 @@ Quick instructions
 ##################
 
 To run the tests, assuming that all requirements have been installed
+
 1. Activate your environment with SmartSim and SmartRedis installed
 2. Modify `SR_DB_TYPE` (`Clustered` or `Standalone`) and
    `SMARTREDIS_TEST_DEVICE` (`gpu` or `cpu`) as necessary in
@@ -14,7 +15,7 @@ To run the tests, assuming that all requirements have been installed
 3. `source setup_test_env.sh`
 4. `pushd utils/create_cluster; python local_cluster.py; popd`
 5. `export SSDB="127.0.0.1:6379,127.0.0.1:6380,127.0.0.1:6381"`
-5. Run the desired tests (see `make help` for more details)
+6. Run the desired tests (see `make help` for more details)
 
 ###################
 Unit Test Framework

--- a/doc/developer/testing.rst
+++ b/doc/developer/testing.rst
@@ -6,16 +6,8 @@ Testing Description
 Quick instructions
 ##################
 
-To run the tests, assuming that all requirements have been installed
-
-1. Activate your environment with SmartSim and SmartRedis installed
-2. Modify `SR_DB_TYPE` (`Clustered` or `Standalone`) and
-   `SMARTREDIS_TEST_DEVICE` (`gpu` or `cpu`) as necessary in
-   `setup_test_env.sh`.
-3. `source setup_test_env.sh`
-4. `pushd utils/create_cluster; python local_cluster.py; popd`
-5. `export SSDB="127.0.0.1:6379,127.0.0.1:6380,127.0.0.1:6381"`
-6. Run the desired tests (see `make help` for more details)
+To run the tests, simply execute the following command. Omit ``SR_PYTHON=On`` or ``SR_FORTRAN=On`` if you do not wish to test those languages:
+   ``make test SR_PYTHON=On SR_FORTRAN=On``
 
 ###################
 Unit Test Framework
@@ -33,6 +25,6 @@ file exists, then it is preferred that a new file (prefixed with *test_*) is cre
 In Summary
 ===========
 
-    - New unit tests should be placed in ``tests/cpp/unit-tests/``
-    - Testing files should be prefixed with *test_*
-    - It is preferred that new unit tests are in a new ``SCENARIO``
+- New unit tests should be placed in ``tests/cpp/unit-tests/``
+- Testing files should be prefixed with *test_*
+- It is preferred that new unit tests are in a new ``SCENARIO``

--- a/doc/examples/cpp_api_examples.rst
+++ b/doc/examples/cpp_api_examples.rst
@@ -35,10 +35,10 @@ DataSets
 
 The C++ ``Client`` API stores and retrieve datasets from the backend database. The C++
 ``DataSet`` API can store and retrieve tensors and metadata from an in-memory ``DataSet`` object.
-To reiterate, the actual interaction with the backend database, 
+To reiterate, the actual interaction with the backend database,
 where a snapshot of the ``DataSet`` object is sent, is handled by the Client API.
 For further information about datasets, please refer to the :ref:`Dataset
-section of the Data Structures documentation page <data_structures_dataset>`.
+section of the Data Structures documentation page <data-structures-dataset>`.
 
 The code below shows how to store and retrieve tensors and metadata
 which belong to a ``DataSet``.

--- a/doc/examples/python_api_examples.rst
+++ b/doc/examples/python_api_examples.rst
@@ -39,10 +39,10 @@ Datasets
 
 The Python ``Client`` API stores and retrieve datasets from the backend database. The Python
 ``DataSet`` API can store and retrieve tensors and metadata from an in-memory ``DataSet`` object.
-To reiterate, the actual interaction with the backend database, 
+To reiterate, the actual interaction with the backend database,
 where a snapshot of the ``DataSet`` object is sent, is handled by the Client API.
 For further information about datasets, please refer to the :ref:`Dataset
-section of the Data Structures documentation page <data_structures_dataset>`.
+section of the Data Structures documentation page <data-structures-dataset>`.
 
 The code below shows how to store and retrieve tensors which belong to a ``DataSet``.
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -3,24 +3,24 @@
 Overview
 ********
 
-SmartRedis is a collection of `Redis <https://redis.io>`_ clients that support
-`RedisAI <https://redisai.io>`_ capabilities and include additional
+SmartRedis is a collection of `Redis <https://redis.io>`__ clients that support
+`RedisAI <https://redisai.io>`__ capabilities and include additional
 features for high performance computing (HPC) applications.
 Key features of RedisAI that are supported by SmartRedis include:
 
 -   A tensor data type in Redis
 -   TensorFlow, TensorFlow Lite, Torch,
-    and `ONNXRuntime <https://onnxruntime.ai/>`_ backends for model evaluations
--   `TorchScript <https://pytorch.org/docs/1.11/jit.html>`_ storage and evaluation
+    and `ONNXRuntime <https://onnxruntime.ai/>`__ backends for model evaluations
+-   `TorchScript <https://pytorch.org/docs/1.11/jit.html>`__ storage and evaluation
 
 In addition to the RedisAI capabilities above,
 SmartRedis includes the following features developed for
 large, distributed HPC architectures:
 
 -   Redis cluster support for RedisAI data types
-    (`tensors <https://oss.redis.com/redisai/intro/#using-redisai-tensors>`_,
-    `models <https://oss.redis.com/redisai/intro/#loading-models>`_,
-    and `scripts <https://oss.redis.com/redisai/intro/#scripting>`_).
+    (`tensors <https://oss.redis.com/redisai/intro/#using-redisai-tensors>`__,
+    `models <https://oss.redis.com/redisai/intro/#loading-models>`__,
+    and `scripts <https://oss.redis.com/redisai/intro/#scripting>`__).
 -   Distributed model and script placement for parallel
     evaluation that maximizes hardware utilization and throughput
 -   A ``DataSet`` storage format to aggregate multiple tensors

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -3,22 +3,24 @@
 Overview
 ********
 
-SmartRedis is a collection of Redis clients that support
-RedisAI capabilities and include additional
+SmartRedis is a collection of `Redis <https://redis.io>`_ clients that support
+`RedisAI <https://redisai.io>`_ capabilities and include additional
 features for high performance computing (HPC) applications.
 Key features of RedisAI that are supported by SmartRedis include:
 
 -   A tensor data type in Redis
 -   TensorFlow, TensorFlow Lite, Torch,
-    and ONNXRuntime backends for model evaluations
--   TorchScript storage and evaluation
+    and `ONNXRuntime <https://onnxruntime.ai/>`_ backends for model evaluations
+-   `TorchScript <https://pytorch.org/docs/1.11/jit.html>`_ storage and evaluation
 
 In addition to the RedisAI capabilities above,
 SmartRedis includes the following features developed for
 large, distributed HPC architectures:
 
--   Redis cluster support for RedisAI data types (tensors,
-    models, and scripts).
+-   Redis cluster support for RedisAI data types
+    (`tensors <https://oss.redis.com/redisai/intro/#using-redisai-tensors>`_,
+    `models <https://oss.redis.com/redisai/intro/#loading-models>`_,
+    and `scripts <https://oss.redis.com/redisai/intro/#scripting>`_).
 -   Distributed model and script placement for parallel
     evaluation that maximizes hardware utilization and throughput
 -   A ``DataSet`` storage format to aggregate multiple tensors

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -1560,7 +1560,8 @@ class Client(SRObject):
            NOTE: The default size of 511MB should be fine for most
            applications, so it is expected to be very rare that a
            client calls this method. It is not necessary to call
-           this method a model to be chunked.
+           this method for a model to be chunked.
+
         :param chunk_size: The new chunk size in bytes
         :type addresses: int
         :raises RedisReplyError: if there is an error


### PR DESCRIPTION
This PR adds links to Redis and RedisAI docs. Some minor issues with internal links were also fixed.