### PR TITLE
Update CI for Intel

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -121,8 +121,7 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
             | sudo tee /etc/apt/sources.list.d/oneAPI.list &&
           sudo apt update -y && \
-          sudo apt install -y intel-oneapi-compiler-fortran-${INTEL_V} intel-oneapi-compiler-dpcpp-cpp-${INTEL_V} &&
-          sudo apt install -y intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-mkl &&
+          sudo apt install -y intel-basekit-${INTEL_V} intel-hpckit-${INTEL_V} &&
           source /opt/intel/oneapi/setvars.sh &&
           printenv >> $GITHUB_ENV &&
           echo "CC=icx" >> $GITHUB_ENV &&

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,12 +8,17 @@ To be released at some future point in time
 
 Description
 
+- Update CI for Intel suite
 - Fix inconsistency in C-API ConfigOptions is_configured() parameters
 
 Detailed Notes
 
+- Version numbers changed for the Intel Compiler chain that lead to the C and C++
+  compilers not being available. Now, the entirety of the Base and HPC kits are
+  installed to ensure consistent versions. (PR475_)
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
+.. _PR475: https://github.com/CrayLabs/SmartRedis/pull/475
 .. _PR471: https://github.com/CrayLabs/SmartRedis/pull/471
 
 


### PR DESCRIPTION
The Github Actions CI was failing because the Intel OneAPI C-compiler, icx, could not be found. This issue was tracked down to the fact that if the versions are not consistent between all the packages, the Intel-provided script that sets up the environment misses some components. This updates the CI to install the entirety of the base and HPC kits for Intel OneAPI. While this takes a significant amount of storage, this is "safest" option for now.