### PR TITLE
Update CMake ExternalProject instructions

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,8 @@ To be released at some future point in time
 
 Description
 
+-   Fix instructions for including SmartRedis as an ExternalProject
+    in CMake-based projects
 -   Touch-up outdated information in README.md
 -   Update codecov to v4.5.0 for github actions
 -   Remove broken oss.redis.com URLs from documentation
@@ -20,6 +22,10 @@ Description
 
 Detailed Notes
 
+-   Instructions for including SmartRedis as a CMake ExternalProject
+    had a couple of missing closing parentheses and typo in the
+    definition of the libsmartredis-fortran block
+    ([PR503](https://github.com/CrayLabs/SmartRedis/pull/503))
 -   Update links to install documentation and remove outdated version
     numbers in the README.md
     ([PR501](https://github.com/CrayLabs/SmartRedis/pull/501))

--- a/doc/install/lib.rst
+++ b/doc/install/lib.rst
@@ -224,13 +224,15 @@ Most applications should be able to incorporate the following into their
     set_target_properties(libsmartredis PROPERTIES
         IMPORTED_LOCATION ${binary_dir}/libsmartredis.so
         INTERFACE_INCLUDE_DIRECTORIES  $<INSTALL_INTERFACE:${CMAKE_BINARY_DIR}/external/include}>
+    )
 
     # Optional, only for Fortran applications
     add_library(libsmartredis-fortran SHARED IMPORTED)
     add_dependencies(libsmartredis-fortran smartredis)
-    set_target_properties(libsmartredis PROPERTIES
+    set_target_properties(libsmartredis-fortran PROPERTIES
         IMPORTED_LOCATION ${binary_dir}/libsmartredis-fortran.so
         INTERFACE_INCLUDE_DIRECTORIES  $<INSTALL_INTERFACE:${CMAKE_BINARY_DIR}/external/include}>
+    )
 
     # ... define the example_target executable here
 


### PR DESCRIPTION
Fixes some typos present in the documentation that describe how to include SmartRedis as a CMake ExternalProject.