### PR TITLE
Enforce matching type for dataset::unpack_tensor

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,16 +8,20 @@ To be released at some future point in time
 
 Description
 
+- Enforce matching TensorType for DataSet::unpack_tensor()
 - Update CI for Intel suite
 - Fix inconsistency in C-API ConfigOptions is_configured() parameters
 
 Detailed Notes
 
+- Client::unpack_tensor() enforces that the user-provided TensorType matches the
+  known tensor type.  Now DataSet::unpack_tensor() enforces the same condition. (PR478_)
 - Version numbers changed for the Intel Compiler chain that lead to the C and C++
   compilers not being available. Now, the entirety of the Base and HPC kits are
   installed to ensure consistent versions. (PR475_)
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
+.. _PR478: https://github.com/CrayLabs/SmartRedis/pull/478
 .. _PR475: https://github.com/CrayLabs/SmartRedis/pull/475
 .. _PR471: https://github.com/CrayLabs/SmartRedis/pull/471
 

--- a/include/dataset.h
+++ b/include/dataset.h
@@ -476,6 +476,15 @@ class DataSet : public SRObject
         inline void _enforce_tensor_exists(const std::string& name) const;
 
         /*!
+        *   \brief Throw an exception if the provided tensor type does not match
+        *          the internal tensor type
+        *   \throw RuntimeException if the provided tensor type does not match
+        *          the internal tensor type
+        */
+        inline void _enforce_tensor_type(const std::string& tensorname,
+                                         const SRTensorType& type) const;
+
+        /*!
         *   \brief SharedMemoryList to manage memory associated
         *          with tensor dimensions from tensor retrieval
         */

--- a/src/cpp/dataset.cpp
+++ b/src/cpp/dataset.cpp
@@ -153,6 +153,7 @@ void DataSet::unpack_tensor(const std::string& name,
     LOG_API_FUNCTION();
 
     _enforce_tensor_exists(name);
+    _enforce_tensor_type(name, type);
     _tensorpack.get_tensor(name)->fill_mem_space(data, dims, mem_layout);
 }
 
@@ -375,6 +376,22 @@ inline void DataSet::_enforce_tensor_exists(const std::string& tensorname) const
         throw SRKeyException("The tensor \"" + std::string(tensorname) +
                              "\" does not exist in dataset \"" +
                              _dsname + "\".");
+    }
+}
+
+// Check that the provided tensor type matches the internal tensor type
+inline void DataSet::_enforce_tensor_type(const std::string& tensorname,
+                                          const SRTensorType& type) const
+{
+    _enforce_tensor_exists(tensorname);
+
+    SRTensorType known_type = _tensorpack.get_tensor(tensorname)->type();
+
+    if (known_type != type) {
+        throw SRRuntimeException("The tensor \"" + std::string(tensorname) +
+                                 "\" has type \"" + TENSOR_STR_MAP.at(known_type) +
+                                 "\" in dataset \"" + _dsname + "\" but the provided " +
+                                 "type is " "\"" + TENSOR_STR_MAP.at(type) + "\".");
     }
 }
 

--- a/tests/cpp/unit-tests/test_dataset.cpp
+++ b/tests/cpp/unit-tests/test_dataset.cpp
@@ -146,6 +146,23 @@ SCENARIO("Testing DataSet object", "[DataSet]")
                     SmartRedis::KeyException
                 );
             }
+
+            THEN("The tensor cannot be retrieved via unpack_tensor() "
+                 "if the specified type does not match")
+            {
+                void* retrieved_data =
+                    malloc(dims[0] * dims[1] * dims[2] * sizeof(float));
+
+                SRTensorType wrong_type = SRTensorTypeDouble;
+
+                CHECK_THROWS_AS(
+                    dataset.unpack_tensor(tensor_name, retrieved_data,
+                                          dims, wrong_type, mem_layout),
+                    SmartRedis::RuntimeException
+                );
+
+                free(retrieved_data);
+            }
         }
 
         AND_WHEN("A meta scalar is added to the DataSet")


### PR DESCRIPTION
``Client.unpack_tensor()`` enforces that the user-provided ``TensorType`` matches the internally known type.  This check was not added to ``DataSet::unpack_tensor()``, although the information is available.  This check was added to resolve a compiler warning regarding the unused ``TensorType`` function parameter.