### PR TITLE
Fix inconsistency with function parameter variable names

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,14 +8,13 @@ To be released at some future point in time
 
 Description
 
-- Update the version of Redis from `7.0.4` to `7.2.4`
+- Fix inconsistency in C-API ConfigOptions is_configured() parameters
 
 Detailed Notes
 
-- Update Redis version to `7.2.4`. This change fixes an issue in the Redis
-  build scripts causing failures on Apple Silicon hosts. (SmartSim-PR507_)
+- Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
-.. _SmartSim-PR507: https://github.com/CrayLabs/SmartSim/pull/507
+.. _SmartSim-PR507: https://github.com/CrayLabs/SmartSim/pull/471
 
 
 0.5.2
@@ -25,13 +24,15 @@ Released on February 16, 2024
 
 Description
 
-- Fix inconsistency in C-API ConfigOptions is_configured() parameters
+- Fixed bug which was sending tensors to the database twice (Python Client)
 
 Detailed Notes
 
-- Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
+- A previous bug fix for the Python client which addressed a problem when sending
+  numpy views inadvertently kept the original put_tensor call in place. This 
+  essentially doubles the cost of the operation. (PR464_)
 
-.. _PR448: https://github.com/CrayLabs/SmartRedis/pull/471
+.. _PR464: https://github.com/CrayLabs/SmartRedis/pull/464
 
 
 0.5.1

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,7 +14,7 @@ Detailed Notes
 
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
-.. _SmartSim-PR507: https://github.com/CrayLabs/SmartSim/pull/471
+.. _PR471: https://github.com/CrayLabs/SmartSim/pull/471
 
 
 0.5.2

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,7 +14,7 @@ Detailed Notes
 
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
-.. _PR471: https://github.com/CrayLabs/SmartSim/pull/471
+.. _PR471: https://github.com/CrayLabs/SmartRedis/pull/471
 
 
 0.5.2

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+Development branch
+------------------
+
+To be released at some future point in time
+
+Description
+
+- Update the version of Redis from `7.0.4` to `7.2.4`
+
+Detailed Notes
+
+- Update Redis version to `7.2.4`. This change fixes an issue in the Redis
+  build scripts causing failures on Apple Silicon hosts. (SmartSim-PR507_)
+
+.. _SmartSim-PR507: https://github.com/CrayLabs/SmartSim/pull/507
+
+
 0.5.2
 -----
 
@@ -8,15 +25,13 @@ Released on February 16, 2024
 
 Description
 
-- Fixed bug which was sending tensors to the database twice (Python Client)
+- Fix inconsistency in C-API ConfigOptions is_configured() parameters
 
 Detailed Notes
 
-- A previous bug fix for the Python client which addressed a problem when sending
-  numpy views inadvertently kept the original put_tensor call in place. This 
-  essentially doubles the cost of the operation. (PR464_)
+- Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
-.. _PR464: https://github.com/CrayLabs/SmartRedis/pull/464
+.. _PR448: https://github.com/CrayLabs/SmartRedis/pull/471
 
 
 0.5.1

--- a/include/c_configoptions.h
+++ b/include/c_configoptions.h
@@ -116,8 +116,8 @@ SRError get_string_option(
 */
 SRError is_configured(
     void* c_cfgopts,
-    const char* key,
-    size_t key_len,
+    const char* option_name,
+    size_t option_name_len,
     bool* cfg_result);
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
As noted by @al-rigazzi, there is a inconsistency in function argument names for the C-interface of ``ConfigOptions``.  This PR updates the ``is_configured`` function parameter names to be consistent with other functions and the doc strings.  The change in names will not cause a break in user code, so this has not been labeled a breaking change.  