### PR TITLE
Fix build wheel

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at some future point in time
 
 Description
 
+-   Fix build wheel error
 -   Fix header styling issue
 -   Correct changelog indention
 -   Automate the creation of release notes
@@ -27,6 +28,8 @@ Description
 
 Detailed Notes
 
+-   Add cstdint import to fix ubuntu with gcc wheel build
+    ([PR491](https://github.com/CrayLabs/SmartRedis/pull/491))
 -   Incorrect lineup of the changelog page index. This fixes the header
     sizes to avoid this issue.
     ([PR489](https://github.com/CrayLabs/SmartRedis/pull/489))

--- a/include/metadatabuffer.h
+++ b/include/metadatabuffer.h
@@ -33,6 +33,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <cstdint>
 #include "srexception.h"
 
 using namespace SmartRedis;


### PR DESCRIPTION
Compiler errors have shown up in the build wheel for SmartRedis.  This PR aims to fix those compiler errors.