### PR TITLE
Add socket time out environment variable

### DIFF
--- a/doc/runtime.rst
+++ b/doc/runtime.rst
@@ -195,6 +195,16 @@ The user can set these environment variables to adjust command execution behavio
 and ``SR_CMD_TIMEOUT`` are read during client initialization and not
 before each command execution.
 
+The environment variable ``SR_SOCKET_TIMEOUT`` sets the time that a connection
+will wait for a reply.  The ``SR_SOCKET_TIMEOUT`` parameter is complementary to
+``SR_CONN_TIMEOUT``, ``SR_CONN_INTERVAL``, and ``SR_CMD_INTERVAL``, 
+``SR_CMD_TIMEOUT``.  That is, within each attempt
+to connect to the server or execute a command on the server there may be an
+additional delay of ``SR_SOCKET_TIMEOUT`` if the connection is unresponsive
+or the command takes a long time to execute.  If commands that
+involve large amounts of data fail (e.g. setting a very large ML model),
+the ``SR_SOCKET_TIMEOUT`` should be set to a larger value.
+
 The environment variable ``SR_THREAD_COUNT`` is used by SmartRedis to determine
 the number of threads to initialize when building a worker pool for parallel task
 execution. The default value is four. If the variable is set to zero, SmartRedis

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -581,6 +581,11 @@ class RedisServer {
         int _command_timeout;
 
         /*!
+        *   \brief Timeout (in milliseconds) of socket timeout.
+        */
+        int _socket_timeout;
+
+        /*!
         *   \brief Interval (in milliseconds) between connection attempts.
         */
         int _connection_interval;
@@ -713,6 +718,12 @@ class RedisServer {
         */
         inline static const std::string _MODEL_TIMEOUT_ENV_VAR =
             "SR_MODEL_TIMEOUT";
+
+        /*!
+        *   \brief Environment variable for socket timeout
+        */
+        inline static const std::string _SOCKET_TIMEOUT_ENV_VAR =
+            "SR_SOCKET_TIMEOUT";
 
         /*!
         *   \brief Environment variable for thread count in thread pool

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -581,7 +581,7 @@ class RedisServer {
         int _command_timeout;
 
         /*!
-        *   \brief Timeout (in milliseconds) of socket timeout.
+        *   \brief Timeout (in milliseconds) for socket reply.
         */
         int _socket_timeout;
 

--- a/src/cpp/redis.cpp
+++ b/src/cpp/redis.cpp
@@ -736,7 +736,7 @@ inline void Redis::_connect(SRAddress& db_address)
         connectOpts.type = sw::redis::ConnectionType::UNIX;
     }
     connectOpts.socket_timeout = std::chrono::milliseconds(
-        _DEFAULT_SOCKET_TIMEOUT);
+        _socket_timeout);
 
     // Connect
     for (int i = 1; i <= _connection_attempts; i++) {

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -1089,7 +1089,7 @@ inline void RedisCluster::_connect(SRAddress& db_address)
             "RedisCluster encountered a UDS request in _connect()");
     }
     connectOpts.socket_timeout = std::chrono::milliseconds(
-        _DEFAULT_SOCKET_TIMEOUT);
+        _socket_timeout);
 
     // Connect
     std::string msg;

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -47,6 +47,8 @@ RedisServer::RedisServer(ConfigOptions* cfgopts)
         _CONN_INTERVAL_ENV_VAR, _DEFAULT_CONN_INTERVAL);
     _command_timeout = _cfgopts->_resolve_integer_option(
         _CMD_TIMEOUT_ENV_VAR, _DEFAULT_CMD_TIMEOUT);
+    _socket_timeout = _cfgopts->_resolve_integer_option(
+        _SOCKET_TIMEOUT_ENV_VAR, _DEFAULT_SOCKET_TIMEOUT);
     _command_interval = _cfgopts->_resolve_integer_option(
         _CMD_INTERVAL_ENV_VAR, _DEFAULT_CMD_INTERVAL);
     _thread_count = _cfgopts->_resolve_integer_option(
@@ -167,6 +169,11 @@ inline void RedisServer::_check_runtime_variables()
                                    " must be less than "
                                    + std::to_string(INT_MAX / 1000));
     }
+
+    if (_socket_timeout <= 0) {
+        throw SRParameterException(_SOCKET_TIMEOUT_ENV_VAR +
+                                   " must be greater than 0.");
+    }
 }
 
 // Create a string representation of the Redis connection
@@ -201,6 +208,8 @@ std::string RedisServer::to_string() const
            + std::to_string(_connection_interval) + "\n";
     result += "    Attempt timeout (ms): "
            + std::to_string(_connection_timeout) + "\n";
+    result += "    Socket timeout (ms): "
+           + std::to_string(_socket_timeout) + "\n";
 
     // Threadpool
     result += "  Threadpool: " + std::to_string(_thread_count) + " threads\n";

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -62,12 +62,14 @@ class RedisTest : public Redis
         int get_connection_interval() {return _connection_interval;}
         int get_command_timeout() {return _command_timeout;}
         int get_command_interval() {return _command_interval;}
+        int get_socket_timeout() {return _socket_timeout;}
         int get_connection_attempts() {return _connection_attempts;}
         int get_command_attempts() {return _command_attempts;}
         int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
         int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
         int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
         int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
+        int get_default_socket_timeout() {return _DEFAULT_SOCKET_TIMEOUT;}
 };
 
 class RedisClusterTest : public RedisCluster
@@ -78,12 +80,14 @@ class RedisClusterTest : public RedisCluster
         int get_connection_interval() {return _connection_interval;}
         int get_command_timeout() {return _command_timeout;}
         int get_command_interval() {return _command_interval;}
+        int get_socket_timeout() {return _socket_timeout;}
         int get_connection_attempts() {return _connection_attempts;}
         int get_command_attempts() {return _command_attempts;}
         int get_default_conn_timeout() {return _DEFAULT_CONN_TIMEOUT;}
         int get_default_conn_interval() {return _DEFAULT_CONN_INTERVAL;}
         int get_default_cmd_timeout() {return _DEFAULT_CMD_TIMEOUT;}
         int get_default_cmd_interval() {return _DEFAULT_CMD_INTERVAL;}
+        int get_default_socket_timeout() {return _DEFAULT_SOCKET_TIMEOUT;}
 };
 
 // For simplicity, define constants for environment variables outside
@@ -92,6 +96,7 @@ const char* CONN_TIMEOUT_ENV_VAR = "SR_CONN_TIMEOUT";
 const char* CONN_INTERVAL_ENV_VAR = "SR_CONN_INTERVAL";
 const char* CMD_TIMEOUT_ENV_VAR = "SR_CMD_TIMEOUT";
 const char* CMD_INTERVAL_ENV_VAR = "SR_CMD_INTERVAL";
+const char* SOCKET_TIMEOUT_ENV_VAR = "SR_SOCKET_TIMEOUT";
 
 // Helper method to invoke the constructor when we expect an
 // error to be thrown
@@ -116,6 +121,7 @@ void unset_all_env_vars()
         unsetenv(CONN_INTERVAL_ENV_VAR);
         unsetenv(CMD_TIMEOUT_ENV_VAR);
         unsetenv(CMD_INTERVAL_ENV_VAR);
+        unsetenv(SOCKET_TIMEOUT_ENV_VAR);
 }
 
 // Helper function to retrieve original versions of environment vars
@@ -123,12 +129,14 @@ void save_env_vars(
     char** conn_timeout,
     char** conn_interval,
     char** cmd_timeout,
-    char** cmd_interval)
+    char** cmd_interval
+    char** socket_timeout)
 {
     *conn_timeout = getenv(CONN_TIMEOUT_ENV_VAR);
     *conn_interval = getenv(CONN_INTERVAL_ENV_VAR);
     *cmd_timeout = getenv(CMD_TIMEOUT_ENV_VAR);
     *cmd_interval = getenv(CMD_INTERVAL_ENV_VAR);
+    *socket_timeout = genenv(SOCKET_TIMEOUT_ENV_VAR);
 }
 
 // Helper function to restore environment vars
@@ -136,7 +144,8 @@ void restore_env_vars(
     char* conn_timeout,
     char* conn_interval,
     char* cmd_timeout,
-    char* cmd_interval)
+    char* cmd_interval,
+    char* socket_timeout)
 {
     if (conn_timeout != NULL)
         setenv(CONN_TIMEOUT_ENV_VAR, conn_timeout, 1);
@@ -154,6 +163,10 @@ void restore_env_vars(
         setenv(CMD_INTERVAL_ENV_VAR, cmd_interval, 1);
     else
         unsetenv(CMD_INTERVAL_ENV_VAR);
+    if (socket_timeout != NULL)
+        setenv(SOCKET_TIMEOUT_ENV_VAR, socket_timeout, 1);
+    else
+        unsetenv(SOCKET_TIMEOUT_ENV_VAR);
 }
 
 // Helper function to check that all default values being used
@@ -171,6 +184,9 @@ void check_all_defaults(T& server)
 
     CHECK(server.get_command_interval() ==
           server.get_default_cmd_interval());
+
+    CHECK(server.get_socket_timeout() ==
+          server.get_default_socket_timeout());
 }
 
 SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
@@ -186,7 +202,8 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     char* __conn_interval;
     char* __cmd_timeout;
     char* __cmd_interval;
-    save_env_vars(&__conn_timeout, &__conn_interval, &__cmd_timeout, &__cmd_interval);
+    char* __socket_timeout;
+    save_env_vars(&__conn_timeout, &__conn_interval, &__cmd_timeout, &__cmd_interval, &__socket_interval);
 
     GIVEN("A Redis derived object created with all environment variables unset")
     {
@@ -213,6 +230,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         setenv(CONN_INTERVAL_ENV_VAR, "", true);
         setenv(CMD_TIMEOUT_ENV_VAR, "", true);
         setenv(CMD_INTERVAL_ENV_VAR, "", true);
+        setenv(SOCKET_TIMEOUT_ENV_VAR, "", true);
 
         if (use_cluster()) {
             RedisClusterTest redis_server(cfgopts);
@@ -237,12 +255,14 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
         int cmd_interval = 250; //milliseconds
         int expected_conn_attempts = 11;
         int expected_cmd_attempts = 9;
+        int socket_timeout = 10; //milliseconds
 
         unset_all_env_vars();
         setenv(CONN_TIMEOUT_ENV_VAR, std::to_string(conn_timeout).c_str(), true);
         setenv(CONN_INTERVAL_ENV_VAR, std::to_string(conn_interval).c_str(), true);
         setenv(CMD_TIMEOUT_ENV_VAR, std::to_string(cmd_timeout).c_str(), true);
         setenv(CMD_INTERVAL_ENV_VAR, std::to_string(cmd_interval).c_str(), true);
+        setenv(SOCKET_TIMEOUT_ENV_VAR, std::to_string(socket_timeout).c_str(), true);
 
         if (use_cluster()) {
             RedisClusterTest redis_server(cfgopts);
@@ -261,6 +281,9 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
                       cmd_interval);
                 CHECK(redis_server.get_command_attempts() ==
                       expected_cmd_attempts);
+
+                CHECK(redis_server.get_socket_timeout() ==
+                      socket_timeout);
             }
         }
         else {
@@ -280,6 +303,9 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
                       cmd_interval);
                 CHECK(redis_server.get_command_attempts() ==
                       expected_cmd_attempts);
+
+                CHECK(redis_server.get_socket_timeout() ==
+                      socket_timeout);
             }
         }
     }
@@ -310,7 +336,15 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
             CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
-
+    GIVEN("A negative value of " +  std::string(SOCKET_TIMEOUT_ENV_VAR))
+    {
+        unset_all_env_vars();
+        setenv(SOCKET_TIMEOUT_ENV_VAR, "-3", true);
+        THEN("Constructor throws an exception")
+        {
+            CHECK_THROWS_AS(invoke_constructor(), ParameterException);
+        }
+    }
     GIVEN("A negative value of " + std::string(CMD_INTERVAL_ENV_VAR))
     {
         unset_all_env_vars();

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -136,7 +136,7 @@ void save_env_vars(
     *conn_interval = getenv(CONN_INTERVAL_ENV_VAR);
     *cmd_timeout = getenv(CMD_TIMEOUT_ENV_VAR);
     *cmd_interval = getenv(CMD_INTERVAL_ENV_VAR);
-    *socket_timeout = genenv(SOCKET_TIMEOUT_ENV_VAR);
+    *socket_timeout = getenv(SOCKET_TIMEOUT_ENV_VAR);
 }
 
 // Helper function to restore environment vars
@@ -203,7 +203,7 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
     char* __cmd_timeout;
     char* __cmd_interval;
     char* __socket_timeout;
-    save_env_vars(&__conn_timeout, &__conn_interval, &__cmd_timeout, &__cmd_interval, &__socket_interval);
+    save_env_vars(&__conn_timeout, &__conn_interval, &__cmd_timeout, &__cmd_interval, &__socket_timeout);
 
     GIVEN("A Redis derived object created with all environment variables unset")
     {

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -129,7 +129,7 @@ void save_env_vars(
     char** conn_timeout,
     char** conn_interval,
     char** cmd_timeout,
-    char** cmd_interval
+    char** cmd_interval,
     char** socket_timeout)
 {
     *conn_timeout = getenv(CONN_TIMEOUT_ENV_VAR);

--- a/tests/cpp/unit-tests/test_redisserver.cpp
+++ b/tests/cpp/unit-tests/test_redisserver.cpp
@@ -397,6 +397,6 @@ SCENARIO("Test runtime settings are initialized correctly", "[RedisServer]")
             CHECK_THROWS_AS(invoke_constructor(), ParameterException);
         }
     }
-    restore_env_vars(__conn_timeout, __conn_interval, __cmd_timeout, __cmd_interval);
+    restore_env_vars(__conn_timeout, __conn_interval, __cmd_timeout, __cmd_interval, __socket_timeout);
     log_data(context, LLDebug, "***End RedisServer testing***");
 }


### PR DESCRIPTION
This PR adds the socket timeout parameter as a user-configurable option via environment variables.  This is important because for commands such as ``set_model`` with large models, the internal socket timeout may be exceeded and multiple retries will have no positive affect because more time is needed to complete the action.