### PR TITLE
Pin pylint to fix regression error

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at some future point in time
 
 Description
 
+-   Fix pylint regression error
 -   Fix build wheel error
 -   Fix header styling issue
 -   Correct changelog indention
@@ -28,6 +29,8 @@ Description
 
 Detailed Notes
 
+-   Pin pylint to fix regression error
+    ([PR492](https://github.com/CrayLabs/SmartRedis/pull/492))
 -   Add cstdint import to fix ubuntu with gcc wheel build
     ([PR491](https://github.com/CrayLabs/SmartRedis/pull/491))
 -   Incorrect lineup of the changelog page index. This fixes the header

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ dev =
     pytest-cov==2.10.1
     black==23.3.0
     isort==5.6.4
-    pylint>=2.10.0
+    pylint>=2.10.0,<3.2.0
     torch<=2.0.1
     mypy>=1.4.0
     typing_extensions


### PR DESCRIPTION
Fix a regression error in latest version of pylint by pinning to known, good version.