### PR TITLE
Remove unused parameter model name in _get_model_script_db()

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,16 +8,20 @@ To be released at some future point in time
 
 Description
 
+- Remove unused parameter in internal redis cluster method
 - Update CI for Intel suite
 - Fix inconsistency in C-API ConfigOptions is_configured() parameters
 
 Detailed Notes
 
+- Removes an unused parameter in the RedisCluster::_get_model_script_db()
+  method. (PR477_)
 - Version numbers changed for the Intel Compiler chain that lead to the C and C++
   compilers not being available. Now, the entirety of the Base and HPC kits are
   installed to ensure consistent versions. (PR475_)
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
+.. _PR477: https://github.com/CrayLabs/SmartRedis/pull/477
 .. _PR475: https://github.com/CrayLabs/SmartRedis/pull/475
 .. _PR471: https://github.com/CrayLabs/SmartRedis/pull/471
 

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -738,16 +738,17 @@ class RedisCluster : public RedisServer
                                 std::vector<std::string> outputs);
 
         /*!
-        *   \brief  Retrieve the optimum model prefix for
-        *           the set of inputs
-        *   \param name The name of the model
+        *   \brief  Retrieve the db node in the cluster that contains
+        *           the most input and output tensors.  If multiple
+        *           db nodes contain the same amount of input and
+        *           output tensors, the first db node in the internal
+        *           data structure is returned.
         *   \param inputs The keys of inputs tensors to use
         *                 in the model
         *   \param outputs The keys of output tensors that
         *                 will be used to save model results
         */
-        DBNode* _get_model_script_db(const std::string& name,
-                                     std::vector<std::string>& inputs,
+        DBNode* _get_model_script_db(std::vector<std::string>& inputs,
                                      std::vector<std::string>& outputs);
 
         /*!

--- a/src/cpp/rediscluster.cpp
+++ b/src/cpp/rediscluster.cpp
@@ -1410,14 +1410,13 @@ void RedisCluster::_delete_keys(std::vector<std::string> keys)
     (void)run(cmd);
 }
 
-// Retrieve the optimum model prefix for the set of inputs
-DBNode* RedisCluster::_get_model_script_db(const std::string& name,
-                                           std::vector<std::string>& inputs,
+// Retrieve the optimum db node for model and script execution
+DBNode* RedisCluster::_get_model_script_db(std::vector<std::string>& inputs,
                                            std::vector<std::string>& outputs)
 {
-    /* This function calculates the optimal model name to use
-    to run the provided inputs.  If a cluster is not being used,
-    the model name is returned, else a prefixed model name is returned.
+    /* This function determines which db node in the cluster
+    contains the most input and output tensors and 
+    returns a pointer to that db node. 
     */
 
     // TODO we should randomly choose the max if there are multiple maxes


### PR DESCRIPTION
This PR removes an unused parameter in ``RedisCluster::_get_model_script_db()``.  The comments for the function were also corrected to reflect the actual behavior of the function.  It is worth noting that _get_model_script_db is not called currently in SmartRedis, but it was not removed because it was a precursor implementation for optimizing model execution.