### PR TITLE
[no-merge] Drop python 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Build sdist
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.7] # versions of RedisAI
-        py_v: ['3.8.x', '3.9.x', '3.10.x', '3.11.x'] # versions of Python
+        py_v: ['3.9.x', '3.10.x', '3.11.x'] # versions of Python
         compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12] # intel compiler, and versions of GNU compiler
         link_type: [Static, Shared]
     env:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SmartRedis provides clients in the following languages:
 
 | Language   | Version/Standard                               |
 |------------|:----------------------------------------------:|
-| Python     |   3.8, 3.9, 3.10, 3.11                         |
+| Python     |   3.9, 3.10, 3.11                         |
 | C++        |   C++17                                        |
 | C          |   C99                                          |
 | Fortran    |   Fortran 2018 (GNU/Intel), 2003 (PGI/Nvidia)  |

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -50,7 +50,7 @@ below summarizes the language standards for each client.
    * - Language
      - Version/Standard
    * - Python
-     - 3.8-3.11
+     - 3.9-3.11
    * - C++
      - C++17
    * - C

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py39', 'py310']
 exclude = '''
 (
   | \.egg

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ contact_email = craylabs@hpe.com
 license = BSD 2-Clause License
 keywords = redis, clients, hpc, ai, deep learning
 classifiers =
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -34,7 +33,7 @@ setup_requires =
 include_package_data = True
 install_requires =
     numpy>=1.18.2
-python_requires = >=3.8,<3.12
+python_requires = >=3.9,<3.12
 
 
 [options.extras_require]


### PR DESCRIPTION
Python 3.8 is no longer going to be supported because it's near end of life. I've gone through and removed/updated everything that I could find! I added no-merge because I am not sure if there's a specific order that we need to merge all the repos.