### PR TITLE
Shift Python support window to 3.10-3.12

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -90,5 +90,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: smartredis-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
-          overwrite: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -87,7 +87,7 @@ jobs:
         run: brew install cmake || true
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: CMAKE_POLICY_VERSION_MINIMUM=3.5 python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
-      CMAKE_MINIMUM_REQUIRED_VERSION: 3.5
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-14]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,7 +36,7 @@ env:
   HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
   HOMEBREW_NO_GITHUB_API: "ON"
   HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-  CIBW_SKIP: "pp* *i686* *musl*" # skip building for PyPy and musllinux
+  CIBW_SKIP: "pp* *i686*" # skip building for PyPy
   CIBW_ARCHES: x86_64
 
 jobs:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-13, macos-14]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -91,3 +91,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          overwrite: true

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,12 +46,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-12, macos-latest]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
-      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
     steps:
       - uses: actions/checkout@v2
@@ -87,9 +86,7 @@ jobs:
         run: brew install cmake || true
 
       - name: Build wheels
-        run: |
-          export CMAKE_POLICY_VERSION_MINIMUM=3.5
-          python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -51,6 +51,7 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
+      CMAKE_MINIMUM_REQUIRED_VERSION: 3.5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -87,7 +87,9 @@ jobs:
         run: brew install cmake || true
 
       - name: Build wheels
-        run: CMAKE_POLICY_VERSION_MINIMUM=3.5 python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          export CMAKE_POLICY_VERSION_MINIMUM=3.5
+          python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,7 +36,7 @@ env:
   HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
   HOMEBREW_NO_GITHUB_API: "ON"
   HOMEBREW_NO_INSTALL_CLEANUP: "ON"
-  CIBW_SKIP: "pp* *i686*" # skip building for PyPy
+  CIBW_SKIP: "pp* *i686* *musl*" # skip building for PyPy and musllinux
   CIBW_ARCHES: x86_64
 
 jobs:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, macos-13, macos-15]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-24.04, macos-15]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
               rai_v: [1.2.5] # verisons of RedisAI
         env:
           # Set the minimum required version of CMake
-          CMAKE_MINIMUM_REQUIRED_VERSION: 3.5
+          CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
         # Service containers to run with docker tests
         services:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,9 @@ jobs:
             matrix:
               os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
               rai_v: [1.2.5] # verisons of RedisAI
+        env:
+          # Set the minimum required version of CMake
+          CMAKE_MINIMUM_REQUIRED_VERSION: 3.5
 
         # Service containers to run with docker tests
         services:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,10 +38,7 @@ jobs:
             fail-fast: true
             matrix:
               os: [ubuntu-22.04] # cannot test on macOS as docker isn't supported on Mac
-              rai_v: [1.2.5] # verisons of RedisAI
-        env:
-          # Set the minimum required version of CMake
-          CMAKE_POLICY_VERSION_MINIMUM: 3.5
+              rai_v: [1.2.5] # versions of RedisAI
 
         # Service containers to run with docker tests
         services:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Build sdist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [ubuntu-24.04, macos-13, macos-15]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}
@@ -113,6 +113,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: artifact
           path: dist/*.tar.gz
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
-      CMAKE_MINIMUM_REQUIRED_VERSION: 3.5
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ubuntu-24.04, macos-15]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-12]
+        os: [ubuntu-24.04, macos-14]
         gcc_v: [11] # Version of GFortran we want to use.
     env:
       FC: gfortran-${{ matrix.gcc_v }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
+      CMAKE_MINIMUM_REQUIRED_VERSION: 3.5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
-      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
     steps:
       - uses: actions/checkout@v2
@@ -93,6 +92,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: smartredis-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       FC: gfortran-${{ matrix.gcc_v }}
       GCC_V: ${{ matrix.gcc_v }}
-      CMAKE_POLICY_VERSION_MINIMUM: 3.5
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -70,7 +70,7 @@ jobs:
     env:
       COMPILER: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
       LINK_TYPE: ${{ matrix.link_type }}
-      CMAKE_MINIMUM_REQUIRED: "3.5" # minimum cmake version required for SmartRedis
+      CMAKE_MINIMUM_REQUIRED_VERSION: "3.5" # minimum cmake version required for SmartRedis
 
     steps:
       # Maximize the space in this image

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -172,12 +172,12 @@ jobs:
 
       - name: Build and install SmartRedis library
         run: |
-          CMAKE_POLICY_VERSION_MINIMUM=3.5 make test-lib INSTALL_PREFIX=$PWD/install/$LINK_TYPE \
+          make test-lib INSTALL_PREFIX=$PWD/install/$LINK_TYPE \
             BUILD_FORTRAN=ON BUILD_PYTHON=ON LINK_TYPE=$LINK_TYPE
           echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/install/$LINK_TYPE/lib >> $GITHUB_ENV
 
       - name: Build SmartRedis python and install
-        run: CMAKE_POLICY_VERSION_MINIMUM=3.5 python -m pip install -e .[dev,xarray]
+        run: python -m pip install -e .[dev,xarray]
 
       - name: Build and install test dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -70,7 +70,7 @@ jobs:
     env:
       COMPILER: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
       LINK_TYPE: ${{ matrix.link_type }}
-      CMAKE_MINIMUM_REQUIRED_VERSION: "3.5" # minimum cmake version required for SmartRedis
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5" # minimum cmake version required for SmartRedis
 
     steps:
       # Maximize the space in this image

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -173,12 +173,12 @@ jobs:
 
       - name: Build and install SmartRedis library
         run: |
-          make test-lib INSTALL_PREFIX=$PWD/install/$LINK_TYPE \
+          CMAKE_POLICY_VERSION_MINIMUM=3.5 make test-lib INSTALL_PREFIX=$PWD/install/$LINK_TYPE \
             BUILD_FORTRAN=ON BUILD_PYTHON=ON LINK_TYPE=$LINK_TYPE
           echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/install/$LINK_TYPE/lib >> $GITHUB_ENV
 
       - name: Build SmartRedis python and install
-        run: python -m pip install -e .[dev,xarray]
+        run: CMAKE_POLICY_VERSION_MINIMUM=3.5 python -m pip install -e .[dev,xarray]
 
       - name: Build and install test dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -70,6 +70,7 @@ jobs:
     env:
       COMPILER: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
       LINK_TYPE: ${{ matrix.link_type }}
+      CMAKE_MINIMUM_REQUIRED: "3.5" # minimum cmake version required for SmartRedis
 
     steps:
       # Maximize the space in this image

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -70,7 +70,6 @@ jobs:
     env:
       COMPILER: ${{ matrix.compiler }} # used when the compiler is gcc/gfortran
       LINK_TYPE: ${{ matrix.link_type }}
-      CMAKE_POLICY_VERSION_MINIMUM: "3.5" # minimum cmake version required for SmartRedis
 
     steps:
       # Maximize the space in this image

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04] # cannot test on macOS as docker isn't supported on Mac
         rai_v: [1.2.7] # versions of RedisAI
-        py_v: ['3.9.x', '3.10.x', '3.11.x'] # versions of Python
+        py_v: ['3.10.x', '3.11.x', '3.12.x'] # versions of Python
         compiler: [nvhpc-24-5, intel-2024.0, gcc-11, gcc-12, gcc-13, gcc-14] # intel compiler, and versions of GNU compiler
         link_type: [shared, static]
     env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ set_target_properties(libhiredis PROPERTIES
 # Define redis++ as an external project
 ExternalProject_Add(redis++
     GIT_REPOSITORY https://github.com/sewenew/redis-plus-plus.git
-    GIT_TAG 1.3.14
+    GIT_TAG e30d4c4c557568b01d5adce9df2714de8d3921c2
     GIT_SHALLOW 1
     INSTALL_COMMAND make install PREFIX=${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS -DREDIS_PLUS_PLUS_BUILD_TEST=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ set_target_properties(libhiredis PROPERTIES
 # Define redis++ as an external project
 ExternalProject_Add(redis++
     GIT_REPOSITORY https://github.com/sewenew/redis-plus-plus.git
-    GIT_TAG 1.3.10
+    GIT_TAG 1.3.14
     GIT_SHALLOW 1
     INSTALL_COMMAND make install PREFIX=${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS -DREDIS_PLUS_PLUS_BUILD_TEST=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ set_target_properties(libhiredis PROPERTIES
 ExternalProject_Add(redis++
     GIT_REPOSITORY https://github.com/sewenew/redis-plus-plus.git
     GIT_TAG e30d4c4c557568b01d5adce9df2714de8d3921c2
-    GIT_SHALLOW 1
+    GIT_SHALLOW 0
     INSTALL_COMMAND make install PREFIX=${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS -DREDIS_PLUS_PLUS_BUILD_TEST=OFF
                -DREDIS_PLUS_PLUS_BUILD_SHARED=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 # Add hiredis as an external project
 ExternalProject_Add(hiredis
     GIT_REPOSITORY https://github.com/redis/hiredis.git
-    GIT_TAG v1.2.0
+    GIT_TAG v1.3.0
     GIT_SHALLOW 1
     CMAKE_ARGS
         -DBUILD_SHARED_LIBS=OFF

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ PEDANTIC := OFF
 # Test dependencies
 REDIS_URL := https://github.com/redis/redis.git
 REDIS_VER := 7.2.4
-REDISAI_URL :=  https://github.com/RedisAI/RedisAI.git
+REDISAI_URL :=  https://github.com/RedisAI/redis-inference-optimization.git
 CATCH2_URL := https://github.com/catchorg/Catch2.git
 CATCH2_VER := v2.13.6
 LCOV_URL := https://github.com/linux-test-project/lcov.git

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SmartRedis provides clients in the following languages:
 
 | Language   | Version/Standard                               |
 |------------|:----------------------------------------------:|
-| Python     |   3.9, 3.10, 3.11                              |
+| Python     |   3.10, 3.11, 3.12                             |
 | C++        |   C++17                                        |
 | C          |   C99                                          |
 | Fortran    |   Fortran 2018 (GNU/Intel), 2003 (PGI/Nvidia)  |

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at a future time.
 
 Description
 
+-  Update supported Python versions to 3.10, 3.11, and 3.12
 -  Bump versions for upload/download-artifact Github Actions
 -  Add Client API functions to put, get, unpack,
    delete, poll, and check for existance of raw bytes for the
@@ -15,6 +16,8 @@ Description
 
 Detailed Notes
 
+- Update supported Python versions to 3.10, 3.11, and 3.12
+   ([PR527](https://github.com/CrayLabs/SmartRedis/pull/527))
 -  Bump versions for upload/download-artifact Github Actions
    ([PR526](https://github.com/CrayLabs/SmartRedis/pull/526))
 -  Add Client API functions to put, get, unpack,

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -47,7 +47,7 @@ below summarizes the language standards for each client.
    * - Language
      - Version/Standard
    * - Python
-     - 3.9-3.11
+     - 3.10-3.12
    * - C++
      - C++17
    * - C

--- a/examples/examples
+++ b/examples/examples
@@ -1,0 +1,1 @@
+./smartredis/examples

--- a/examples/examples
+++ b/examples/examples
@@ -1,1 +1,0 @@
-./smartredis/examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [build-system]
 requires = ["setuptools>=42",
             "wheel",
@@ -7,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py310', 'py311', 'py312']
 exclude = '''
 (
   | \.egg

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ contact_email = craylabs@hpe.com
 license = BSD 2-Clause License
 keywords = redis, clients, hpc, ai, deep learning
 classifiers =
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: BSD License
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
 include_package_data = True
 install_requires =
     numpy>=1.18.2,<2
-python_requires = >=3.9,<3.12
+python_requires = >=3.10,<3.13
 
 
 [options.extras_require]


### PR DESCRIPTION
Routine update for SmartRedis.
- Add support for Python 3.12
- Update `hiredis` and `redis++` to versions complying with new required `CMAKE_POLICY_VERSION_MINIMUM`
- Update artifact naming to comply with new `upload-artifact@v4` behavior