### PR TITLE
Readthedocs changelog errors

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -704,7 +704,7 @@ Detailed Notes
 
 ## 0.3.0
 
-Released on Febuary 11, 2022
+Released on February 11, 2022
 
 Description
 
@@ -714,15 +714,14 @@ Description
     ([PR199](https://github.com/CrayLabs/SmartRedis/pull/199))
     ([PR205](https://github.com/CrayLabs/SmartRedis/pull/205))
     ([PR206](https://github.com/CrayLabs/SmartRedis/pull/206))
-    -   Includes changes to C and Fortran function prototypes that are
-        not backwards compatible
-    -   Includes changes to error class names and enum type names that
-        are not backwards compatible
+    Includes changes to C and Fortran function prototypes that are
+    not backwards compatible. Includes changes to error class names
+    and enum type names that are not backwards compatible
 -   Add `poll_dataset` functionality to all SmartRedis clients
     ([PR184](https://github.com/CrayLabs/SmartRedis/pull/184))
-    -   Due to other breaking changes made in this release, applications
-        using methods other than `poll_dataset` to check for the
-        existence of a dataset should now use `poll_dataset`
+    Due to other breaking changes made in this release, applications
+    using methods other than `poll_dataset` to check for the
+    existence of a dataset should now use `poll_dataset`
 -   Add environment variables to control client connection and command
     timeout behavior
     ([PR194](https://github.com/CrayLabs/SmartRedis/pull/194))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at some future point in time
 
 Description
 
+-   Correct changelog indention
 -   Automate the creation of release notes
 -   Auto-post release PR to develop from master
 -   Upgrade ubuntu to 22.04 and gcc to 11
@@ -25,6 +26,9 @@ Description
 
 Detailed Notes
 
+-   After converting from rst to md, readthedocs began throwing indention
+    errors in old release info. This fixes the styling.
+    ([PR488](https://github.com/CrayLabs/SmartRedis/pull/488))
 -   Add a configuration file to the root of .github/ to configure
     the generated release notes.
     ([PR487](https://github.com/CrayLabs/SmartRedis/pull/487))


### PR DESCRIPTION
After converting the changelog from rst to md, readthedocs throws errors from old documented releases. This PR formats the changelog correctly.

The Errors:
../smartredis/doc/changelog.md:718: ERROR: Unexpected indentation.
../smartredis/doc/changelog.md:719: WARNING: Block quote ends without a blank line; unexpected unindent.
../smartredis/doc/changelog.md:724: ERROR: Unexpected indentation.