### PR TITLE
Remove a vestigial requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-# requirements.txt
-# Dependencies are maintained in setup.cfg
--e .


### PR DESCRIPTION
We are keeping a requirements.txt file around in the SmartRedis repo which has no apparent use. This removes the file to avoid any misunderstandings about where our dependencies come from.