### PR TITLE
Bump redis dep to 7.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ htmlcov
 .idea
 *.iml
 *.komodoproject
+.vscode
 
 # Complexity
 output/*.html

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ RPP_VER := 1.3.10
 PYBIND_URL := https://github.com/pybind/pybind11.git
 PYBIND_VER := v2.11.1
 REDIS_URL := https://github.com/redis/redis.git
-REDIS_VER := 7.0.5
+REDIS_VER := 7.2.4
 REDISAI_URL := https://github.com/RedisAI/RedisAI.git
 # REDISAI_VER is controlled instead by SR_TEST_REDISAI_VER below
 CATCH2_URL := https://github.com/catchorg/Catch2.git

--- a/utils/launch_redis.py
+++ b/utils/launch_redis.py
@@ -57,6 +57,8 @@ def check_availability(n_nodes, port, udsport):
                 sleep(5)
         if not command_succeeded:
             raise RuntimeError(f"Failed to validate availability for connection {connection}")
+    # add a small sleep after completing availability test to let cluster complete setup
+    sleep(1)
 
 def stop_db(n_nodes, port, udsport):
     """Stop a redis cluster and clear the files
@@ -205,10 +207,11 @@ def create_db(n_nodes, port, device, rai_ver, udsport):
     # Create cluster for clustered Redis request
     if n_nodes > 1:
         cluster_str = " ".join(f"127.0.0.1:{port + i}" for i in range(n_nodes))
-        cmd = f"{rediscli} --cluster create {cluster_str} --cluster-replicas 0"
+        cmd = f"{rediscli} --cluster create {cluster_str} --cluster-replicas 0 --cluster-yes"
         print(cmd)
-        proc = run(cmd.split(), input="yes", encoding="utf-8", shell=False)
+        proc = run(cmd.split(), encoding="utf-8", shell=False)
         if proc.returncode != 0:
+            print(f'{rediscli} returncode: {proc.returncode}')
             raise SubprocessError("Cluster could not be created!")
         sleep(2)
         print("Cluster has been setup!")


### PR DESCRIPTION
A fix in the build scripts of Redis 7.2.4 modifies build behavior on MacOS on Apple Silicon. The change fixes an issue where incorrect compiler flags are defined and result in build failures due to the `redis_fstat` macro