### PR TITLE
Add compatibility with Numpy 2.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(BUILD_PYTHON)
     FetchContent_Declare(
         pybind11
         GIT_REPOSITORY https://github.com/pybind/pybind11
-        GIT_TAG        v2.11.1
+        GIT_TAG        v2.13.6
     )
 endif(BUILD_PYTHON)
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,8 @@ To be released at a future time.
 
 Description
 
+-  Bump pybind11 version number to v2.13.6 to avoid Python
+   client bug
 -  Add missing header file to scalarfield.h
 -  Fix a segfault in the dataset destructor
 -  Update supported Python versions to 3.10, 3.11, and 3.12
@@ -17,7 +19,13 @@ Description
 -  Reenable move semantics and fix compiler warnings.
 
 Detailed Notes
--  When including scalarfield.h into an application, 
+-  The older version of pybind11 has a python array descriptor
+   which was incompatibile with numpy 2.x, leading to a bug
+   wehn using the python client. This bumps the pybind11
+   version to add support for numpy 2.x while retaining
+   support for numpy 1.x
+   ([PR531](https://github.com/CrayLabs/SmartRedis/pull/531))
+-  When including scalarfield.h into an application,
    MetadataBuffer was never defined. Add an explicit include
    to the header file to ensure that applications can build.
    ([PR530](https://github.com/CrayLabs/SmartRedis/pull/530))

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
     setuptools>=42
 include_package_data = True
 install_requires =
-    numpy>=1.18.2,<2
+    numpy>=1.18.2
 python_requires = >=3.10,<3.13
 
 


### PR DESCRIPTION
The version of pybind11 was rather old and had known compatibility issues with numpy 2.x. This manifested within SmartRedis with Python clients filling tensors sent to or retrieved from the database with just the value of the first element of the tensor.