### PR TITLE
Ensure all reply errors are logged

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at some future point in time
 
 Description
 
+-   Improve client error logging
 -   Fix pylint regression error
 -   Fix build wheel error
 -   Fix header styling issue
@@ -29,6 +30,8 @@ Description
 
 Detailed Notes
 
+-   Ensure errors raised from client include details
+    ([PR485](https://github.com/CrayLabs/SmartRedis/pull/485))
 -   Pin pylint to fix regression error
     ([PR492](https://github.com/CrayLabs/SmartRedis/pull/492))
 -   Add cstdint import to fix ubuntu with gcc wheel build

--- a/include/client.h
+++ b/include/client.h
@@ -1751,6 +1751,13 @@ class Client : public SRObject
         */
        void _establish_server_connection();
 
+       /*!
+        *   \brief Augment exceptions with underlying connection errors
+        *   \param reply The CommandReply to inspect for errors
+        *   \param error_message The base error message to raise
+        *   \throw SmartRedis::Exception if poll list length command fails
+        */
+       void _report_reply_errors(CommandReply &reply, std::string error_message);
 };
 
 /*!


### PR DESCRIPTION
During testing, @AlyssaCote noticed `SmartRedis` logging a variety of misleading errors when a database was unreachable. This change improves error handling by ensuring that the underlying error is logged.

```log
SmartRedis Library@12-38-02:WARNING: Environment variable SR_LOG_FILE is not set. Defaulting to stdout
SmartRedis Library@12-38-02:WARNING: Environment variable SR_LOG_LEVEL is not set. Defaulting to INFO
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'save') - Invalid save parameters
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'save') - Invalid save parameters
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'maxmemory') - argument must be a memory value
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'maxmemory') - argument must be a memory value
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'maxclients') - argument must be between 1 and 4294967295 inclusive
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'maxclients') - argument couldn't be parsed into an integer
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'maxclients') - argument couldn't be parsed into an integer
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'proto-max-bulk-len') - argument must be between 1048576 and 9223372036854775807 inclusive
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'proto-max-bulk-len') - argument must be a memory value
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'proto-max-bulk-len') - argument must be a memory value
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR CONFIG SET failed (possibly related to argument 'maxmemory-policy') - argument(s) must be one of the following: volatile-lru, volatile-lfu, volatile-random, volatile-ttl, allkeys-lru, allkeys-lfu, allkeys-random, noeviction
SmartRedis Library@12-38-02:ERROR: Exception at "/project/src/cpp/redis.cpp", line 692: Redis error when executing command: ERR Unknown option or number of arguments for CONFIG SET - 'invalid-parameter'
PASSED
```