### PR TITLE
Add gcc-14 support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -88,6 +88,6 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
+        os: [ubuntu-24.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.7] # versions of RedisAI
         py_v: ['3.9.x', '3.10.x', '3.11.x'] # versions of Python
         compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12, gcc-14] # intel compiler, and versions of GNU compiler

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -65,7 +65,7 @@ jobs:
         os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.7] # versions of RedisAI
         py_v: ['3.9.x', '3.10.x', '3.11.x'] # versions of Python
-        compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12] # intel compiler, and versions of GNU compiler
+        compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12, gcc-14] # intel compiler, and versions of GNU compiler
         link_type: [shared, static]
     env:
       COMPILER: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -62,10 +62,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04] # cannot test on macOS as docker isn't supported on Mac
+        os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.7] # versions of RedisAI
         py_v: ['3.9.x', '3.10.x', '3.11.x'] # versions of Python
-        compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12, gcc-14] # intel compiler, and versions of GNU compiler
+        compiler: [nvhpc-23-11, intel-2024.0, gcc-11, gcc-12] # intel compiler, and versions of GNU compiler
         link_type: [shared, static]
     env:
       COMPILER: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,7 +6,8 @@ To be released at some future point in time
 
 Description
 
--   Include algorithm import in rediscluster for gcc-14
+-   Include algorithm import in rediscluster for gcc-14 and
+    updated github artifact version
 -   Touch-up outdated information in README.md
 -   Update codecov to v4.5.0 for github actions
 -   Remove broken oss.redis.com URLs from documentation
@@ -22,7 +23,8 @@ Description
 Detailed Notes
 
 -   Include algorithm import in rediscluster.h to satisfy
-    gcc-14 compilation error.
+    gcc-14 compilation error and update github actions to
+    upload-artifact@v3
     ([PR505](https://github.com/CrayLabs/SmartRedis/pull/505))
 -   Update links to install documentation and remove outdated version
     numbers in the README.md

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -23,6 +23,7 @@ Detailed Notes
 
 -   Include algorithm import in rediscluster.h to satisfy
     gcc-14 compilation error.
+    ([PR505](https://github.com/CrayLabs/SmartRedis/pull/505))
 -   Update links to install documentation and remove outdated version
     numbers in the README.md
     ([PR501](https://github.com/CrayLabs/SmartRedis/pull/501))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at some future point in time
 
 Description
 
+-   Include algorithm import in rediscluster for gcc-14
 -   Touch-up outdated information in README.md
 -   Update codecov to v4.5.0 for github actions
 -   Remove broken oss.redis.com URLs from documentation
@@ -20,6 +21,8 @@ Description
 
 Detailed Notes
 
+-   Include algorithm import in rediscluster.h to satisfy
+    gcc-14 compilation error.
 -   Update links to install documentation and remove outdated version
     numbers in the README.md
     ([PR501](https://github.com/CrayLabs/SmartRedis/pull/501))

--- a/include/rediscluster.h
+++ b/include/rediscluster.h
@@ -31,6 +31,7 @@
 
 #include <unordered_set>
 #include <mutex>
+#include <algorithm>
 
 #include "redisserver.h"
 #include "dbnode.h"


### PR DESCRIPTION
This PR fixes a compilation error that will occur with gcc-14.

Note that gcc-14 was not added to the testing infrastructure because that would require the runners being bumped to ubuntu 24.04 which had some domino effects.  This will be addressed in a future PR.