### PR TITLE
Reenable move semantics and suppress warnings

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### Develop
+
+To be released at a future time.
+
+Description
+
+-  Reenable move semantics and fix compiler warnings.
+
+Detailed Notes
+
+-  Fix compiler warnings stemming from override and const
+   keywords as well as move semantics impliclty disabled
+   because of std::random_device.
+   ([PR520](https://github.com/CrayLabs/SmartRedis/pull/520))
+
 ### 0.6.1
 
 Released on 27 September, 2024

--- a/include/redisserver.h
+++ b/include/redisserver.h
@@ -658,11 +658,6 @@ class RedisServer {
         const SRObject* _context;
 
         /*!
-        *   \brief Seeding for the random number engine
-        */
-        std::random_device _rd;
-
-        /*!
         *   \brief Random number generator
         */
         std::mt19937 _gen;

--- a/include/srexception.h
+++ b/include/srexception.h
@@ -192,7 +192,7 @@ class Exception: public std::exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const{
         return std::string("Exception");
     }
 
@@ -247,7 +247,7 @@ class BadAllocException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override {
         return std::string("BadAllocException");
     }
 };
@@ -278,7 +278,7 @@ class DatabaseException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override {
         return std::string("DatabaseException");
     }
 };
@@ -309,7 +309,7 @@ class RuntimeException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override{
         return std::string("RuntimeException");
     }
 };
@@ -340,7 +340,7 @@ class ParameterException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override{
         return std::string("ParameterException");
     }
 };
@@ -371,7 +371,7 @@ class TimeoutException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override{
         return std::string("TimeoutException");
     }
 };
@@ -402,7 +402,7 @@ class InternalException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override {
         return std::string("InternalException");
     }
 };
@@ -433,7 +433,7 @@ class KeyException: public Exception
     *   \brief Get a string representation of the exception class
     *   \returns Stringified version of the class name
     */
-    virtual std::string exception_class() {
+    virtual std::string exception_class() const override {
         return std::string("KeyException");
     }
 };

--- a/src/cpp/redisserver.cpp
+++ b/src/cpp/redisserver.cpp
@@ -39,7 +39,7 @@ using namespace SmartRedis;
 // RedisServer constructor
 RedisServer::RedisServer(ConfigOptions* cfgopts)
     : _cfgopts(cfgopts), _context(cfgopts->_get_log_context()),
-      _gen(_rd())
+    _gen(std::random_device()())
 {
     _connection_timeout = _cfgopts->_resolve_integer_option(
         _CONN_TIMEOUT_ENV_VAR, _DEFAULT_CONN_TIMEOUT);


### PR DESCRIPTION
This PR makes two small changes to the SmartRedis code:

1. The ``std::random_device`` instance is not stored as a member variable on the ``RedisServer`` class.  The ``std::random_device`` is not movable or copyable, and as a result, it was implicitly disabling move semantics for the ``Client`` and the ``RedisServer`` derivates. 
2. ``Exception`` class methods have been marked with the appropriate ``const override`` keywords to suppress compiler warnings.