### PR TITLE
Make namespace declarations consistent

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Improved consistency of namespace declarations for C++ pybind interface
 - Improved const correctness of C++ Client
 - Improved const correctness of C++ Dataset
 - Updated documentation
@@ -32,6 +33,7 @@ Description
 
 Detailed Notes
 
+- Made the declaration of the py namespace in py*.h consistenly outside the SmartRedis namespace declaration (PR434_)
 - Fields in several C++ API methods are now properly marked as const (PR430_)
 - The Dataset add_tensor method is now const correct, as are all internal the methods it calls (PR427_)
 - Some broken links in the documentation were fixed, and the instructions to run the tests were updated (PR423_)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,7 +33,7 @@ Description
 
 Detailed Notes
 
-- Made the declaration of the py namespace in py*.h consistenly outside the SmartRedis namespace declaration (PR434_)
+- Made the declaration of the py namespace in py*.h consistently outside the SmartRedis namespace declaration (PR434_)
 - Fields in several C++ API methods are now properly marked as const (PR430_)
 - The Dataset add_tensor method is now const correct, as are all internal the methods it calls (PR427_)
 - Some broken links in the documentation were fixed, and the instructions to run the tests were updated (PR423_)
@@ -55,6 +55,7 @@ Detailed Notes
 - Create CONTRIBUTIONS.md file that points to the contribution guideline for both SmartSim and SmartRedis (PR395_)
 - Migrated to ConfigOptions-based Client construction, adding multiple database support (PR353_)
 
+.. _PR434: https://github.com/CrayLabs/SmartRedis/pull/434
 .. _PR430: https://github.com/CrayLabs/SmartRedis/pull/430
 .. _PR427: https://github.com/CrayLabs/SmartRedis/pull/427
 .. _PR423: https://github.com/CrayLabs/SmartRedis/pull/423

--- a/include/pyclient.h
+++ b/include/pyclient.h
@@ -43,9 +43,9 @@
 
 ///@file
 
-namespace SmartRedis {
-
 namespace py = pybind11;
+
+namespace SmartRedis {
 
 /*!
 *   \brief The PyClient class is a wrapper around the

--- a/include/pyconfigoptions.h
+++ b/include/pyconfigoptions.h
@@ -41,7 +41,6 @@
 
 namespace py = pybind11;
 
-
 namespace SmartRedis {
 
 


### PR DESCRIPTION
The declaration of the `py` namespace was inconsistent. In pyclient.h, it was declared inside the SmartRedis namespace, but in the other py*.h headers, it was declared outside. In this PR, we make the declaration consistent across all of the py*.h headers.