### PR TITLE
Increase build space for Github Actions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -53,7 +53,7 @@ env:
 jobs:
 
   run_tests:
-    name: Run smartredis tests using ${{ matrix.os }}, Python ${{ matrix.py_v }}, RedisAI ${{ matrix.rai_v }}, and compiler ${{ matrix.compiler }}
+    name: Run smartredis tests using ${{ matrix.os }}, Python ${{ matrix.py_v }}, and ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -69,6 +69,15 @@ jobs:
 
 
     steps:
+      # Maximize the space in this image
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-docker-images: true
+
       # download a copy of SmartRedis before running CI tests
       - uses: actions/checkout@v3
 
@@ -76,13 +85,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py_v }}
-
-      # Free up some disk space
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet &&
-          sudo rm -rf /opt/ghc &&
-          sudo rm -rf "/usr/local/share/boost"
 
       # Install compilers (Intel or GCC)
       - name: Install GCC
@@ -141,7 +143,6 @@ jobs:
           sudo apt clean
 
       # Set up perl environment for LCOV
-      - uses: actions/checkout@v3
       - name: Setup perl
         uses: shogo82148/actions-setup-perl@v1
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 8096
+          root-reserve-mb: 30720
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,9 +73,11 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
+          root-reserve-mb: 8096
           remove-dotnet: true
           remove-android: true
           remove-haskell: true
+          remove-codeql: true
           remove-docker-images: true
 
       # download a copy of SmartRedis before running CI tests


### PR DESCRIPTION
Our Github Actions require us to install Intel and Nvidia compilers which can be quite large. This leads to failures if we completely run out of space on the Github runner. This uses a new Github Action that removes unneeded packages.