### PR TITLE
Utilize mutable fields to make Dataset getter methods const

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,13 +8,13 @@ To be released at some future point in time
 
 Description
 
-- Use mutable fields to enable get methods that store memory to be marked const
+- Use mutable fields to enable Dataset get methods that store memory to be marked const
 
 Detailed Notes
 
-- Use mutable fields to enable get methods that store memory to be marked const (PR439_)
+- Use mutable fields to enable Dataset get methods that store memory to be marked const (PR443_)
 
-.. _PR439: https://github.com/CrayLabs/SmartRedis/pull/439
+.. _PR443: https://github.com/CrayLabs/SmartRedis/pull/443
 
 0.5.0
 -----

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,16 @@ Development branch
 
 To be released at some future point in time
 
+Description
+
+- Use mutable fields to enable get methods that store memory to be marked const
+
+Detailed Notes
+
+- Use mutable fields to enable get methods that store memory to be marked const (PR439_)
+
+.. _PR439: https://github.com/CrayLabs/SmartRedis/pull/439
+
 0.5.0
 -----
 

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -160,7 +160,7 @@ class DataSet : public SRObject
                         void*& data,
                         std::vector<size_t>& dims,
                         SRTensorType& type,
-                        const SRMemoryLayout mem_layout);
+                        const SRMemoryLayout mem_layout) const;
 
         /*!
         *   \brief Get the tensor data, dimensions, and type for the tensor
@@ -192,7 +192,7 @@ class DataSet : public SRObject
                         size_t*& dims,
                         size_t& n_dims,
                         SRTensorType& type,
-                        const SRMemoryLayout mem_layout);
+                        const SRMemoryLayout mem_layout) const;
 
         /*!
         *   \brief Retrieve tensor data to a caller-supplied buffer.
@@ -227,7 +227,7 @@ class DataSet : public SRObject
         void get_meta_scalars(const std::string& name,
                               void*& data,
                               size_t& length,
-                              SRMetaDataType& type);
+                              SRMetaDataType& type) const;
 
         /*!
         *   \brief Retrieve metadata string field values from the DataSet.
@@ -450,7 +450,7 @@ class DataSet : public SRObject
         *   \param name  The name used to reference the tensor
         *   \returns A TensorBase object.
         */
-        TensorBase* _get_tensorbase_obj(const std::string& name);
+        TensorBase* _get_tensorbase_obj(const std::string& name) const;
 
     private:
 
@@ -473,20 +473,20 @@ class DataSet : public SRObject
         *   \brief Throw an exception if a tensor does not exist
         *   \throw RuntimeException if the tensor is not in the DataSet
         */
-        inline void _enforce_tensor_exists(const std::string& name);
+        inline void _enforce_tensor_exists(const std::string& name) const;
 
         /*!
         *   \brief SharedMemoryList to manage memory associated
         *          with tensor dimensions from tensor retrieval
         */
-        SharedMemoryList<size_t> _dim_queries;
+        mutable SharedMemoryList<size_t> _dim_queries;
 
         /*!
         *  \brief The _tensor_pack memory is not for querying
         *         by name, but is used to manage memory associated
         *         with get_tensor() function calls.
         */
-        TensorPack _tensor_memory;
+        mutable TensorPack _tensor_memory;
 
 };
 

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -259,7 +259,7 @@ class DataSet : public SRObject
         void get_meta_strings(const std::string& name,
                               char**& data,
                               size_t& n_strings,
-                              size_t*& lengths);
+                              size_t*& lengths) const;
 
         /*!
         *   \brief Check whether the dataset contains a field
@@ -310,7 +310,7 @@ class DataSet : public SRObject
         */
         void get_tensor_names(char**& data,
                               size_t& n_strings,
-                              size_t*& lengths);
+                              size_t*& lengths) const;
 
         /*!
         *   \brief Retrieve the data type of a Tensor in the DataSet
@@ -347,7 +347,7 @@ class DataSet : public SRObject
         */
         void get_metadata_field_names(char**& data,
                                       size_t& n_strings,
-                                      size_t*& lengths);
+                                      size_t*& lengths) const;
 
         /*!
         *   \brief Retrieve the data type of a metadata field in the DataSet

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -206,7 +206,7 @@ class MetaData
         void get_string_values(const std::string& name,
                                char**& data,
                                size_t& n_strings,
-                               size_t*& lengths);
+                               size_t*& lengths) const;
 
         /*!
         *   \brief This function checks if the DataSet has a
@@ -272,7 +272,7 @@ class MetaData
         void get_field_names(char**& data,
                              size_t& n_strings,
                              size_t*& lengths,
-                             bool skip_internal = false);
+                             bool skip_internal = false) const;
     private:
 
        /*!

--- a/include/metadata.h
+++ b/include/metadata.h
@@ -171,7 +171,7 @@ class MetaData
         void get_scalar_values(const std::string& name,
                                void*& data,
                                size_t& length,
-                               SRMetaDataType& type);
+                               SRMetaDataType& type) const;
 
         /*!
         *   \brief  Get metadata values string field
@@ -292,56 +292,56 @@ class MetaData
         *          memory allocation associated with retrieving
         *          metadata
         */
-        SharedMemoryList<char*>_char_array_mem_mgr;
+        mutable SharedMemoryList<char*>_char_array_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for c-str memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<char> _char_mem_mgr;
+        mutable SharedMemoryList<char> _char_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for double memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<double> _double_mem_mgr;
+        mutable SharedMemoryList<double> _double_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for float memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<float> _float_mem_mgr;
+        mutable SharedMemoryList<float> _float_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for int64 memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<int64_t> _int64_mem_mgr;
+        mutable SharedMemoryList<int64_t> _int64_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for uint64 memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<uint64_t> _uint64_mem_mgr;
+        mutable SharedMemoryList<uint64_t> _uint64_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for int32 memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<int32_t> _int32_mem_mgr;
+        mutable SharedMemoryList<int32_t> _int32_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for uint32 memory
         *          allocation associated with retrieving metadata
         */
-        SharedMemoryList<uint32_t> _uint32_mem_mgr;
+        mutable SharedMemoryList<uint32_t> _uint32_mem_mgr;
 
         /*!
         *   \brief SharedMemoryList for size_t memory
         *          allocation associated with retrieving
         *          string field sting lengths
         */
-        SharedMemoryList<size_t> _str_len_mem_mgr;
+        mutable SharedMemoryList<size_t> _str_len_mem_mgr;
 
         /*!
         *   \brief Create a new metadata field with the given
@@ -400,7 +400,7 @@ class MetaData
         void _get_numeric_field_values(const std::string& name,
                                        void*& data,
                                        size_t& n_values,
-                                       SharedMemoryList<T>& mem_list);
+                                       SharedMemoryList<T>& mem_list) const;
 
         /*!
         *   \brief Delete the memory associated with all fields

--- a/src/cpp/dataset.cpp
+++ b/src/cpp/dataset.cpp
@@ -180,7 +180,7 @@ void DataSet::get_meta_scalars(const std::string& name,
 void DataSet::get_meta_strings(const std::string& name,
                                char**& data,
                                size_t& n_strings,
-                               size_t*& lengths)
+                               size_t*& lengths) const
 {
     // Track calls to this API function
     LOG_API_FUNCTION();
@@ -221,7 +221,7 @@ std::vector<std::string> DataSet::get_tensor_names() const
 
 // Retrieve tensor names from the DataSet
 void DataSet::get_tensor_names(
-    char**& data, size_t& n_strings, size_t*& lengths)
+    char**& data, size_t& n_strings, size_t*& lengths) const
 {
     // Track calls to this API function
     LOG_API_FUNCTION();
@@ -235,7 +235,6 @@ void DataSet::get_tensor_names(
         lengths = NULL;
         n_strings = 0;
     }
-
 }
 
 // Get the strings in a metadata string field. Because standard C++
@@ -296,7 +295,7 @@ std::vector<std::string> DataSet::get_metadata_field_names() const
 
 // Retrieve metadata field names from the DataSet
 void DataSet::get_metadata_field_names(
-    char**& data, size_t& n_strings, size_t*& lengths)
+    char**& data, size_t& n_strings, size_t*& lengths) const
 {
     // Track calls to this API function
     LOG_API_FUNCTION();

--- a/src/cpp/dataset.cpp
+++ b/src/cpp/dataset.cpp
@@ -95,7 +95,7 @@ void DataSet::get_tensor(const std::string& name,
                          void*& data,
                          std::vector<size_t>& dims,
                          SRTensorType& type,
-                         SRMemoryLayout mem_layout)
+                         SRMemoryLayout mem_layout) const
 {
     // Track calls to this API function
     LOG_API_FUNCTION();
@@ -119,7 +119,7 @@ void DataSet::get_tensor(const std::string&  name,
                          size_t*& dims,
                          size_t& n_dims,
                          SRTensorType& type,
-                         SRMemoryLayout mem_layout)
+                         SRMemoryLayout mem_layout) const
 {
     // Track calls to this API function
     LOG_API_FUNCTION();
@@ -164,7 +164,7 @@ void DataSet::unpack_tensor(const std::string& name,
 void DataSet::get_meta_scalars(const std::string& name,
                                void*& data,
                                size_t& length,
-                               SRMetaDataType& type)
+                               SRMetaDataType& type) const
 {
     // Track calls to this API function
     LOG_API_FUNCTION();
@@ -370,7 +370,7 @@ void DataSet::_add_serialized_field(const std::string& name,
 }
 
 // Check and enforce that a tensor must exist or throw an error.
-inline void DataSet::_enforce_tensor_exists(const std::string& tensorname)
+inline void DataSet::_enforce_tensor_exists(const std::string& tensorname) const
 {
     if (!_tensorpack.tensor_exists(tensorname)) {
         throw SRKeyException("The tensor \"" + std::string(tensorname) +
@@ -383,7 +383,7 @@ inline void DataSet::_enforce_tensor_exists(const std::string& tensorname)
 // can be used to return tensor information to the user. The returned TensorBase
 // object has been dynamically allocated, but not yet tracked for memory
 // management in any object.
-TensorBase* DataSet::_get_tensorbase_obj(const std::string& name)
+TensorBase* DataSet::_get_tensorbase_obj(const std::string& name) const
 {
     _enforce_tensor_exists(name);
     return _tensorpack.get_tensor(name)->clone();

--- a/src/cpp/metadata.cpp
+++ b/src/cpp/metadata.cpp
@@ -270,7 +270,7 @@ std::vector<std::string> MetaData::get_field_names(bool skip_internal) const
 void MetaData::get_field_names(char**& data,
                                size_t& n_strings,
                                size_t*& lengths,
-                               bool skip_internal /*= false*/)
+                               bool skip_internal /*= false*/) const
 {
     // Retrieve the names
     std::vector<std::string> name_strings = get_field_names(skip_internal);
@@ -304,8 +304,7 @@ void MetaData::get_field_names(char**& data,
 void MetaData::get_string_values(const std::string& name,
                                  char**& data,
                                  size_t& n_strings,
-                                 size_t*& lengths)
-
+                                 size_t*& lengths) const
 {
     // Retrieve the strings
     std::vector<std::string> field_strings = get_string_values(name);

--- a/src/cpp/metadata.cpp
+++ b/src/cpp/metadata.cpp
@@ -188,16 +188,20 @@ void MetaData::add_string(const std::string& field_name,
 void MetaData::get_scalar_values(const std::string& name,
                                 void*& data,
                                 size_t& length,
-                                SRMetaDataType& type)
+                                SRMetaDataType& type) const
 {
     // Make sure the field exists
-    if (_field_map[name] == NULL) {
+    MetadataField* mdf = NULL;
+    try {
+         mdf = _field_map.at(name);
+    }
+    catch (std::out_of_range& e) {
         throw SRRuntimeException("The metadata field " + name +
                                  " does not exist.");
     }
 
     // Get values for the field
-    type = _field_map[name]->type();
+    type = mdf->type();
     switch (type) {
         case SRMetadataTypeDouble:
             _get_numeric_field_values<double>
@@ -475,11 +479,14 @@ void MetaData::_get_numeric_field_values(
     const std::string& name,
     void*& data,
     size_t& n_values,
-    SharedMemoryList<T>& mem_list)
+    SharedMemoryList<T>& mem_list) const
 {
     // Make sure the field exists
-    MetadataField* mdf = _field_map[name];
-    if (mdf == NULL) {
+    MetadataField* mdf = NULL;
+    try {
+        mdf = _field_map.at(name);
+    }
+    catch (std::out_of_range& e) {
         throw SRRuntimeException("Field " + name + " does not exist.");
     }
 


### PR DESCRIPTION
The following methods have been updated:

- get_tensor()
- get_meta_scalars()
- get_meta_strings()
- get_tensor_names()

Additionally, a few uses of `std::unordered_map::operator[]` have been replaced with calls to `std::unordered_map::at()` since the latter is const but the former is not. This also required adding an exception handler since `std::unordered_map::at()` throws an exception rather than returning null if the requested element is not found