### PR TITLE
Remove unused memory layout constructor parameter for TensorBase.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,16 +8,21 @@ To be released at some future point in time
 
 Description
 
+- Removed unused TensorBase constructor parameter
 - Update CI for Intel suite
 - Fix inconsistency in C-API ConfigOptions is_configured() parameters
 
 Detailed Notes
 
+- The TensorBase constructor SRMemoryLayout parameter was removed because it was
+  not used.  It is not needed as a member variable because all Tensor<T> objects
+  store internal representations in contiguous memory. (PR479_)
 - Version numbers changed for the Intel Compiler chain that lead to the C and C++
   compilers not being available. Now, the entirety of the Base and HPC kits are
   installed to ensure consistent versions. (PR475_)
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
+.. _PR479: https://github.com/CrayLabs/SmartRedis/pull/479
 .. _PR475: https://github.com/CrayLabs/SmartRedis/pull/475
 .. _PR471: https://github.com/CrayLabs/SmartRedis/pull/471
 

--- a/include/tensor.tcc
+++ b/include/tensor.tcc
@@ -38,7 +38,7 @@ Tensor<T>::Tensor(const std::string& name,
                   const std::vector<size_t>& dims,
                   const SRTensorType type,
                   const SRMemoryLayout mem_layout) :
-                  TensorBase(name, data, dims, type, mem_layout)
+                  TensorBase(name, data, dims, type)
 {
     _set_tensor_data(data, dims, mem_layout);
 }

--- a/include/tensorbase.h
+++ b/include/tensorbase.h
@@ -97,8 +97,7 @@ class TensorBase{
         TensorBase(const std::string& name,
                    const void* data,
                    const std::vector<size_t>& dims,
-                   const SRTensorType type,
-                   const SRMemoryLayout mem_layout);
+                   const SRTensorType type);
 
         /*!
         *   \brief TensorBase copy constructor

--- a/src/cpp/tensorbase.cpp
+++ b/src/cpp/tensorbase.cpp
@@ -36,8 +36,7 @@ using namespace SmartRedis;
 TensorBase::TensorBase(const std::string& name,
                        const void* data,
                        const std::vector<size_t>& dims,
-                       const SRTensorType type,
-                       const SRMemoryLayout mem_layout)
+                       const SRTensorType type)
 {
     /* The TensorBase constructor makes a copy of the
     name, type, and dims associated with the tensor.


### PR DESCRIPTION
The ``TensorBase`` object has an ``SRMemoryLayout`` parameter that is not used.  The ``SRMemoryLayout`` is only used by the child ``Tensor<T>`` class.  Because all tensors are stored internally has contiguous memory, there is no need to have it stored as a member variable.  It has been removed to avoid compiler warnings.