### PR TITLE
Fix bug in Fortran dataset destructor

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -19,9 +19,9 @@ Detailed Notes
 -  For compilers that automatically call the dataset
    destructor when the object goes out of scope, a segfault
    was being triggered if the user was also explictly calling
-   the destructor. This was partially arising because the
-   while we were freeing the underlying data and pointing to
-   null, the pointer to the object itself was never being
+   the destructor. This was partially arising because
+   although we were freeing the underlying data and pointing to
+   NULL, the pointer to the object itself was never being
    set to NULL. This has been fixed and should now be robust
    to multiple calls to the destructor.
    ([PR525](https://github.com/CrayLabs/SmartRedis/pull/525))

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at a future time.
 
 Description
 
+-  Fix a segfault in the dataset destructor
 -  Update supported Python versions to 3.10, 3.11, and 3.12
 -  Bump versions for upload/download-artifact Github Actions
 -  Add Client API functions to put, get, unpack,
@@ -15,8 +16,16 @@ Description
 -  Reenable move semantics and fix compiler warnings.
 
 Detailed Notes
-
-- Update supported Python versions to 3.10, 3.11, and 3.12
+-  For compilers that automatically call the dataset
+   destructor when the object goes out of scope, a segfault
+   was being triggered if the user was also explictly calling
+   the destructor. This was partially arising because the
+   while we were freeing the underlying data and pointing to
+   null, the pointer to the object itself was never being
+   set to NULL. This has been fixed and should now be robust
+   to multiple calls to the destructor.
+   ([PR525](https://github.com/CrayLabs/SmartRedis/pull/525))
+-  Update supported Python versions to 3.10, 3.11, and 3.12
    ([PR527](https://github.com/CrayLabs/SmartRedis/pull/527))
 -  Bump versions for upload/download-artifact Github Actions
    ([PR526](https://github.com/CrayLabs/SmartRedis/pull/526))

--- a/src/c/c_dataset.cpp
+++ b/src/c/c_dataset.cpp
@@ -95,6 +95,7 @@ extern "C" SRError DeallocateDataSet(void** dataset)
     DataSet* d = reinterpret_cast<DataSet*>(*dataset);
     delete d;
     *dataset = NULL;
+    dataset = NULL;
   });
 }
 

--- a/src/fortran/dataset.F90
+++ b/src/fortran/dataset.F90
@@ -153,7 +153,7 @@ subroutine final_destructor(self)
   type(dataset_type), intent(inout) :: self
   integer :: code
 
-  if (c_associated(self%dataset_ptr)) code = dataset_deconstructor(self%dataset_ptr)
+  code = self%destructor()
 end subroutine final_destructor
 
 !> Destroy the dataset

--- a/tests/fortran/client_test_dataset.F90
+++ b/tests/fortran/client_test_dataset.F90
@@ -73,7 +73,7 @@ program main
   integer :: ndims
 
   integer :: i, j, k
-  type(dataset_type) :: dataset
+  type(dataset_type) :: dataset, retrieved_dataset
   type(client_type) :: client
 
   integer :: err_code
@@ -238,6 +238,11 @@ program main
   result = client%poll_dataset("test_dataset", 50, 5, exists)
   if (result .ne. SRNoError) error stop
   if (.not. exists) error stop 'existent dataset: FAILED'
+
+  ! Test retrieval of dataset
+  result = client%get_dataset("test_dataset", retrieved_dataset)
+  if (result .ne. SRNoError) error stop
+  if (.not. exists) error stop 'get_dataset: FAILED'
 
 
   write(*,*) "Fortran Dataset: passed"


### PR DESCRIPTION
Fixes a bug in the Fortran client where (on compilers that support automatic destruction) the program would segfault if the user had manually destroyed the dataset. This behaviour was tracked down to an error in the C-client where only the one-level de-referenced pointer was being set to `NULL` but not the actual double-pointer.