### PR TITLE
Add basic concurrency groups

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,6 +40,10 @@ on:
       - master
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   HOMEBREW_NO_ANALYTICS: "ON" # Make Homebrew installation a little quicker
   HOMEBREW_NO_AUTO_UPDATE: "ON"


### PR DESCRIPTION
This PR adds concurrency groups to the `run_tests.yml` workflow, to prevent too many runners from being started by the same PR.