### PR TITLE
Make Dataset::add_tensor() const correct

### DIFF
--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -84,8 +84,7 @@ jobs:
           --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V} &&
           echo "CC=gcc" >> $GITHUB_ENV &&
           echo "CXX=g++" >> $GITHUB_ENV &&
-          echo "FC=gfortran" >> $GITHUB_ENV &&
-          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH
+          echo "FC=gfortran" >> $GITHUB_ENV
         # Note CC and CXX need to be set otherwise, some Ubuntu images default to
         # a Debian-flavored compiler
 
@@ -97,7 +96,7 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran=2023.2.2-47 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
           sudo apt-get install -y intel-oneapi-common-vars &&
           printenv >> $GITHUB_ENV &&

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -96,12 +96,9 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-          source /opt/intel/oneapi/setvars.sh &&
-          printenv >> $GITHUB_ENV &&
-          echo "CC=icx" >> $GITHUB_ENV &&
-          echo "CXX=icpx" >> $GITHUB_ENV &&
-          echo "FC=ifort" >> $GITHUB_ENV
+          sudo apt-get install -y intel-oneapi-common-vars &&
+          sudo apt-get install -y intel-oneapi-compiler-fortran &&
+          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
       # Install additional dependencies
       - name: Install Cmake Linux

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -98,6 +98,7 @@ jobs:
           sudo apt-get update -y &&
           sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
+          sudo apt-get install -y intel-oneapi-common-vars &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -96,7 +96,7 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran=2023.2.1 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -101,7 +101,7 @@ jobs:
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&
-          echo "FC=ifort" >> $GITHUB_ENV
+          echo "FC=ifx" >> $GITHUB_ENV
 
       # Install additional dependencies
       - name: Install Cmake Linux

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -96,7 +96,7 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran=2023.2.1 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -84,7 +84,8 @@ jobs:
           --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V} &&
           echo "CC=gcc" >> $GITHUB_ENV &&
           echo "CXX=g++" >> $GITHUB_ENV &&
-          echo "FC=gfortran" >> $GITHUB_ENV
+          echo "FC=gfortran" >> $GITHUB_ENV &&
+          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH
         # Note CC and CXX need to be set otherwise, some Ubuntu images default to
         # a Debian-flavored compiler
 

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -101,7 +101,7 @@ jobs:
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&
-          echo "FC=ifx" >> $GITHUB_ENV
+          echo "FC=ifort" >> $GITHUB_ENV
 
       # Install additional dependencies
       - name: Install Cmake Linux

--- a/.github/workflows/run_static_and_examples.yml
+++ b/.github/workflows/run_static_and_examples.yml
@@ -96,9 +96,12 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-common-vars &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran &&
-          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          source /opt/intel/oneapi/setvars.sh &&
+          printenv >> $GITHUB_ENV &&
+          echo "CC=icx" >> $GITHUB_ENV &&
+          echo "CXX=icpx" >> $GITHUB_ENV &&
+          echo "FC=ifort" >> $GITHUB_ENV
 
       # Install additional dependencies
       - name: Install Cmake Linux

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -108,7 +108,7 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran=2023.2.1 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -110,6 +110,7 @@ jobs:
           sudo apt-get update -y &&
           sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
+          sudo apt-get install -y intel-oneapi-common-vars &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -108,7 +108,7 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran=2023.2.1 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -108,7 +108,7 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB &&
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt-get update -y &&
-          sudo apt-get install -y intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-fortran=2023.2.2-47 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh &&
           sudo apt-get install -y intel-oneapi-common-vars &&
           printenv >> $GITHUB_ENV &&
@@ -182,14 +182,11 @@ jobs:
         run: make build-examples SR_LINK=Static SR_FORTRAN=ON
       - name: Test static build -- intel compilers
         if: contains(matrix.os, 'ubuntu') && contains(matrix.compiler, 'intel')
-        run: |
-          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH &&
-          make build-example-serial SR_LINK=Static SR_FORTRAN=ON
+        run: make build-example-serial SR_LINK=Static SR_FORTRAN=ON
 
       # Run the tests using various DB deployments
       - name: Run tests
         run: |
-          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH &&
           make test-verbose-with-coverage \
             COV_FLAGS="--cov=./src/python/module/smartredis/ --cov-report=xml --cov-append" \
             SR_FORTRAN=ON SR_PYTHON=ON SR_TEST_REDIS_MODE=All SR_TEST_PORT=7000 \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -96,8 +96,7 @@ jobs:
           --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V} &&
           echo "CC=gcc" >> $GITHUB_ENV &&
           echo "CXX=g++" >> $GITHUB_ENV &&
-          echo "FC=gfortran" >> $GITHUB_ENV &&
-          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH
+          echo "FC=gfortran" >> $GITHUB_ENV
         # Note CC and CXX need to be set otherwise, some Ubuntu images default to
         # a Debian-flavored compiler
 
@@ -183,11 +182,14 @@ jobs:
         run: make build-examples SR_LINK=Static SR_FORTRAN=ON
       - name: Test static build -- intel compilers
         if: contains(matrix.os, 'ubuntu') && contains(matrix.compiler, 'intel')
-        run: make build-example-serial SR_LINK=Static SR_FORTRAN=ON
+        run: |
+          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH &&
+          make build-example-serial SR_LINK=Static SR_FORTRAN=ON
 
       # Run the tests using various DB deployments
       - name: Run tests
         run: |
+          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH &&
           make test-verbose-with-coverage \
             COV_FLAGS="--cov=./src/python/module/smartredis/ --cov-report=xml --cov-append" \
             SR_FORTRAN=ON SR_PYTHON=ON SR_TEST_REDIS_MODE=All SR_TEST_PORT=7000 \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -96,7 +96,8 @@ jobs:
           --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V} &&
           echo "CC=gcc" >> $GITHUB_ENV &&
           echo "CXX=g++" >> $GITHUB_ENV &&
-          echo "FC=gfortran" >> $GITHUB_ENV
+          echo "FC=gfortran" >> $GITHUB_ENV &&
+          echo "/opt/intel/oneapi/compiler/2024.0.0/linux/bin/intel64:/opt/intel/oneapi/compiler/2024.0.0/linux/bin" >> $GITHUB_PATH
         # Note CC and CXX need to be set otherwise, some Ubuntu images default to
         # a Debian-flavored compiler
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -113,7 +113,7 @@ jobs:
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&
           echo "CXX=icpx" >> $GITHUB_ENV &&
-          echo "FC=ifort" >> $GITHUB_ENV
+          echo "FC=ifx" >> $GITHUB_ENV
 
       # Set up perl environment for LCOV
       - uses: actions/checkout@v3

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Improved const correctness of Dataset
 - Updated documentation
 - Added test cases for all Client construction parameter combinations
 - Centralized dependency tracking to setup.cfg
@@ -30,6 +31,7 @@ Description
 
 Detailed Notes
 
+- The Dataset add_tensor method is now const correct, as are all internal the methods it calls (PR426_)
 - Some broken links in the documentation were fixed, and the instructions to run the tests were updated (PR423_)
 - Added test cases for all Client construction parameter combinations (PR422_)
 - Merged dependency lists from requirements.txt and requirements-dev.txt into setup.cfg to have only one set of dependencies going forward (PR420_)
@@ -49,6 +51,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
+.. _PR426: https://github.com/CrayLabs/SmartRedis/pull/426
 .. _PR423: https://github.com/CrayLabs/SmartRedis/pull/423
 .. _PR422: https://github.com/CrayLabs/SmartRedis/pull/422
 .. _PR421: https://github.com/CrayLabs/SmartRedis/pull/421

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -31,7 +31,7 @@ Description
 
 Detailed Notes
 
-- The Dataset add_tensor method is now const correct, as are all internal the methods it calls (PR426_)
+- The Dataset add_tensor method is now const correct, as are all internal the methods it calls (PR427_)
 - Some broken links in the documentation were fixed, and the instructions to run the tests were updated (PR423_)
 - Added test cases for all Client construction parameter combinations (PR422_)
 - Merged dependency lists from requirements.txt and requirements-dev.txt into setup.cfg to have only one set of dependencies going forward (PR420_)
@@ -51,7 +51,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
-.. _PR426: https://github.com/CrayLabs/SmartRedis/pull/426
+.. _PR427: https://github.com/CrayLabs/SmartRedis/pull/427
 .. _PR423: https://github.com/CrayLabs/SmartRedis/pull/423
 .. _PR422: https://github.com/CrayLabs/SmartRedis/pull/422
 .. _PR421: https://github.com/CrayLabs/SmartRedis/pull/421

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -105,7 +105,7 @@ class DataSet : public SRObject
         *   \throw SmartRedis::Exception if add_tensor operation fails
         */
         void add_tensor(const std::string& name,
-                        void* data,
+                        const void* data,
                         const std::vector<size_t>& dims,
                         const SRTensorType type,
                         const SRMemoryLayout mem_layout);
@@ -423,7 +423,7 @@ class DataSet : public SRObject
         *   \param mem_layout The memory layout for the provided tensor data
         */
         void _add_to_tensorpack(const std::string& name,
-                                void* data,
+                                const void* data,
                                 const std::vector<size_t>& dims,
                                 const SRTensorType type,
                                 const SRMemoryLayout mem_layout);

--- a/include/tensor.h
+++ b/include/tensor.h
@@ -59,7 +59,7 @@ class Tensor : public TensorBase
         *   \param mem_layout The memory layout of the source data
         */
         Tensor(const std::string& name,
-               void* data,
+               const void* data,
                const std::vector<size_t>& dims,
                const SRTensorType type,
                const SRMemoryLayout mem_layout);
@@ -157,7 +157,7 @@ class Tensor : public TensorBase
         *            only.  The initial caller SHOULD NOT use
         *            this pointer.
         */
-        void* _copy_nested_to_contiguous(void* src_data,
+        void* _copy_nested_to_contiguous(const void* src_data,
                                          const size_t* dims,
                                          const size_t n_dims,
                                          void* dest_data);
@@ -213,7 +213,7 @@ class Tensor : public TensorBase
         *   \param mem_layout The layout of the source data
         *                     memory structure
         */
-        virtual void _set_tensor_data(void* src_data,
+        virtual void _set_tensor_data(const void* src_data,
                                       const std::vector<size_t>& dims,
                                       const SRMemoryLayout mem_layout);
 
@@ -226,7 +226,7 @@ class Tensor : public TensorBase
         *   \param dims The dimensions of the tensor
         */
         void _f_to_c_memcpy(T* c_data,
-                            T* f_data,
+                            const T* f_data,
                             const std::vector<size_t>& dims);
 
         /*!
@@ -238,7 +238,7 @@ class Tensor : public TensorBase
         *   \param dims The dimensions of the tensor
         */
         void _c_to_f_memcpy(T* f_data,
-                            T* c_data,
+                            const T* c_data,
                             const std::vector<size_t>& dims);
 
         /*!
@@ -253,7 +253,7 @@ class Tensor : public TensorBase
         *   \param current_dim The index of the current dimension
         */
         void _f_to_c(T* c_data,
-                     T* f_data,
+                     const T* f_data,
                      const std::vector<size_t>& dims,
                      std::vector<size_t> dim_positions,
                      size_t current_dim);
@@ -270,7 +270,7 @@ class Tensor : public TensorBase
         *   \param current_dim The index of the current dimension
         */
         void _c_to_f(T* f_data,
-                     T* c_data,
+                     const T* c_data,
                      const std::vector<size_t>& dims,
                      std::vector<size_t> dim_positions,
                      size_t current_dim);

--- a/include/tensor.tcc
+++ b/include/tensor.tcc
@@ -34,7 +34,7 @@
 // Tensor constructor
 template <class T>
 Tensor<T>::Tensor(const std::string& name,
-                  void* data,
+                  const void* data,
                   const std::vector<size_t>& dims,
                   const SRTensorType type,
                   const SRMemoryLayout mem_layout) :
@@ -218,7 +218,7 @@ void Tensor<T>::fill_mem_space(void* data,
 
 // copy values from nested memory structure to contiguous memory structure
 template <class T>
-void* Tensor<T>::_copy_nested_to_contiguous(void* src_data,
+void* Tensor<T>::_copy_nested_to_contiguous(const void* src_data,
                                             const size_t* dims,
                                             const size_t n_dims,
                                             void* dest_data)
@@ -293,7 +293,7 @@ T* Tensor<T>::_build_nested_memory(void** data,
 
 // Set the tensor data from a src memory location.
 template <class T>
-void Tensor<T>::_set_tensor_data(void* src_data,
+void Tensor<T>::_set_tensor_data(const void* src_data,
                                  const std::vector<size_t>& dims,
                                  const SRMemoryLayout mem_layout)
 {
@@ -311,7 +311,7 @@ void Tensor<T>::_set_tensor_data(void* src_data,
             std::memcpy(_data, src_data, n_bytes);
             break;
         case SRMemLayoutFortranContiguous:
-            _f_to_c_memcpy((T*)_data, (T*) src_data, dims);
+            _f_to_c_memcpy((T*)_data, (const T*)src_data, dims);
             break;
         case SRMemLayoutNested:
             _copy_nested_to_contiguous(
@@ -333,7 +333,7 @@ size_t Tensor<T>::_n_data_bytes()
 // c-style array memory space (row major)
 template <class T>
 void Tensor<T>::_f_to_c_memcpy(T* c_data,
-                               T* f_data,
+                               const T* f_data,
                                const std::vector<size_t>& dims)
 {
     if (c_data == NULL || f_data == NULL) {
@@ -347,7 +347,7 @@ void Tensor<T>::_f_to_c_memcpy(T* c_data,
 // fortran memory space layout (col major)
 template <class T>
 void Tensor<T>::_c_to_f_memcpy(T* f_data,
-                               T* c_data,
+                               const T* c_data,
                                const std::vector<size_t>& dims)
 {
     if (c_data == NULL || f_data == NULL) {
@@ -360,7 +360,7 @@ void Tensor<T>::_c_to_f_memcpy(T* f_data,
 // Copy fortran column major memory to c-style row major memory recursively
 template <class T>
 void Tensor<T>::_f_to_c(T* c_data,
-                        T* f_data,
+                        const T* f_data,
                         const std::vector<size_t>& dims,
                         std::vector<size_t> dim_positions,
                         size_t current_dim)
@@ -388,7 +388,7 @@ void Tensor<T>::_f_to_c(T* c_data,
 // Copy c-style row major memory to fortran column major memory recursively
 template <class T>
 void Tensor<T>::_c_to_f(T* f_data,
-                        T* c_data,
+                        const T* c_data,
                         const std::vector<size_t>& dims,
                         std::vector<size_t> dim_positions,
                         size_t current_dim)

--- a/include/tensorbase.h
+++ b/include/tensorbase.h
@@ -95,7 +95,7 @@ class TensorBase{
         *   \param mem_layout The memory layout of the source data
         */
         TensorBase(const std::string& name,
-                   void* data,
+                   const void* data,
                    const std::vector<size_t>& dims,
                    const SRTensorType type,
                    const SRMemoryLayout mem_layout);
@@ -259,7 +259,7 @@ class TensorBase{
         *   \param dims The dimensions of the data
         *   \param mem_layout The memory layout of the source data
         */
-        virtual void _set_tensor_data(void* src_data,
+        virtual void _set_tensor_data(const void* src_data,
                                       const std::vector<size_t>& dims,
                                       const SRMemoryLayout mem_layout) = 0;
 

--- a/include/tensorpack.h
+++ b/include/tensorpack.h
@@ -97,7 +97,7 @@ class TensorPack
         *   \param mem_layout The memory layout of the data
         */
         void add_tensor(const std::string& name,
-                        void* data,
+                        const void* data,
                         const std::vector<size_t>& dims,
                         const SRTensorType type,
                         const SRMemoryLayout mem_layout);

--- a/src/cpp/dataset.cpp
+++ b/src/cpp/dataset.cpp
@@ -51,7 +51,7 @@ DataSet::~DataSet()
 
 // Add a tensor to the DataSet.
 void DataSet::add_tensor(const std::string& name,
-                         void* data,
+                         const void* data,
                          const std::vector<size_t>& dims,
                          const SRTensorType type,
                          SRMemoryLayout mem_layout)
@@ -321,7 +321,7 @@ SRMetaDataType DataSet::get_metadata_field_type(
 
 // Add a Tensor (not yet allocated) to the TensorPack
 void DataSet::_add_to_tensorpack(const std::string& name,
-                                 void* data,
+                                 const void* data,
                                  const std::vector<size_t>& dims,
                                  const SRTensorType type,
                                  const SRMemoryLayout mem_layout)

--- a/src/cpp/tensorbase.cpp
+++ b/src/cpp/tensorbase.cpp
@@ -34,7 +34,7 @@ using namespace SmartRedis;
 
 // TensorBase constructor
 TensorBase::TensorBase(const std::string& name,
-                       void* data,
+                       const void* data,
                        const std::vector<size_t>& dims,
                        const SRTensorType type,
                        const SRMemoryLayout mem_layout)

--- a/src/cpp/tensorpack.cpp
+++ b/src/cpp/tensorpack.cpp
@@ -62,7 +62,7 @@ TensorPack::~TensorPack()
 
 // Add a tensor to the dataset
 void TensorPack::add_tensor(const std::string& name,
-                            void* data,
+                            const void* data,
                             const std::vector<size_t>& dims,
                             const SRTensorType type,
                             const SRMemoryLayout mem_layout)


### PR DESCRIPTION
The `data` parameter of Dataset::add_tensor() is now properly marked as const. This required const correctness updates to all the methods that are called as part of effecting add_tensor().