### PR TITLE
Fix bug when sending an array view

### DIFF
--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -184,6 +184,10 @@ class Client(SRObject):
         typecheck(data, "data", np.ndarray)
         dtype = Dtypes.tensor_from_numpy(data)
         self._client.put_tensor(name, dtype, data)
+        if data.base is None:
+            self._client.put_tensor(name, dtype, data)
+        else:
+            self._client.put_tensor(name, dtype, data.copy())
 
     @exception_handler
     def get_tensor(self, name: str) -> np.ndarray:

--- a/src/python/module/smartredis/dataset.py
+++ b/src/python/module/smartredis/dataset.py
@@ -61,7 +61,7 @@ class Dataset(SRObject):
     def from_pybind(dataset: PyDataset) -> "Dataset":
         """Initialize a Dataset object from a PyDataset object
 
-            Create a new Dataset object using the data and properties 
+            Create a new Dataset object using the data and properties
             of a PyDataset object as the initial values.
 
         :param dataset: The pybind PyDataset object
@@ -106,8 +106,13 @@ class Dataset(SRObject):
         """
         typecheck(name, "name", str)
         typecheck(data, "data", np.ndarray)
-        dtype = Dtypes.tensor_from_numpy(data)
-        self._data.add_tensor(name, data, dtype)
+        if data.base is None:
+            dtype = Dtypes.tensor_from_numpy(data)
+            self._data.add_tensor(name, data, dtype)
+        else:
+            view_copy = data.copy(order="K")
+            dtype = Dtypes.tensor_from_numpy(view_copy)
+            self._data.add_tensor(name, view_copy, dtype)
 
     @exception_handler
     def get_tensor(self, name: str) -> np.ndarray:
@@ -132,10 +137,10 @@ class Dataset(SRObject):
 
     @exception_handler
     def add_meta_scalar(self, name: str, data: t.Union[int, float]) -> None:
-        """Add scalar (non-string) metadata to a field name if it exists; 
+        """Add scalar (non-string) metadata to a field name if it exists;
         otherwise, create and add
 
-            If the field name exists, append the scalar metadata; otherwise, 
+            If the field name exists, append the scalar metadata; otherwise,
             create the field within the DataSet object and add the scalar metadata.
 
         :param name: The name used to reference the scalar metadata field
@@ -157,7 +162,7 @@ class Dataset(SRObject):
     def add_meta_string(self, name: str, data: str) -> None:
         """Add string metadata to a field name if it exists; otherwise, create and add
 
-            If the field name exists, append the string metadata; otherwise, 
+            If the field name exists, append the string metadata; otherwise,
             create the field within the DataSet object and add the string metadata.
 
         :param name: The name used to reference the string metadata field

--- a/src/python/module/smartredis/dataset.py
+++ b/src/python/module/smartredis/dataset.py
@@ -110,7 +110,7 @@ class Dataset(SRObject):
             dtype = Dtypes.tensor_from_numpy(data)
             self._data.add_tensor(name, data, dtype)
         else:
-            view_copy = data.copy(order="K")
+            view_copy = data.copy()
             dtype = Dtypes.tensor_from_numpy(view_copy)
             self._data.add_tensor(name, view_copy, dtype)
 

--- a/tests/python/test_dataset_methods.py
+++ b/tests/python/test_dataset_methods.py
@@ -102,38 +102,38 @@ def test_dim2_reverse_2D_put_get(mock_data, context):
     modified = [i.copy() for i in modified]
     add_get_arrays(dataset, modified)
 
-    modified = [i[0, ::-1] for i in data]
+
+def test_2D_transpose_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10))
+    modified = [i.transpose() for i in data]
     add_get_arrays(dataset, modified)
 
 
-# def test_2D_transpose_put_get(mock_data, context):
-#     dataset = Dataset("test-dataset")
-#     data = mock_data.create_data((10, 10))
-#     modified = [i.transpose() for i in data]
-#     add_get_arrays(dataset, modified)
+def test_2D_reshape_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10))
+    reshaped = [i.reshape((25, 4)) for i in data]
+    add_get_arrays(dataset, reshaped)
+
+    dataset = Dataset("test-dataset")
+    reshaped = [i.reshape((100, 1)) for i in data]
+    add_get_arrays(dataset, reshaped)
+
+    dataset = Dataset("test-dataset")
+    reshaped = [i.reshape((1, 100)) for i in data]
+    add_get_arrays(dataset, reshaped)
+
+    dataset = Dataset("test-dataset")
+    reshaped = [i.reshape((-1)) for i in data]
+    add_get_arrays(dataset, reshaped)
 
 
-# def test_2D_reshape_put_get(mock_data, context):
-#     dataset = Dataset("test-dataset")
-#     data = mock_data.create_data((10, 10))
-#     reshaped = [i.reshape((25, 4)) for i in data]
-#     add_get_arrays(dataset, reshaped)
-
-#     reshaped = [i.reshape((100, 1)) for i in data]
-#     add_get_arrays(dataset, reshaped)
-
-#     reshaped = [i.reshape((1, 100)) for i in data]
-#     add_get_arrays(dataset, reshaped)
-
-#     reshaped = [i.reshape((-1)) for i in data]
-#     add_get_arrays(dataset, reshaped)
-
-
-# def test_3D_transpose_put_get(mock_data, context):
-#     dataset = Dataset("test-dataset")
-#     data = mock_data.create_data((10, 10, 10))
-#     modified = [i.transpose() for i in data]
-#     add_get_arrays(dataset, modified)
+def test_3D_transpose_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10, 10))
+    modified = [i.transpose() for i in data]
+    add_get_arrays(dataset, modified)
 
 
 def test_add_get_scalar(mock_data):

--- a/tests/python/test_dataset_methods.py
+++ b/tests/python/test_dataset_methods.py
@@ -74,6 +74,68 @@ def test_add_get_tensor_3D(mock_data):
     add_get_arrays(dataset, data_3D)
 
 
+def test_dim1_modified_2D_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10))
+    modified = [i[0, :] for i in data]
+    add_get_arrays(dataset, modified)
+
+
+def test_dim2_modified_2D_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10))
+    modified = [i[:, 0] for i in data]
+    add_get_arrays(dataset, modified)
+
+
+def test_subset_2D_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10))
+    modified = [i[1:3, 5:7] for i in data]
+    add_get_arrays(dataset, modified)
+
+
+def test_dim2_reverse_2D_put_get(mock_data, context):
+    dataset = Dataset("test-dataset")
+    data = mock_data.create_data((10, 10))
+    modified = [i[::-1, 0] for i in data]
+    modified = [i.copy() for i in modified]
+    add_get_arrays(dataset, modified)
+
+    modified = [i[0, ::-1] for i in data]
+    add_get_arrays(dataset, modified)
+
+
+# def test_2D_transpose_put_get(mock_data, context):
+#     dataset = Dataset("test-dataset")
+#     data = mock_data.create_data((10, 10))
+#     modified = [i.transpose() for i in data]
+#     add_get_arrays(dataset, modified)
+
+
+# def test_2D_reshape_put_get(mock_data, context):
+#     dataset = Dataset("test-dataset")
+#     data = mock_data.create_data((10, 10))
+#     reshaped = [i.reshape((25, 4)) for i in data]
+#     add_get_arrays(dataset, reshaped)
+
+#     reshaped = [i.reshape((100, 1)) for i in data]
+#     add_get_arrays(dataset, reshaped)
+
+#     reshaped = [i.reshape((1, 100)) for i in data]
+#     add_get_arrays(dataset, reshaped)
+
+#     reshaped = [i.reshape((-1)) for i in data]
+#     add_get_arrays(dataset, reshaped)
+
+
+# def test_3D_transpose_put_get(mock_data, context):
+#     dataset = Dataset("test-dataset")
+#     data = mock_data.create_data((10, 10, 10))
+#     modified = [i.transpose() for i in data]
+#     add_get_arrays(dataset, modified)
+
+
 def test_add_get_scalar(mock_data):
     """Test adding and retrieving scalars to
     a dataset and with all datatypes

--- a/tests/python/test_put_get_tensor.py
+++ b/tests/python/test_put_get_tensor.py
@@ -71,7 +71,6 @@ def test_dim2_modified_2D_put_get(mock_data, context):
     client = Client(None, logger_name=context)
     data = mock_data.create_data((10, 10))
     modified = [i[:, 0] for i in data]
-    print("True array:\n", data[0])
     send_get_arrays(client, modified)
 
 
@@ -79,7 +78,6 @@ def test_subset_2D_put_get(mock_data, context):
     client = Client(None, logger_name=context)
     data = mock_data.create_data((10, 10))
     modified = [i[1:3, 5:7] for i in data]
-    print("True array:\n", data[0])
     send_get_arrays(client, modified)
 
 
@@ -87,13 +85,11 @@ def test_dim2_reverse_2D_put_get(mock_data, context):
     client = Client(None, logger_name=context)
     data = mock_data.create_data((10, 10))
     modified = [i[::-1, ...] for i in data]
-    print("True array:\n", data[0])
     send_get_arrays(client, modified)
 
     client = Client(None, logger_name=context)
     data = mock_data.create_data((10, 10))
     modified = [i[..., ::-1] for i in data]
-    print("True array:\n", data[0])
     send_get_arrays(client, modified)
 
 

--- a/tests/python/test_put_get_tensor.py
+++ b/tests/python/test_put_get_tensor.py
@@ -110,18 +110,12 @@ def test_2D_reshape_put_get(mock_data, context):
     reshaped = [i.reshape((25, 4)) for i in data]
     send_get_arrays(client, reshaped)
 
-    client = Client(None, logger_name=context)
-    data = mock_data.create_data((10, 10))
     reshaped = [i.reshape((100, 1)) for i in data]
     send_get_arrays(client, reshaped)
 
-    client = Client(None, logger_name=context)
-    data = mock_data.create_data((10, 10))
     reshaped = [i.reshape((1, 100)) for i in data]
     send_get_arrays(client, reshaped)
 
-    client = Client(None, logger_name=context)
-    data = mock_data.create_data((10, 10))
     reshaped = [i.reshape((-1)) for i in data]
     send_get_arrays(client, reshaped)
 
@@ -156,6 +150,7 @@ def send_get_arrays(client, data):
     for index, array in enumerate(data):
         key = f"array_{str(index)}"
         rarray = client.get_tensor(key)
+        assert rarray.dtype == array.dtype
         np.testing.assert_array_equal(
             rarray, array, "Returned array from get_tensor not equal to sent tensor"
         )

--- a/tests/python/test_put_get_tensor.py
+++ b/tests/python/test_put_get_tensor.py
@@ -24,8 +24,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import numpy as np
+import os
+
+
 from smartredis import Client
 
 # ----- Tests -----------------------------------------------------------
@@ -56,6 +58,79 @@ def test_3D_put_get(mock_data, context):
 
     data = mock_data.create_data((10, 10, 10))
     send_get_arrays(client, data)
+
+
+def test_dim1_modified_2D_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    modified = [i[0, :] for i in data]
+    send_get_arrays(client, modified)
+
+
+def test_dim2_modified_2D_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    modified = [i[:, 0] for i in data]
+    print("True array:\n", data[0])
+    send_get_arrays(client, modified)
+
+
+def test_subset_2D_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    modified = [i[1:3, 5:7] for i in data]
+    print("True array:\n", data[0])
+    send_get_arrays(client, modified)
+
+
+def test_dim2_reverse_2D_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    modified = [i[::-1, ...] for i in data]
+    print("True array:\n", data[0])
+    send_get_arrays(client, modified)
+
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    modified = [i[..., ::-1] for i in data]
+    print("True array:\n", data[0])
+    send_get_arrays(client, modified)
+
+
+def test_2D_transpose_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    modified = [i.transpose() for i in data]
+    send_get_arrays(client, modified)
+
+
+def test_2D_reshape_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    reshaped = [i.reshape((25, 4)) for i in data]
+    send_get_arrays(client, reshaped)
+
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    reshaped = [i.reshape((100, 1)) for i in data]
+    send_get_arrays(client, reshaped)
+
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    reshaped = [i.reshape((1, 100)) for i in data]
+    send_get_arrays(client, reshaped)
+
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10))
+    reshaped = [i.reshape((-1)) for i in data]
+    send_get_arrays(client, reshaped)
+
+
+def test_3D_transpose_put_get(mock_data, context):
+    client = Client(None, logger_name=context)
+    data = mock_data.create_data((10, 10, 10))
+    modified = [i.transpose() for i in data]
+    send_get_arrays(client, modified)
 
 
 # ------- Helper Functions -----------------------------------------------


### PR DESCRIPTION
NumPy tries to return views of arrays for many types of operations. This however can cause difficulties when trying to send subsets or transposes of the array because the underlying buffer that we access via PyBind11 still points to the original array. Thus the result that gets sent to the database itself is the result of striding through the original array, not the individual piece. To fix this, we detect whether the tensor the user is sending is a view and if so, make an explicit copy.