### PR TITLE
Add missing header file

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,7 @@ To be released at a future time.
 
 Description
 
+-  Add missing header file to scalarfield.h
 -  Update supported Python versions to 3.10, 3.11, and 3.12
 -  Bump versions for upload/download-artifact Github Actions
 -  Add Client API functions to put, get, unpack,
@@ -16,7 +17,11 @@ Description
 
 Detailed Notes
 
-- Update supported Python versions to 3.10, 3.11, and 3.12
+-  When including scalarfield.h into an application, 
+   MetadataBuffer was never defined. Add an explicit include
+   to the header file to ensure that applications can build.
+   ([PR528](https://github.com/CrayLabs/SmartRedis/pull/528))
+-  Update supported Python versions to 3.10, 3.11, and 3.12
    ([PR527](https://github.com/CrayLabs/SmartRedis/pull/527))
 -  Bump versions for upload/download-artifact Github Actions
    ([PR526](https://github.com/CrayLabs/SmartRedis/pull/526))

--- a/include/scalarfield.h
+++ b/include/scalarfield.h
@@ -29,6 +29,7 @@
 #ifndef SMARTREDIS_SCALARFIELD_H
 #define SMARTREDIS_SCALARFIELD_H
 
+#include "metadatabuffer.h"
 #include "metadatafield.h"
 #include <iostream>
 


### PR DESCRIPTION
When including scalarfield.h into an application, MetadataBuffer was never defined. Add an explicit include to the header file to ensure that applications can build.