### PR TITLE
Add Python 3.11 and remove Python 3.7

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.7] # versions of RedisAI
-        py_v: ['3.8.x', '3.9.x', '3.10.x'] # versions of Python
+        py_v: ['3.8.x', '3.9.x', '3.10.x', '3.11.x'] # versions of Python
         compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12] # intel compiler, and versions of GNU compiler
         link_type: [Static, Shared]
     env:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Update supported python versions [Add 3.11, remove 3.7]
 - Tweak the build system to enable building SmartRedis with Nvidia's NVHPC toolchain
 - Improvements/upgrades to the container used for Github actions
 - Code updates to avoid compiler warnings
@@ -17,6 +18,8 @@ Description
 
 Detailed Notes
 
+- Deprecate support for Python 3.7 by removing from the allowed Python versions (PR450_)
+- Update Python package dependencies to add support for Python 3.11 (PR450_)
 - Change the order of arguments in our MakeFile to ensure that all dependencies are compiled with GCC (PR448_)
 - Add new user-configurable parameters DEP_CC, DEP_CXX to control which compiler is used to build dependencies (PR448_)
 - Ameliorate some compiler warnings related that were flagged in GCC 12 (unreachable code blocks, signed/unsigned mismatches) (PR448_)
@@ -31,6 +34,7 @@ Detailed Notes
 - Resolve a linting issue with pybind-to-python error propagation by changing import format and narrowing the lookup of pybind error names to the error module (PR444_)
 - Use mutable fields to enable Dataset get methods that store memory to be marked const (PR443_)
 
+.. _PR450: https://github.com/CrayLabs/SmartRedis/pull/450
 .. _PR448: https://github.com/CrayLabs/SmartRedis/pull/448
 .. _PR445: https://github.com/CrayLabs/SmartRedis/pull/445
 .. _PR444: https://github.com/CrayLabs/SmartRedis/pull/444

--- a/doc/install/python_client.rst
+++ b/doc/install/python_client.rst
@@ -27,8 +27,7 @@ the ``Client`` from ``smartredis`` as follows:
 
 .. code-block:: python
 
-    Python 3.7.7 (default, May  7 2020, 21:25:33)
-    [GCC 7.3.0] :: Anaconda, Inc. on linux
+    Python 3.11.7 (main, Jan 12 2024, 20:10:36) [GCC 11.4.0] on linux
     Type "help", "copyright", "credits" or "license" for more information.
     >>> from smartredis import Client
     >>>

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -50,7 +50,7 @@ below summarizes the language standards for each client.
    * - Language
      - Version/Standard
    * - Python
-     - 3.7, 3.8, 3.9, 3.10
+     - 3.8-3.11
    * - C++
      - C++17
    * - C

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ contact_email = craylabs@hpe.com
 license = BSD 2-Clause License
 keywords = redis, clients, hpc, ai, deep learning
 classifiers =
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -35,7 +34,7 @@ setup_requires =
 include_package_data = True
 install_requires =
     numpy>=1.18.2
-python_requires = >=3.7,<3.12
+python_requires = >=3.8,<3.12
 
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: BSD License
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering
@@ -34,7 +35,7 @@ setup_requires =
 include_package_data = True
 install_requires =
     numpy>=1.18.2
-python_requires = >=3.7,<3.11
+python_requires = >=3.7,<3.12
 
 
 [options.extras_require]
@@ -44,7 +45,7 @@ dev =
     black==23.3.0
     isort==5.6.4
     pylint>=2.10.0
-    torch==1.11.0
+    torch<=2.0.1
     mypy>=1.4.0
     jinja2==3.0.3
 


### PR DESCRIPTION
Python 3.7 has reached end of life. Additionally, work has been done on the SmartSim side to confirm that updated versions of the ML backends which do support 3.11 are compatible with SmartSim and SmartRedis. This PR thus removes support for 3.7 and adds support for 3.11