### PR TITLE
Expose SR Typehints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ dev =
     pylint>=2.10.0
     torch<=2.0.1
     mypy>=1.4.0
+    typing_extensions
     jinja2==3.0.3
 
 doc=

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -33,6 +33,11 @@ from .smartredisPy import PyConfigOptions
 from .util import exception_handler, typecheck
 
 
+if t.TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    _PR = ParamSpec("_PR")
+
 _T = t.TypeVar("_T")
 
 
@@ -58,15 +63,15 @@ def create_managed_instance(base: t.Type[_T]) -> _T:
     return managed_class()
 
 
-def managed(func: t.Callable) -> t.Callable:
+def managed(func: "t.Callable[_PR, _T]") -> "t.Callable[_PR, _T]":
     """Decorator to verify that a class was constructed using a factory"""
     not_managed = (
-        "Attempting to call managed method on ConfigOptions object not "
+        "Attempting to call managed method on {} object not "
         "created from a factory method"
     )
 
     @wraps(func)
-    def _wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+    def _wrapper(*args: "_PR.args", **kwargs: "_PR.kwargs") -> _T:
         instance = args[0]
         if not isinstance(instance, _Managed):
             msg = not_managed.format(instance.__class__.__name__)

--- a/src/python/module/smartredis/configoptions.py
+++ b/src/python/module/smartredis/configoptions.py
@@ -33,14 +33,18 @@ from .smartredisPy import PyConfigOptions
 from .util import exception_handler, typecheck
 
 
+_T = t.TypeVar("_T")
+
+
 class _Managed:
     """Marker class identifying factory-created objects"""
 
 
-def create_managed_instance(base: t.Type[t.Any]) -> t.Any:
-    """Instantiate a managed instance of the class, enabling the use of type 
+def create_managed_instance(base: t.Type[_T]) -> _T:
+    """Instantiate a managed instance of the class, enabling the use of type
     checking to detect if an instance is managed"""
-    def get_dynamic_class_name(bases: t.Tuple[t.Type]) -> str:
+
+    def get_dynamic_class_name(bases: t.Tuple[t.Type[_Managed], t.Type[t.Any]]) -> str:
         """Create a name for the new type by concatenating base names. Appends a
         unique suffix to avoid confusion if dynamic type comparisons occur"""
         unique_key = str(uuid4()).split("-", 1)[0]
@@ -94,7 +98,7 @@ class ConfigOptions:
 
     @exception_handler
     @managed
-    def get_data(self):
+    def get_data(self) -> PyConfigOptions:
         """Return the PyConfigOptions attribute
 
         :return: The PyConfigOptions attribute containing


### PR DESCRIPTION
Add and ship `py.typed` marker per [pep-561](https://peps.python.org/pep-0561/). This change will help change the `mypy` output for this script
```py
from smartsim import Experiment
from smartredis import Client

exp = Experiment(b"my-exp")  # Should err expected str
client = Client(False)

reveal_type(exp)
reveal_type(client)
```
from this
```sh
$ mypy script.py
script.py:1: error: Skipping analyzing "smartsim": module is installed, but missing library stubs or py.typed marker  [import-untyped]
script.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
script.py:2: error: Skipping analyzing "smartredis": module is installed, but missing library stubs or py.typed marker  [import-untyped]
script.py:7: note: Revealed type is "Any"
script.py:8: note: Revealed type is "Any"
Found 2 errors in 1 file (checked 1 source file)
```
to this
```sh
$ mypy script.py
script.py:4: error: Argument 1 to "Experiment" has incompatible type "bytes"; expected "str"  [arg-type]
script.py:7: note: Revealed type is "smartsim.experiment.Experiment"
script.py:8: note: Revealed type is "smartredis.client.Client"
Found 1 error in 1 file (checked 1 source file)
```