### PR TITLE
Remove broken redis documentation links

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ Released on 14 May 2024
 
 Description
 
+-   Remove broken oss.redis.com URLs from documentation
 -   Pin NumPy version to 1.x
 -   Improve client error logging
 -   Fix pylint regression error

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -17,10 +17,7 @@ In addition to the RedisAI capabilities above,
 SmartRedis includes the following features developed for
 large, distributed HPC architectures:
 
--   Redis cluster support for RedisAI data types
-    (`tensors <https://oss.redis.com/redisai/intro/#using-redisai-tensors>`__,
-    `models <https://oss.redis.com/redisai/intro/#loading-models>`__,
-    and `scripts <https://oss.redis.com/redisai/intro/#scripting>`__).
+-   Redis cluster support for RedisAI data types (`tensors`, `models`, and `scripts`).
 -   Distributed model and script placement for parallel
     evaluation that maximizes hardware utilization and throughput
 -   A ``DataSet`` storage format to aggregate multiple tensors


### PR DESCRIPTION
This PR will remove 3 broken links to `oss.redis.com` that are breaking the documentation build