### PR TITLE
Bump action versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -88,6 +88,6 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -110,7 +110,7 @@ jobs:
           sudo apt-get install cmake
           python setup.py sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -119,7 +119,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 40960
+          root-reserve-mb: 35840
           remove-dotnet: true
           remove-android: true
           remove-haskell: true

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at a future time.
 
 Description
 
+-  Bump versions for upload/download-artifact Github Actions
 -  Add Client API functions to put, get, unpack,
    delete, poll, and check for existance of raw bytes for the
    C++ and Python clients.
@@ -14,6 +15,8 @@ Description
 
 Detailed Notes
 
+-  Bump versions for upload/download-artifact Github Actions
+   ([PR526](https://github.com/CrayLabs/SmartRedis/pull/526))
 -  Add Client API functions to put, get, unpack,
    delete, poll, and check for existance of raw bytes for the
    C++ and Python clients.


### PR DESCRIPTION
Github Actions are failing due to deprecated actions versions. This bumps the versions of some actions to make the CI pass again.