### PR TITLE
Remove extra put tensor call in python client

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+0.5.2
+-----
+
+Released on February 16, 2024
+
+Description
+
+- Fixed bug which was sending tensors to the database twice (Python Client)
+
+Detailed Notes
+
+- A previous bug fix for the Python client which addressed a problem when sending
+  numpy views inadvertently kept the original put_tensor call in place. This 
+  essentially doubles the cost of the operation. (PR464_)
+
+.. _PR464: https://github.com/CrayLabs/SmartRedis/pull/464
+
+
 0.5.1
 -----
 

--- a/src/python/module/smartredis/client.py
+++ b/src/python/module/smartredis/client.py
@@ -183,7 +183,6 @@ class Client(SRObject):
         typecheck(name, "name", str)
         typecheck(data, "data", np.ndarray)
         dtype = Dtypes.tensor_from_numpy(data)
-        self._client.put_tensor(name, dtype, data)
         if data.base is None:
             self._client.put_tensor(name, dtype, data)
         else:


### PR DESCRIPTION
An accidental put_tensor call was added when attempting to fix another bug. This is a significant performance concern which is eliminated by removing this line.