### PR TITLE
Upgrade ubuntu to version 22.04 and gcc to version 11

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,8 +46,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12]
-        gcc_v: [8] # Version of GFortran we want to use.
+        os: [ubuntu-22.04, macos-12]
+        gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12]
-        gcc_v: [8] # Version of GFortran we want to use.
+        os: [ubuntu-22.04, macos-12]
+        gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ To be released at some future point in time
 
 Description
 
+- Upgrade ubuntu to 22.04 and gcc to 11
 - Drop Python 3.8 support
 - Fix C++ cosmetic defects leading to compiler warnings
 - Enforce changelog updates
@@ -19,6 +20,8 @@ Description
 
 Detailed Notes
 
+- After dropping support for Python 3.8, ubuntu and gcc need to be upgraded.
+  (PR484_)
 - Python 3.8 is reaching its end-of-life in October, 2024, so it will
   no longer continue to be supported. (PR482_)
 - Fixes some mainly cosmetic defects in the C++ client that were leading to warnings
@@ -38,6 +41,7 @@ Detailed Notes
   installed to ensure consistent versions. (PR475_)
 - Fix an inconsistency in the C-API ConfigOptions is_configured() parameter names. (PR471_)
 
+.. _PR484: https://github.com/CrayLabs/SmartRedis/pull/484
 .. _PR482: https://github.com/CrayLabs/SmartRedis/pull/482
 .. _PR476: https://github.com/CrayLabs/SmartRedis/pull/476
 .. _PR480: https://github.com/CrayLabs/SmartRedis/pull/480


### PR DESCRIPTION
After dropping python 3.8, there's been some issues with ubuntu versions and gcc version for the smartsim dev docs. Upgrading ubuntu to 22.04 is necessary now that we've dropped support for python 3.8 and should solve the problem.