### PR TITLE
Resolve linting issue

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,12 +8,15 @@ To be released at some future point in time
 
 Description
 
+- Resolve a linting issue with pybind-to-python error propagation
 - Use mutable fields to enable Dataset get methods that store memory to be marked const
 
 Detailed Notes
 
+- Resolve a linting issue with pybind-to-python error propagation by changing import format and narrowing the lookup of pybind error names to the error module (PR444_)
 - Use mutable fields to enable Dataset get methods that store memory to be marked const (PR443_)
 
+.. _PR444: https://github.com/CrayLabs/SmartRedis/pull/444
 .. _PR443: https://github.com/CrayLabs/SmartRedis/pull/443
 
 0.5.0

--- a/src/python/module/smartredis/util.py
+++ b/src/python/module/smartredis/util.py
@@ -29,7 +29,6 @@ from functools import wraps
 
 import numpy as np
 from . import error
-#from .error import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 from .smartredisPy import RedisReplyError as PybindRedisReplyError
 from .smartredisPy import c_get_last_error_location

--- a/src/python/module/smartredis/util.py
+++ b/src/python/module/smartredis/util.py
@@ -153,7 +153,6 @@ def exception_handler(func: "t.Callable[_PR, _RT]") -> "t.Callable[_PR, _RT]":
                 cpp_error_str = (
                     f"File {error_loc}, in SmartRedis library\n{str(cpp_error)}"
                 )
-            #raise globals()[exception_name](cpp_error_str, method_name) from None
             raise getattr(error, exception_name)(cpp_error_str, method_name) from None
 
     return smartredis_api_wrapper

--- a/src/python/module/smartredis/util.py
+++ b/src/python/module/smartredis/util.py
@@ -28,7 +28,8 @@ import typing as t
 from functools import wraps
 
 import numpy as np
-from .error import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from . import error
+#from .error import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 from .smartredisPy import RedisReplyError as PybindRedisReplyError
 from .smartredisPy import c_get_last_error_location
@@ -152,7 +153,8 @@ def exception_handler(func: "t.Callable[_PR, _RT]") -> "t.Callable[_PR, _RT]":
                 cpp_error_str = (
                     f"File {error_loc}, in SmartRedis library\n{str(cpp_error)}"
                 )
-            raise globals()[exception_name](cpp_error_str, method_name) from None
+            #raise globals()[exception_name](cpp_error_str, method_name) from None
+            raise getattr(error, exception_name)(cpp_error_str, method_name) from None
 
     return smartredis_api_wrapper
 


### PR DESCRIPTION
Avoid wildcard import by reformatting import. Avoid apparent non-use of errors module  by restricting search of pybind error name to errors module.