### PR TITLE
Fix memory leak in Fortran

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### 0.6.1
+
+Released on 26 September, 2024
+
+Description
+
+-  Fix a memory leak in the Fortran Dataset implementation
+
+Detailed Notes
+
+-  The dataset object, if used in a loop, would leave memory dangling.
+   To alleviate this, a final procedure has been implemented. Fortran
+   compilers, however, are notoriously bad at detecting when an object
+   goes out of scope and to destroy them automatically. We thus also
+   provide an explicit destructor procedure.
+   ([PR514](https://github.com/CrayLabs/SmartRedis/pull/514))
+
 ### 0.6.0
 
 Released on 25 September, 2024

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -157,12 +157,13 @@ subroutine final_destructor(self)
 end subroutine final_destructor
 
 !> Destroy the dataset
-subroutine destructor(self)
+function destructor(self) result(code)
   class(dataset_type), intent(inout) :: self
   integer :: code
 
+  code = 0
   if (c_associated(self%dataset_ptr)) code = dataset_deconstructor(self%dataset_ptr)
-end subroutine destructor
+end function destructor
 
 !> Access the raw C pointer for the dataset
 function get_c_pointer(self)

--- a/src/fortran/dataset/dataset_interfaces.inc
+++ b/src/fortran/dataset/dataset_interfaces.inc
@@ -36,6 +36,15 @@ interface
 end interface
 
 interface
+  function dataset_deconstructor( dataset ) bind(c, name="DeallocateDataSet")
+    use iso_c_binding, only : c_ptr
+    import :: enum_kind
+    integer(kind=enum_kind)       :: dataset_deconstructor
+    type(c_ptr)                   :: dataset !< Pointer to the underlying dataset
+  end function dataset_deconstructor
+end interface
+
+interface
   function dataset_to_string_c(client) bind(c, name="dataset_to_string")
     use iso_c_binding, only : c_ptr, c_char
     type(c_ptr)                   :: dataset_to_string_c


### PR DESCRIPTION
The dataset object, if used in a loop, would leave memory dangling. To alleviate this, a `final` procedure has been implemented. Fortran compilers, however, are notoriously bad at detecting when an object goes out of scope and to destroy them automatically. We thus also provide an explicit ``destructor`` type procedure.